### PR TITLE
feat: Update OpenAI spec to include image url in message content

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ if __name__ == "__main__":
 ```
 &nbsp;
 
-LitServe's OpenAISpec also enables capability to handle images in the input. Below is an example of how to set this up using LitServe.
+LitServe's `OpenAISpec` can also handle images in the input. Here is an example:
 
 ```python
 import litserve as ls

--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ When using `OpenAISpec`, `predict` is expected to take an input with the followi
 
   },
    {"role": "assistant", "content": "This image shows a wooden boardwalk extending through a lush green marshland."},
-   {"role": "user", "content": "How is the weather depicted in the image?"}]
+   {"role": "user", "content": "What is the weather like in the image?"}]
   ```
 
 The above server can be queried using a standard OpenAI client:

--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ if __name__ == "__main__":
     server.run(port=8000)
 ```
 
-In this case, `predict` is expected to take an input with the following shape:
+When using `OpenAISpec`, `predict` is expected to take an input with the following shape:
 
 - Text Input Example:
   ```

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -54,7 +54,7 @@ class ImageContent(BaseModel):
 
 class ChatMessage(BaseModel):
     role: str
-    content: Union[str, List[Union[TextContentPart, ImageContentPart]]]
+    content: Union[str, List[Union[TextContent, ImageContent]]]
 
 
 class ChoiceDelta(ChatMessage):

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -42,7 +42,7 @@ class UsageInfo(BaseModel):
     completion_tokens: Optional[int] = 0
 
 
-class TextContentPart(BaseModel):
+class TextContent(BaseModel):
     type: str
     text: str
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -47,7 +47,7 @@ class TextContent(BaseModel):
     text: str
 
 
-class ImageContentPart(BaseModel):
+class ImageContent(BaseModel):
     type: str
     image_url: str
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -42,9 +42,19 @@ class UsageInfo(BaseModel):
     completion_tokens: Optional[int] = 0
 
 
+class TextContentPart(BaseModel):
+    type: str
+    text: str
+
+
+class ImageContentPart(BaseModel):
+    type: str
+    image_url: str
+
+
 class ChatMessage(BaseModel):
     role: str
-    content: str
+    content: Union[str, List[Union[TextContentPart, ImageContentPart]]]
 
 
 class ChoiceDelta(ChatMessage):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def openai_request_data():
 @pytest.fixture()
 def openai_request_data_with_image():
     return {
-        "model": "",
+        "model": "lit",
         "messages": [
             {
                 "role": "user",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,3 +134,31 @@ def openai_request_data():
         "frequency_penalty": 0,
         "user": "string",
     }
+
+
+@pytest.fixture()
+def openai_request_data_with_image():
+    return {
+        "model": "",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What's in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                    },
+                ],
+            }
+        ],
+        "temperature": 0.7,
+        "top_p": 1,
+        "n": 1,
+        "max_tokens": 0,
+        "stop": "string",
+        "stream": False,
+        "presence_penalty": 0,
+        "frequency_penalty": 0,
+        "user": "string",
+    }

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -34,6 +34,19 @@ async def test_openai_spec(openai_request_data):
 
 
 @pytest.mark.asyncio()
+async def test_openai_spec_with_image(openai_request_data_with_image):
+    spec = OpenAISpec()
+    server = ls.LitServer(TestAPI(), spec=spec)
+    async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
+        resp = await ac.post("/v1/chat/completions", json=openai_request_data_with_image, timeout=10)
+        assert resp.status_code == 200, "Status code should be 200"
+
+        assert (
+            resp.json()["choices"][0]["message"]["content"] == "This is a generated output"
+        ), "LitAPI predict response should match with the generated output"
+
+
+@pytest.mark.asyncio()
 async def test_override_encode(openai_request_data):
     spec = OpenAISpec()
     server = ls.LitServer(TestAPIWithCustomEncode(), spec=spec)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #107.
- Add support for images to be included in chat messages, similar to [gpt-4o](https://platform.openai.com/docs/guides/vision).
