### PR TITLE
Bump version since litserve is different from the last released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 **High-throughput serving engine for AI models**
 
 <pre>
-✅ Batching       ✅ Streaming          ✅ Auto-GPU, multi-GPU 
-✅ Multi-modal    ✅ PyTorch/JAX/TF     ✅ Full control        
-✅ Auth           ✅ Built on Fast API                         
+✅ Batching       ✅ Streaming          ✅ Auto-GPU, multi-GPU
+✅ Multi-modal    ✅ PyTorch/JAX/TF     ✅ Full control
+✅ Auth           ✅ Built on Fast API
 </pre>
 
 

--- a/src/litserve/__about__.py
+++ b/src/litserve/__about__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.1.0"
+__version__ = "0.1.1.dev0"
 __author__ = "Lightning-AI et al."
 __author_email__ = "community@lightning.ai"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
This bumps the version so that we can distinguish it from the last released version on PyPI.