### PR TITLE
Exclude markdown files from pre-commit formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        exclude: '.*\.md$'
       - id: check-case-conflict
       - id: check-yaml
       - id: check-toml


### PR DESCRIPTION
Let's see if this fixes the issue with removing the whitespaces in the README etc.