### PR TITLE
Fix Starlette streaming responses

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -467,12 +467,13 @@ class LitServer:
     async def data_streamer(self, read: Connection, write: Connection):
         data_available = asyncio.Event()
         while True:
-            if not read.poll(1):
+            # Calling poll blocks the event loop, so keep the timeout low
+            if not read.poll(0.001):
                 asyncio.get_event_loop().add_reader(read.fileno(), data_available.set)
                 await data_available.wait()
                 data_available.clear()
                 asyncio.get_event_loop().remove_reader(read.fileno())
-            if read.poll(1):
+            if read.poll(0.001):
                 response, status = read.recv()
                 if status == LitAPIStatus.FINISH_STREAMING:
                     return


### PR DESCRIPTION
Starlette's `StreamingResponse` doesn't behave as intended when you give it an async generator function. It tries to start a threadpool with a bunch of workers to process the async generator. But of course, tokens are sequential. Each task has to wait on the previous, and the order that they're processed seems to be random, so the tokens come in spurts. Everything is consistent once the threadpool closes, but this is not the intended behavior.

To make Starlette process the tokens in order, wrap the async generator with a synchronous one.

I'm less sure about my implementation though. If this could be done better, let me know.