### PR TITLE
allow to set mps accelerator explicitly 

### DIFF
--- a/src/litserve/connector.py
+++ b/src/litserve/connector.py
@@ -26,6 +26,8 @@ class _Connector:
             self._accelerator = "cpu"
         elif accelerator == "cuda":
             self._accelerator = "cuda"
+        elif accelerator == "mps":
+            self._accelerator = "mps"
 
         elif accelerator == "auto":
             self._accelerator = self._choose_auto_accelerator()
@@ -50,8 +52,8 @@ class _Connector:
         if isinstance(accelerator, str):
             accelerator = accelerator.lower()
 
-        if accelerator not in ["auto", "cpu", "cuda", "gpu", None]:
-            raise ValueError("accelerator must be one of 'auto', 'cpu', 'cuda', or 'gpu'")
+        if accelerator not in ["auto", "cpu", "mps", "cuda", "gpu", None]:
+            raise ValueError("accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'")
 
         if accelerator is None:
             return "auto"

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -81,5 +81,5 @@ def test_connector(input_accelerator, expected_accelerator, expected_devices):
 def test__sanitize_accelerator():
     assert _Connector._sanitize_accelerator(None) == "auto"
     assert _Connector._sanitize_accelerator("CPU") == "cpu"
-    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'cuda', or 'gpu'"):
+    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'"):
         _Connector._sanitize_accelerator("SUPER_CHIP")

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -51,6 +51,12 @@ def test_check_cuda_with_nvidia_smi():
             marks=pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Only tested on Apple MPS"),
         ),
         pytest.param(
+            "mps",
+            "mps",
+            1,
+            marks=pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Only tested on Apple MPS"),
+        ),
+        pytest.param(
             None,
             "mps",
             1,
@@ -68,7 +74,7 @@ def test_connector(input_accelerator, expected_accelerator, expected_devices):
         connector.devices == expected_devices
     ), f"devices was supposed to be {expected_devices} but was {connector.devices}"
 
-    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'cuda', or 'gpu'"):
+    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'"):
         _Connector(accelerator="SUPER_CHIP")
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Right now, to set `mps` accelerator explicitly, we need to set it to "gpu". This PR allows, `accelerator="mps"`

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
