### PR TITLE
feat: Support multipart & url-encoded form bodies

### DIFF
--- a/_requirements/test.txt
+++ b/_requirements/test.txt
@@ -4,6 +4,7 @@ pytest-cov
 mypy ==1.9.0
 pytest-asyncio
 asgi-lifespan
+python-multipart
 
 requests
 lightning >2.0.0

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -386,7 +386,12 @@ class LitServer:
             read, write = self.new_pipe()
 
             if self.request_type == Request:
-                self.app.request_buffer[uid] = (await request.json(), write)
+                if request.headers["Content-Type"] == "application/x-www-form-urlencoded" or request.headers[
+                    "Content-Type"
+                ].startswith("multipart/form-data"):
+                    self.app.request_buffer[uid] = (await request.form(), write)
+                else:
+                    self.app.request_buffer[uid] = (await request.json(), write)
             else:
                 self.app.request_buffer[uid] = (request, write)
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,0 +1,64 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import Request, Response
+from fastapi.testclient import TestClient
+
+from litserve import LitAPI, LitServer
+
+
+class SimpleFileLitAPI(LitAPI):
+    def setup(self, device):
+        self.model = lambda x: x**2
+
+    def decode_request(self, request: Request):
+        return float(request["input"].file.read().decode("utf-8"))
+
+    def predict(self, x):
+        return self.model(x)
+
+    def encode_response(self, output) -> Response:
+        return {"output": output}
+
+
+def test_multipart_form_data():
+    server = LitServer(SimpleFileLitAPI(), accelerator="cpu", devices=1, workers_per_device=1)
+
+    with TestClient(server.app) as client:
+        file = {"input": "4.0"}
+        response = client.post("/predict", files=file)
+        assert response.json() == {"output": 16.0}
+
+
+class SimpleFormLitAPI(LitAPI):
+    def setup(self, device):
+        self.model = lambda x: x**2
+
+    def decode_request(self, request: Request):
+        return float(request["input"])
+
+    def predict(self, x):
+        return self.model(x)
+
+    def encode_response(self, output) -> Response:
+        return {"output": output}
+
+
+def test_urlencoded_form_data():
+    server = LitServer(SimpleFormLitAPI(), accelerator="cpu", devices=1, workers_per_device=1)
+
+    with TestClient(server.app) as client:
+        file = {"input": "4.0"}
+        response = client.post("/predict", data=file)
+        assert response.json() == {"output": 16.0}


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR adds support for handling requests bodies with the content type of `multipart/form-data` and `application/x-www-form-urlencoded`.  Both of these formats are commonly used in web applications.

**`multipart/form-data`**

Currently, there is no good way to post files to to litserve.  Since only JSON is supported, the file must be encoded with something like base64, which increases the payload size.

**`application/x-www-form-urlencoded`**

This is the default format used for HTML `<form>`s


Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
