### PR TITLE
Add option to disable automatic client.py generation

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -574,8 +574,9 @@ class LitServer:
         except Exception as e:
             print(f"Error copying file: {e}")
 
-    def run(self, port: Union[str, int] = 8000, log_level: str = "info", **kwargs):
-        self.generate_client_file()
+    def run(self, port: Union[str, int] = 8000, log_level: str = "info", generate_client_file: bool = True, **kwargs):
+        if generate_client_file:
+            self.generate_client_file()
 
         port_msg = f"port must be a value from 1024 to 65535 but got {port}"
         try:


### PR DESCRIPTION
This adds an option to disable the automatic generation of a `client.py` file. It's by default still enabled so it doesn't change anything for current LitServe users and the documentation.

But it allows me to disable the file generation, because it may create incorrect files, in LitGPT as discussed in [#1466](https://github.com/Lightning-AI/litgpt/pull/1466)