### PR TITLE
cleanup inference workers on FastAPI shutdown event

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 import contextlib
+import logging
 from contextlib import asynccontextmanager
 import inspect
 from multiprocessing import Process, Manager, Queue, Pipe
@@ -147,6 +148,7 @@ async def lifespan(app: FastAPI):
     manager = Manager()
     app.request_buffer = manager.dict()
 
+    process_list = []
     # NOTE: device: str | List[str], the latter in the case a model needs more than one device to run
     for worker_id, device in enumerate(app.devices * app.workers_per_device):
         if len(device) == 1:
@@ -165,8 +167,13 @@ async def lifespan(app: FastAPI):
             daemon=True,
         )
         process.start()
+        process_list.append((process, worker_id))
 
     yield
+
+    for process, worker_id in process_list:
+        logging.info(f"terminating worker worker_id={worker_id}")
+        process.terminate()
 
 
 class LitServer:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR terminates the parallel inference workers on FastAPI app shutdown lifespan. 

Here is the pseudocode:

```py
async def lifespan(app: FastAPI):
  
    process_list = []
    for worker_id, device in worker_id, devices:
        process = start_process(worker_id)
        process_list.append((process, worker_id))

    yield

    for process, worker_id in process_list:
        logging.info(f"terminating worker worker_id={worker_id}")
        process.terminate()
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
