### PR TITLE
decouple decode_request from get_batch_from_uid

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ pip install -e '.[all]'
 &nbsp;
 
 # Get started
-LitServe has a minimal API that allows enterprise-scale, with full control.   
+LitServe has a minimal API that allows enterprise-scale, with full control.
 
-1. Implement the LitAPI class which describes the inference process for the model(s).    
-2. Enable the specific optimizations (such as batching or streaming) in the LitServer.   
+1. Implement the LitAPI class which describes the inference process for the model(s).
+2. Enable the specific optimizations (such as batching or streaming) in the LitServer.
 
 ## Implement a server
 Here's a hello world example:
@@ -177,7 +177,7 @@ LitServe supports multiple advanced state-of-the-art features.
 | ML frameworks  | PyTorch, Jax, Tensorflow, numpy, etc...  |
 | Batching | ✅ |
 | API authentication | ✅ |
-| Multiple models in a single API | ✅ |    
+| Multiple models in a single API | ✅ |
 | Full request/response control | ✅ |
 | Automatic schema validation | ✅ |
 | Handle timeouts | ✅ |

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -81,8 +81,7 @@ def get_batch_from_uid(uids, lit_api, request_buffer):
             x_enc, pipe_s = request_buffer.pop(uid)
         except KeyError:
             continue
-        x = lit_api.decode_request(x_enc)
-        batches.append((x, pipe_s))
+        batches.append((x_enc, pipe_s))
     return batches
 
 
@@ -113,7 +112,8 @@ def run_batched_loop(lit_api, request_queue: Queue, request_buffer, max_batch_si
         inputs, pipes = zip(*batches)
 
         try:
-            x = lit_api.batch(inputs)
+            x = [lit_api.decode_request(input) for input in inputs]
+            x = lit_api.batch(x)
             y = lit_api.predict(x)
             outputs = lit_api.unbatch(y)
             for y, pipe_s in zip(outputs, pipes):
@@ -193,7 +193,8 @@ def run_batched_streaming_loop(lit_api, request_queue: Queue, request_buffer, ma
         inputs, pipes = zip(*batches)
 
         try:
-            x = lit_api.batch(inputs)
+            x = [lit_api.decode_request(input) for input in inputs]
+            x = lit_api.batch(x)
             y_iter = lit_api.predict(x)
             unbatched_iter = lit_api.unbatch(y_iter)
             y_enc_iter = lit_api.encode_response(unbatched_iter)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -147,5 +147,5 @@ def test_batched_loop():
         run_batched_loop(lit_api_mock, requests_queue, request_buffer, max_batch_size=2, batch_timeout=4)
 
     lit_api_mock.batch.assert_called_once()
-    lit_api_mock.batch.assert_called_once_with((4.0, 5.0))
+    lit_api_mock.batch.assert_called_once_with([4.0, 5.0])
     lit_api_mock.unbatch.assert_called_once()

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -257,7 +257,7 @@ def test_batched_streaming_loop(loop_args):
 
     with pytest.raises(StopIteration, match="finish streaming"):
         run_batched_streaming_loop(fake_stream_api, requests_queue, request_buffer, max_batch_size=2, batch_timeout=2)
-    fake_stream_api.predict.assert_called_once_with(("Hello", "World"))
+    fake_stream_api.predict.assert_called_once_with(["Hello", "World"])
     fake_stream_api.encode_response.assert_called_once()
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

`get_batch_from_uid` takes extra responsibility and decodes the request. This PR decouples it and make LitAPI.decode_request call in the loop along with other LitAPI method calls. 

```py
def get_batch_from_uid(uids, lit_api, request_buffer):
    batches = []
    for uid in uids:
        try:
            x_enc, pipe_s = request_buffer.pop(uid)
        except KeyError:
            continue
        #### decode request shouldn't be here #####
        x = lit_api.decode_request(x_enc)  
        batches.append((x_enc, pipe_s))
    return batches
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
