### PR TITLE
fix:Adds import statement for ChatMessage in OpenAI compatible API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ Here is an example of overriding `encode_response` in `LitAPI`:
 
 ```python
 import litserve as ls
-from litserve.specs.openai import ChatCompletionResponseChoice
+from litserve.specs.openai import ChatCompletionResponseChoice, ChatMessage
 
 class GPT2LitAPI(ls.LitAPI):
     def setup(self, device):


### PR DESCRIPTION
fixes #111

**Adds missing ChatMessage import in OpenAI compatible API example in Readme**

Before:
```python
from litserve.specs.openai import ChatCompletionResponseChoice

```


After:
```python
from litserve.specs.openai import ChatCompletionResponseChoice, ChatMessage

```