### PR TITLE
inject context to share/log values across LitAPI methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,7 +764,7 @@ response = requests.post("http://127.0.0.1:8000/v1/chat/completions", json={
 </details>    
 
 <details>
-    <summary>✅ Track context throughout request lifecycle</summary>
+    <summary>✅ Track context throughout the request lifecycle</summary>
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -763,6 +763,35 @@ response = requests.post("http://127.0.0.1:8000/v1/chat/completions", json={
 ```
 </details>    
 
+<details>
+    <summary>✅ Track context throughout request lifecycle</summary>
+
+&nbsp;
+
+You can pass around and track context throughout a request lifecycle by adding a special argument `context` to the 
+`LitAPI` methods.
+
+```python
+import litserve as ls 
+
+class TrackLitAPI(ls.examples.SimpleLitAPI):
+    def predict(self, x, context):
+        context["input_value"] = x
+        return self.model(x)
+
+    def encode_response(self, output, context):
+        # Retrieve the context from LitPI.predict inside encode_response
+        input_value = context["input_value"]
+        return {"output": input_value * output}
+
+if __name__=="__main__":
+    api = TrackLitAPI() 
+    server = ls.LitServer(api)
+    server.run(port=8000)
+```
+
+</details>
+
 &nbsp;
 
 > [!NOTE]

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -14,6 +14,7 @@
 import inspect
 import json
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -63,10 +64,10 @@ class LitAPI(ABC):
         """Setup the model so it can be called in `predict`."""
         pass
 
-    def decode_request(self, request):
+    def decode_request(self, request, meta_kwargs: Optional[dict] = None):
         """Convert the request payload to your model input."""
         if self._spec:
-            return self._spec.decode_request(request)
+            return self._spec.decode_request(request, meta_kwargs)
         return request
 
     def batch(self, inputs):
@@ -89,7 +90,7 @@ class LitAPI(ABC):
         raise NotImplementedError(message)
 
     @abstractmethod
-    def predict(self, x):
+    def predict(self, x, meta_kwargs: Optional[dict] = None):
         """Run the model on the input and return or yield the output."""
         pass
 
@@ -111,14 +112,14 @@ class LitAPI(ABC):
         """Convert a batched output to a list of outputs."""
         return self._default_unbatch(output)
 
-    def encode_response(self, output):
+    def encode_response(self, output, meta_kwargs: Optional[dict] = None):
         """Convert the model output to a response payload.
 
         To enable streaming, it should yield the output.
 
         """
         if self._spec:
-            return self._spec.encode_response(output)
+            return self._spec.encode_response(output, meta_kwargs)
         return output
 
     def format_encoded_response(self, data):

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -14,7 +14,6 @@
 import inspect
 import json
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -64,10 +63,10 @@ class LitAPI(ABC):
         """Setup the model so it can be called in `predict`."""
         pass
 
-    def decode_request(self, request, meta_kwargs: Optional[dict] = None):
+    def decode_request(self, request, **kwargs):
         """Convert the request payload to your model input."""
         if self._spec:
-            return self._spec.decode_request(request, meta_kwargs)
+            return self._spec.decode_request(request, **kwargs)
         return request
 
     def batch(self, inputs):
@@ -90,7 +89,7 @@ class LitAPI(ABC):
         raise NotImplementedError(message)
 
     @abstractmethod
-    def predict(self, x, meta_kwargs: Optional[dict] = None):
+    def predict(self, x):
         """Run the model on the input and return or yield the output."""
         pass
 
@@ -112,14 +111,14 @@ class LitAPI(ABC):
         """Convert a batched output to a list of outputs."""
         return self._default_unbatch(output)
 
-    def encode_response(self, output, meta_kwargs: Optional[dict] = None):
+    def encode_response(self, output, **kwargs):
         """Convert the model output to a response payload.
 
         To enable streaming, it should yield the output.
 
         """
         if self._spec:
-            return self._spec.encode_response(output, meta_kwargs)
+            return self._spec.encode_response(output, **kwargs)
         return output
 
     def format_encoded_response(self, data):

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -89,7 +89,7 @@ class LitAPI(ABC):
         raise NotImplementedError(message)
 
     @abstractmethod
-    def predict(self, x):
+    def predict(self, x, **kwargs):
         """Run the model on the input and return or yield the output."""
         pass
 

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -50,10 +50,10 @@ LIT_SERVER_API_KEY = os.environ.get("LIT_SERVER_API_KEY")
 LONG_TIMEOUT = 100
 
 
-def _inject_meta(meta_kwargs: dict, func, *args, **kwargs):
+def _inject_meta(context_kwargs: dict, func, *args, **kwargs):
     sig = inspect.signature(func)
-    if "meta_kwargs" in sig.parameters:
-        return func(*args, **kwargs, meta_kwargs=meta_kwargs)
+    if "context_kwargs" in sig.parameters:
+        return func(*args, **kwargs, context_kwargs=context_kwargs)
     return func(*args, **kwargs)
 
 
@@ -127,19 +127,19 @@ def run_single_loop(lit_api, lit_spec, request_queue: Queue, request_buffer):
         except (Empty, ValueError):
             continue
         try:
-            meta_kwargs = {}
+            context_kwargs = {}
             x = _inject_meta(
-                meta_kwargs,
+                context_kwargs,
                 lit_api.decode_request,
                 x_enc,
             )
             y = _inject_meta(
-                meta_kwargs,
+                context_kwargs,
                 lit_api.predict,
                 x,
             )
             y_enc = _inject_meta(
-                meta_kwargs,
+                context_kwargs,
                 lit_api.encode_response,
                 y,
             )
@@ -169,19 +169,19 @@ def run_streaming_loop(lit_api: LitAPI, lit_spec, request_queue: Queue, request_
             continue
 
         try:
-            meta_kwargs = {}
+            context_kwargs = {}
             x = _inject_meta(
-                meta_kwargs,
+                context_kwargs,
                 lit_api.decode_request,
                 x_enc,
             )
             y_gen = _inject_meta(
-                meta_kwargs,
+                context_kwargs,
                 lit_api.predict,
                 x,
             )
             y_enc_gen = _inject_meta(
-                meta_kwargs,
+                context_kwargs,
                 lit_api.encode_response,
                 y_gen,
             )

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -50,10 +50,10 @@ LIT_SERVER_API_KEY = os.environ.get("LIT_SERVER_API_KEY")
 LONG_TIMEOUT = 100
 
 
-def _inject_meta(context_kwargs: dict, func, *args, **kwargs):
+def _inject_context(context: dict, func, *args, **kwargs):
     sig = inspect.signature(func)
-    if "context_kwargs" in sig.parameters:
-        return func(*args, **kwargs, context_kwargs=context_kwargs)
+    if "context" in sig.parameters:
+        return func(*args, **kwargs, context=context)
     return func(*args, **kwargs)
 
 
@@ -127,19 +127,19 @@ def run_single_loop(lit_api, lit_spec, request_queue: Queue, request_buffer):
         except (Empty, ValueError):
             continue
         try:
-            context_kwargs = {}
-            x = _inject_meta(
-                context_kwargs,
+            context = {}
+            x = _inject_context(
+                context,
                 lit_api.decode_request,
                 x_enc,
             )
-            y = _inject_meta(
-                context_kwargs,
+            y = _inject_context(
+                context,
                 lit_api.predict,
                 x,
             )
-            y_enc = _inject_meta(
-                context_kwargs,
+            y_enc = _inject_context(
+                context,
                 lit_api.encode_response,
                 y,
             )
@@ -169,19 +169,19 @@ def run_streaming_loop(lit_api: LitAPI, lit_spec, request_queue: Queue, request_
             continue
 
         try:
-            context_kwargs = {}
-            x = _inject_meta(
-                context_kwargs,
+            context = {}
+            x = _inject_context(
+                context,
                 lit_api.decode_request,
                 x_enc,
             )
-            y_gen = _inject_meta(
-                context_kwargs,
+            y_gen = _inject_context(
+                context,
                 lit_api.predict,
                 x,
             )
-            y_enc_gen = _inject_meta(
-                context_kwargs,
+            y_enc_gen = _inject_context(
+                context,
                 lit_api.encode_response,
                 y_gen,
             )

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -50,6 +50,13 @@ LIT_SERVER_API_KEY = os.environ.get("LIT_SERVER_API_KEY")
 LONG_TIMEOUT = 100
 
 
+def _inject_meta(meta_kwargs: dict, func, *args, **kwargs):
+    sig = inspect.signature(func)
+    if "meta_kwargs" in sig.parameters:
+        return func(*args, **kwargs, meta_kwargs=meta_kwargs)
+    return func(*args, **kwargs)
+
+
 def get_batch_from_uid(uids, lit_api, request_buffer):
     batches = []
     for uid in uids:
@@ -120,9 +127,22 @@ def run_single_loop(lit_api, lit_spec, request_queue: Queue, request_buffer):
         except (Empty, ValueError):
             continue
         try:
-            x = lit_api.decode_request(x_enc)
-            y = lit_api.predict(x)
-            y_enc = lit_api.encode_response(y)
+            meta_kwargs = {}
+            x = _inject_meta(
+                meta_kwargs,
+                lit_api.decode_request,
+                x_enc,
+            )
+            y = _inject_meta(
+                meta_kwargs,
+                lit_api.predict,
+                x,
+            )
+            y_enc = _inject_meta(
+                meta_kwargs,
+                lit_api.encode_response,
+                y,
+            )
 
             with contextlib.suppress(BrokenPipeError):
                 pipe_s.send((y_enc, LitAPIStatus.OK))
@@ -149,9 +169,22 @@ def run_streaming_loop(lit_api: LitAPI, lit_spec, request_queue: Queue, request_
             continue
 
         try:
-            x = lit_api.decode_request(x_enc)
-            y_gen = lit_api.predict(x)
-            y_enc_gen = lit_api.encode_response(y_gen)
+            meta_kwargs = {}
+            x = _inject_meta(
+                meta_kwargs,
+                lit_api.decode_request,
+                x_enc,
+            )
+            y_gen = _inject_meta(
+                meta_kwargs,
+                lit_api.predict,
+                x,
+            )
+            y_enc_gen = _inject_meta(
+                meta_kwargs,
+                lit_api.encode_response,
+                y_gen,
+            )
             for y_enc in y_enc_gen:
                 with contextlib.suppress(BrokenPipeError):
                     y_enc = lit_api.format_encoded_response(y_enc)

--- a/src/litserve/specs/base.py
+++ b/src/litserve/specs/base.py
@@ -38,12 +38,12 @@ class LitSpec:
         return self._endpoints.copy()
 
     @abstractmethod
-    def decode_request(self, request):
+    def decode_request(self, request, meta_kwargs):
         """Convert the request payload to your model input."""
         pass
 
     @abstractmethod
-    def encode_response(self, output):
+    def encode_response(self, output, meta_kwargs):
         """Convert the model output to a response payload.
 
         To enable streaming, it should yield the output.

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -184,7 +184,9 @@ class OpenAISpec(LitSpec):
             raise ValueError(LITAPI_VALIDATION_MSG.format("encode_response is not a generator"))
         print("OpenAI spec setup complete")
 
-    def decode_request(self, request: ChatCompletionRequest) -> List[Dict[str, str]]:
+    def decode_request(
+        self, request: ChatCompletionRequest, meta_kwargs: Optional[dict] = None
+    ) -> List[Dict[str, str]]:
         # returns [{"role": "system", "content": "..."}, ...]
         return [el.dict() for el in request.messages]
 
@@ -218,7 +220,9 @@ class OpenAISpec(LitSpec):
 
         return ChatMessage(**message)
 
-    def encode_response(self, output_generator: Union[Dict[str, str], List[Dict[str, str]]]) -> ChatMessage:
+    def encode_response(
+        self, output_generator: Union[Dict[str, str], List[Dict[str, str]]], meta_kwargs: Optional[dict] = None
+    ) -> ChatMessage:
         for output in output_generator:
             logger.debug(output)
             yield self._encode_response(output)

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -185,7 +185,7 @@ class OpenAISpec(LitSpec):
         print("OpenAI spec setup complete")
 
     def decode_request(
-        self, request: ChatCompletionRequest, meta_kwargs: Optional[dict] = None
+        self, request: ChatCompletionRequest, context_kwargs: Optional[dict] = None
     ) -> List[Dict[str, str]]:
         # returns [{"role": "system", "content": "..."}, ...]
         return [el.dict() for el in request.messages]
@@ -221,7 +221,7 @@ class OpenAISpec(LitSpec):
         return ChatMessage(**message)
 
     def encode_response(
-        self, output_generator: Union[Dict[str, str], List[Dict[str, str]]], meta_kwargs: Optional[dict] = None
+        self, output_generator: Union[Dict[str, str], List[Dict[str, str]]], context_kwargs: Optional[dict] = None
     ) -> ChatMessage:
         for output in output_generator:
             logger.debug(output)

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -386,8 +386,6 @@ async def test_inject_context(mocked_load_and_raise):
 
     api = PredictError()
     server = LitServer(api)
-    with pytest.raises(
-        TypeError, match=re.escape("PredictError.predict() missing 1 required positional argument: 'y'")
-    ):
+    with pytest.raises(TypeError, match=re.escape("predict() missing 1 required positional argument: 'y'")):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import asyncio
 import inspect
+import pickle
+import re
 import subprocess
 import time
 from multiprocessing import Pipe, Manager
@@ -37,6 +39,7 @@ from litserve.server import (
     run_batched_streaming_loop,
 )
 from litserve.server import LitServer
+import litserve as ls
 
 
 def test_index(sync_testclient):
@@ -345,3 +348,46 @@ def test_server_run(mock_uvicorn):
     mock_uvicorn.reset_mock()
     server.run(port="8001")
     mock_uvicorn.run.assert_called()
+
+
+class IndentityAPI(ls.examples.SimpleLitAPI):
+    def predict(self, x, context):
+        context["input"] = x
+        return self.model(x)
+
+    def encode_response(self, output, context):
+        input = context["input"]
+        return {"output": input}
+
+
+class PredictError(ls.examples.SimpleLitAPI):
+    def predict(self, x, y, context):
+        context["input"] = x
+        return self.model(x)
+
+    def encode_response(self, output, context):
+        input = context["input"]
+        return {"output": input}
+
+
+@pytest.mark.asyncio()
+@patch("litserve.server.load_and_raise")
+async def test_inject_context(mocked_load_and_raise):
+    def dummy_load_and_raise(resp):
+        raise pickle.loads(resp)
+
+    mocked_load_and_raise.side_effect = dummy_load_and_raise
+
+    api = IndentityAPI()
+    server = LitServer(api)
+    async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
+        resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
+    assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
+
+    api = PredictError()
+    server = LitServer(api)
+    with pytest.raises(
+        TypeError, match=re.escape("PredictError.predict() missing 1 required positional argument: 'y'")
+    ):
+        async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
+            resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)


### PR DESCRIPTION
When trying to share request context across decode, predict and encode method, the current way to do this is not clean and breaks batching.  This PR injects a `context` that lives across decode, predict, and encode which can be used to log important details that can be passed on from one method to another. 

**User impact**: `context_kwargs` is an optional argument and users won't be forced to include it while defining a custom LitAPI.

Example, we can track the number of tokens for token usage schema of `OpenAISpec`:

```python
import time
from typing import Optional

from transformers import pipeline
import litserve as ls
import logging

class GPT2LitAPI(ls.LitAPI):
    def setup(self, device):
        pass

    def predict(self, x, context_kwargs): 
        context_kwargs["num_tokens"] = 0
        for text in "this is a generated text".split():
            context_kwargs["num_tokens"] += 1
            yield text + " "

    def encode_response(self, output, context_kwargs):
        for e in super().encode_response(output):
           if context_kwargs["num_tokens"] > num_max_tokens:
                context_kwargs["finish_reason"] = "length"
                return
           usage = {"num_tokens": context_kwargs["num_tokens"]}
           # we can encode and return usage here
            yield e


if __name__ == '__main__':
    api = GPT2LitAPI()
    server = ls.LitServer(api, accelerator='auto', spec=ls.OpenAISpec())
    server.run(port=8000)
```