### PR TITLE
pre-populate context with OpenAISpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,34 @@ if __name__=="__main__":
     server.run(port=8000)
 ```
 
+
+`LitSpec` can pre-populate the context by defining a `populate_context(context, request)` method. 
+This method takes the context and the raw HTTP request as input. 
+
+`OpenAISpec` automatically pre-populate the `context` with the client request. 
+
+Here is an example that pre-populates the context using a custom spec.
+
+```python
+import litserve as ls
+
+class CustomSpec(ls.specs.OpenAISpec):
+    def populate_context(self, context, request):
+        context["CUSTOM_VALUE_X"] = "This a random value"
+
+class TestAPI(ls.LitAPI):
+    def setup(self, device):
+        self.model = None
+
+    def predict(self, x, context):
+        yield context["CUSTOM_VALUE_X"]
+
+if __name__ == "__main__":
+    api = TestAPI()
+    server = ls.LitServer(api, spec=CustomSpec())
+    server.run(port=8000)
+```
+
 </details>
 
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -791,10 +791,10 @@ if __name__=="__main__":
 ```
 
 
-`LitSpec` can pre-populate the context by defining a `populate_context(context, request)` method. 
-This method takes the context and the raw HTTP request as input. 
+LitSpec can pre-populate the context by defining a `populate_context(context, request)` method. This method takes the 
+context and the raw HTTP request as inputs.
 
-`OpenAISpec` automatically pre-populate the `context` with the client request. 
+`OpenAISpec` automatically pre-populate the `context` with the ChatCompletion client request. 
 
 Here is an example that pre-populates the context using a custom spec.
 

--- a/README.md
+++ b/README.md
@@ -791,12 +791,12 @@ if __name__=="__main__":
 ```
 
 
-LitSpec can pre-populate the context by defining a `populate_context(context, request)` method. This method takes the 
+`LitSpec` can pre-populate the `context` by defining a `populate_context(context, request)` method. This method takes the 
 context and the raw HTTP request as inputs.
 
-`OpenAISpec` automatically pre-populate the `context` with the ChatCompletion client request. 
+`OpenAISpec` automatically populates the `context` with the `ChatCompletion` request meta-data (e.g. `temperature`, `max_tokens`), see the [request model](src/litserve/specs/openai.py#L99) for reference.
 
-Here is an example that pre-populates the context using a custom spec.
+Here is an example that populates the `context` using a custom spec.
 
 ```python
 import litserve as ls

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -170,6 +170,8 @@ def run_streaming_loop(lit_api: LitAPI, lit_spec, request_queue: Queue, request_
 
         try:
             context = {}
+            if isinstance(lit_spec, OpenAISpec):
+                lit_spec.populate_context(context, x_enc)
             x = _inject_context(
                 context,
                 lit_api.decode_request,

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -170,7 +170,7 @@ def run_streaming_loop(lit_api: LitAPI, lit_spec, request_queue: Queue, request_
 
         try:
             context = {}
-            if isinstance(lit_spec, OpenAISpec):
+            if hasattr(lit_spec, "populate_context"):
                 lit_spec.populate_context(context, x_enc)
             x = _inject_context(
                 context,

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -220,6 +220,11 @@ class OpenAISpec(LitSpec):
             raise ValueError(LITAPI_VALIDATION_MSG.format("encode_response is not a generator"))
         print("OpenAI spec setup complete")
 
+    def populate_context(self, context, request):
+        data = request.dict()
+        data.pop("messages")
+        context.update(data)
+
     def decode_request(
         self, request: ChatCompletionRequest, context_kwargs: Optional[dict] = None
     ) -> List[Dict[str, str]]:

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -108,7 +108,7 @@ async def test_openai_spec_validation(openai_request_data):
             await manager.shutdown()
 
 
-class PrePoulatedAPI(ls.LitAPI):
+class PrePopulatedAPI(ls.LitAPI):
     def setup(self, device):
         self.sentence = ["This", "is", "a", "sample", "response"]
 

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -123,7 +123,7 @@ class PrePopulatedAPI(ls.LitAPI):
 async def test_oai_prepopulated_context(openai_request_data):
     openai_request_data["max_tokens"] = 3
     spec = OpenAISpec()
-    server = ls.LitServer(PrePoulatedAPI(), spec=spec)
+    server = ls.LitServer(PrePopulatedAPI(), spec=spec)
     async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
         resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
         assert (


### PR DESCRIPTION
## User motivation

While using OpenAISpec users have to track the openai ChatCompletion request parameters manually in decode_request and most of the time users will need these parameters. LitServe can automatically pre-populate `context` with the parameters so that user don't have to do it manually in decode_request.

## Before
```python
import litserve as ls

class SimpleLitAPI(ls.LitAPI):
    def setup(self, device):
        self.sentence = ["This", "is", "a", "sample", "response"]
   
    ####### This can be automated ########
    def decode_request(self, request, context):
        context["max_tokens"] = request.max_tokens
        return [el.dict() for el in request.messages]

    def predict(self, prompt, context):
        for count, token in enumerate(self.sentence, start=1):
            yield token
            if count > context["max_tokens"]:
                return

if __name__ == "__main__":
    api = SimpleLitAPI()
    server = ls.LitServer(api, spec=ls.OpenAISpec())
    server.run(port=8000)
```

## After

```python
import litserve as ls

class SimpleLitAPI(ls.LitAPI):
    def setup(self, device):
        self.sentence = ["This", "is", "a", "sample", "response"]

    def predict(self, prompt, context):
        for count, token in enumerate(self.sentence, start=1):
            yield token
            if count > context["max_tokens"]:
                return

if __name__ == "__main__":
    api = SimpleLitAPI()
    server = ls.LitServer(api, spec=ls.OpenAISpec())
    server.run(port=8000)
```