### PR TITLE
[WIP] dynamic stream loop selection

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -90,7 +90,11 @@ class LitAPI(ABC):
 
     @abstractmethod
     def predict(self, x):
-        """Run the model on the input and return or yield the output."""
+        """Run the model on the input and return the output."""
+        pass
+
+    def iter_predict(self, x):
+        """Run the model on the input and yield the output."""
         pass
 
     def _unbatch_no_stream(self, output):
@@ -114,12 +118,22 @@ class LitAPI(ABC):
     def encode_response(self, output):
         """Convert the model output to a response payload.
 
-        To enable streaming, it should yield the output.
+        It should return the output.
 
         """
         if self._spec:
             return self._spec.encode_response(output)
         return output
+
+    def iter_encode_response(self, output):
+        """Convert the model output to a response payload.
+
+        It should yield the output.
+
+        """
+        if self._spec:
+            yield self._spec.encode_response(output)
+        yield output
 
     def format_encoded_response(self, data):
         if isinstance(data, dict):

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -93,10 +93,6 @@ class LitAPI(ABC):
         """Run the model on the input and return the output."""
         pass
 
-    def iter_predict(self, x):
-        """Run the model on the input and yield the output."""
-        pass
-
     def _unbatch_no_stream(self, output):
         if hasattr(output, "__torch_function__") or output.__class__.__name__ == "ndarray":
             return list(output)
@@ -124,16 +120,6 @@ class LitAPI(ABC):
         if self._spec:
             return self._spec.encode_response(output)
         return output
-
-    def iter_encode_response(self, output):
-        """Convert the model output to a response payload.
-
-        It should yield the output.
-
-        """
-        if self._spec:
-            yield self._spec.encode_response(output)
-        yield output
 
     def format_encoded_response(self, data):
         if isinstance(data, dict):

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -163,8 +163,8 @@ def run_streaming_loop(data, lit_api: LitAPI, lit_spec, request_queue: Queue, re
     uid, x_enc, pipe_s, meta = data
     try:
         x = lit_api.decode_request(x_enc)
-        y_gen = lit_api.iter_predict(x)
-        y_enc_gen = lit_api.iter_encode_response(y_gen)
+        y_gen = lit_api.predict(x)
+        y_enc_gen = lit_api.encode_response(y_gen)
         for y_enc in y_enc_gen:
             with contextlib.suppress(BrokenPipeError):
                 y_enc = lit_api.format_encoded_response(y_enc)

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -411,7 +411,7 @@ class LitServer:
         asyncio.get_event_loop().remove_reader(read.fileno())
         return read.recv()
 
-    async def win_data_streamer(self, read, write):
+    async def _win_data_streamer(self, read, write):
         # this is a workaround for Windows since asyncio loop.add_reader is not supported.
         # https://docs.python.org/3/library/asyncio-platforms.html
         while True:
@@ -431,7 +431,7 @@ class LitServer:
 
             await asyncio.sleep(0.0001)
 
-    async def data_streamer(self, read, write):
+    async def _data_streamer(self, read, write):
         data_available = asyncio.Event()
         while True:
             asyncio.get_event_loop().add_reader(read.fileno(), data_available.set)
@@ -466,9 +466,9 @@ class LitServer:
 
     async def stream_from_pipe(self, read, write):
         if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith("win"):
-            return StreamingResponse(self.win_data_streamer(read, write))
+            return StreamingResponse(self._win_data_streamer(read, write))
 
-        return StreamingResponse(self.data_streamer(read, write))
+        return StreamingResponse(self._data_streamer(read, write))
 
     def setup_server(self):
         @self.app.get("/", dependencies=[Depends(setup_auth())])

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -566,7 +566,9 @@ class LitServer:
             self.app.add_api_route(
                 endpoint, stream_predict if stream else predict, methods=methods, dependencies=[Depends(setup_auth())]
             )
-            self.app.add_api_route(endpoint, experimental, methods=methods, dependencies=[Depends(setup_auth())])
+            self.app.add_api_route(
+                "/experimental/predict", experimental, methods=methods, dependencies=[Depends(setup_auth())]
+            )
 
         for spec in self._specs:
             spec: LitSpec


### PR DESCRIPTION
fixes #99 

* Select streaming or non-streaming loop based on client's `request["stream"]` parameter. 

## Server
```py
# server.py
import logging

import litserve as ls
logging.basicConfig(level=logging.INFO)

# STEP 1: DEFINE YOUR MODEL API
class SimpleLitAPI(ls.LitAPI):
    def setup(self, device):
        # Setup the model so it can be called in `predict`.
        self.model = lambda x: x**2

    def decode_request(self, request):
        # Convert the request payload to your model input.
        input = request["input"]
        stream = request.get("stream", False)
        return input, stream

    def predict(self, x):
        input, stream = x
        def gen():
            yield self.model(input)
        if stream:
            return gen()
        return self.model(input)

    def encode_response(self, output):
        # YEILD or return based on output
        ...


# STEP 2: START THE SERVER
if __name__ == "__main__":
    api = SimpleLitAPI()
    server = ls.LitServer(api, accelerator="auto")
    server.run(port=8000)
```

## Client
```py
import requests

response = requests.post("http://127.0.0.1:8000/predict", json={"input": 4.0, "stream": False})
print(f"Status: {response.status_code}\nResponse:\n {response.text}")

```


EDIT: Updated to remove the `iter_*` API