### PR TITLE
fix summary tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ if __name__ == "__main__":
 
 
 <details>
-  <summary>Stream long responses</summaryoutput >
+  <summary>Stream long responses</summary>
 
 &nbsp;
 


### PR DESCRIPTION
closing `</summary>` was modified somehow and it breaks the markdown preview. 