### PR TITLE
removes `/stream-predict` endpoint and standardizes to `/predict`

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -404,7 +404,6 @@ class LitServer:
         async def index(request: Request) -> Response:
             return Response(content="litserve running")
 
-        @self.app.post("/predict", dependencies=[Depends(setup_auth())])
         async def predict(request: self.request_type, background_tasks: BackgroundTasks) -> self.response_type:
             uid = uuid.uuid4()
             logger.debug(f"Received request uid={uid}")
@@ -452,7 +451,6 @@ class LitServer:
                 load_and_raise(response)
             return response
 
-        @self.app.post("/stream-predict", dependencies=[Depends(setup_auth())])
         async def stream_predict(request: self.request_type, background_tasks: BackgroundTasks) -> self.response_type:
             uid = uuid.uuid4()
             logger.debug(f"Received request uid={uid}")
@@ -509,6 +507,9 @@ class LitServer:
                 return StreamingResponse(stream_from_pipe())
 
             return StreamingResponse(data_streamer())
+
+        fn = stream_predict if self.app.lit_api.stream else predict
+        self.app.add_api_route("/predict", fn, methods=["post"], dependencies=[Depends(setup_auth())])
 
     def generate_client_file(self):
         src_path = os.path.join(os.path.dirname(__file__), "python_client.py")

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -56,7 +56,7 @@ def test_e2e_batched_streaming():
     )
 
     time.sleep(5)
-    resp = requests.post("http://127.0.0.1:8000/stream-predict", json={"input": 4.0}, headers=None, stream=True)
+    resp = requests.post("http://127.0.0.1:8000/predict", json={"input": 4.0}, headers=None, stream=True)
     assert resp.status_code == 200, f"Expected response to be 200 but got {resp.status_code}"
 
     outputs = []

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -143,8 +143,8 @@ async def test_stream(simple_stream_api):
     expected_output2 = "prompt=World generated_output=LitServe is streaming output".lower().replace(" ", "")
 
     async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
-        resp1 = ac.post("/stream-predict", json={"prompt": "Hello"}, timeout=10)
-        resp2 = ac.post("/stream-predict", json={"prompt": "World"}, timeout=10)
+        resp1 = ac.post("/predict", json={"prompt": "Hello"}, timeout=10)
+        resp2 = ac.post("/predict", json={"prompt": "World"}, timeout=10)
         resp1, resp2 = await asyncio.gather(resp1, resp2)
         assert resp1.status_code == 200, "Check if server is running and the request format is valid."
         assert resp1.text == expected_output1, "Server returns input prompt and generated output which didn't match."
@@ -159,8 +159,8 @@ async def test_batched_stream_server(simple_batched_stream_api):
     expected_output2 = "World LitServe is streaming output".lower().replace(" ", "")
 
     async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
-        resp1 = ac.post("/stream-predict", json={"prompt": "Hello"}, timeout=10)
-        resp2 = ac.post("/stream-predict", json={"prompt": "World"}, timeout=10)
+        resp1 = ac.post("/predict", json={"prompt": "Hello"}, timeout=10)
+        resp2 = ac.post("/predict", json={"prompt": "World"}, timeout=10)
         resp1, resp2 = await asyncio.gather(resp1, resp2)
         assert resp1.status_code == 200, "Check if server is running and the request format is valid."
         assert resp2.status_code == 200, "Check if server is running and the request format is valid."


### PR DESCRIPTION
* removes `/stream-predict` endpoint and standardizes to `/predict` 