### PR TITLE
fix: broken pipes caused inference worker to fail

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -102,9 +102,9 @@ def run_batched_loop(lit_api, request_queue: Queue, request_buffer, max_batch_si
         except Exception as e:
             logging.exception(e)
             err_pkl = pickle.dumps(e)
-
-            for pipe_s in pipes:
-                pipe_s.send((err_pkl, LitAPIStatus.ERROR))
+            with contextlib.suppress(BrokenPipeError):
+                for pipe_s in pipes:
+                    pipe_s.send((err_pkl, LitAPIStatus.ERROR))
 
 
 def run_single_loop(lit_api, request_queue: Queue, request_buffer):
@@ -126,7 +126,8 @@ def run_single_loop(lit_api, request_queue: Queue, request_buffer):
                 pipe_s.send((y_enc, LitAPIStatus.OK))
         except Exception as e:
             logging.exception(e)
-            pipe_s.send((pickle.dumps(e), LitAPIStatus.ERROR))
+            with contextlib.suppress(BrokenPipeError):
+                pipe_s.send((pickle.dumps(e), LitAPIStatus.ERROR))
 
 
 def run_streaming_loop(lit_api, request_queue: Queue, request_buffer):
@@ -150,7 +151,8 @@ def run_streaming_loop(lit_api, request_queue: Queue, request_buffer):
             pipe_s.send(("", LitAPIStatus.FINISH_STREAMING))
         except Exception as e:
             logging.exception(e)
-            pipe_s.send((pickle.dumps(e), LitAPIStatus.ERROR))
+            with contextlib.suppress(BrokenPipeError):
+                pipe_s.send((pickle.dumps(e), LitAPIStatus.ERROR))
 
 
 def inference_worker(lit_api, device, worker_id, request_queue, request_buffer, max_batch_size, batch_timeout, stream):

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -148,7 +148,8 @@ def run_streaming_loop(lit_api, request_queue: Queue, request_buffer):
             for y_enc in y_enc_gen:
                 with contextlib.suppress(BrokenPipeError):
                     pipe_s.send((y_enc, LitAPIStatus.OK))
-            pipe_s.send(("", LitAPIStatus.FINISH_STREAMING))
+            with contextlib.suppress(BrokenPipeError):
+                pipe_s.send(("", LitAPIStatus.FINISH_STREAMING))
         except Exception as e:
             logging.exception(e)
             with contextlib.suppress(BrokenPipeError):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

```py
def run_single_loop(lit_api, request_queue: Queue, request_buffer):
    while True:
        ...
        try:
            x = lit_api.decode_request(x_enc)
            y = lit_api.predict(x)
            y_enc = lit_api.encode_response(y)
        
            with contextlib.suppress(BrokenPipeError):
                pipe_s.send((y_enc, LitAPIStatus.OK))
        except Exception as e:
            logging.exception(e)
            ######## broken pipe here will fail the worker ########
            pipe_s.send((pickle.dumps(e), LitAPIStatus.ERROR))
```

We need to suppress the broken pipe error. As a follow-up we should also add a test to send a second client request after first client request disconnects prematurely.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
