### PR TITLE
custom api endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,26 @@ if __name__ == "__main__":
 
 </details>
 
+<details>
+  <summary>Customize endpoint path</summary>
+
+&nbsp;
+
+By default, LitServe exposes the `/predict` endpoint for serving the model. 
+You can customize this endpoint path by providing the `api_path` argument in `LitServer` as follows:
+
+```python
+import litserve as ls
+from litserve.examples import SimpleLitAPI
+
+if __name__ == '__main__':
+    api = SimpleLitAPI()
+    server = ls.LitServer(api, api_path="/my_api/classify")
+    server.run(port=8000)
+```
+
+</details>
+
 &nbsp;
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-  <summary>Customize endpoint path</summary>
+  <summary>Customize the endpoint path</summary>
 
 &nbsp;
 

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -37,6 +37,7 @@ from litserve.server import (
 )
 from litserve.server import LitServer
 import litserve as ls
+from fastapi.testclient import TestClient
 
 
 def test_index(sync_testclient):
@@ -370,3 +371,14 @@ async def test_inject_context(mocked_load_and_raise):
     with pytest.raises(TypeError, match=re.escape("predict() missing 1 required positional argument: 'y'")):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
+
+
+def test_custom_api_path(sync_testclient):
+    with pytest.raises(ValueError, match="api_path must start with '/'. "):
+        LitServer(SimpleLitAPI(), api_path="predict")
+
+    server = LitServer(SimpleLitAPI(), api_path="/v1/custom_predict")
+    url = server.api_path
+    with TestClient(server.app) as client:
+        response = client.post(url, json={"input": 4.0})
+        assert response.status_code == 200

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -373,12 +373,12 @@ async def test_inject_context(mocked_load_and_raise):
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
 
 
-def test_custom_api_path(sync_testclient):
+def test_custom_api_path():
     with pytest.raises(ValueError, match="api_path must start with '/'. "):
-        LitServer(SimpleLitAPI(), api_path="predict")
+        LitServer(ls.examples.SimpleLitAPI(), api_path="predict")
 
-    server = LitServer(SimpleLitAPI(), api_path="/v1/custom_predict")
+    server = LitServer(ls.examples.SimpleLitAPI(), api_path="/v1/custom_predict")
     url = server.api_path
     with TestClient(server.app) as client:
         response = client.post(url, json={"input": 4.0})
-        assert response.status_code == 200
+        assert response.status_code == 200, "Server response should be 200 (OK)"


### PR DESCRIPTION
As discussed in #90, a public facing endpoint path should match the functionality to reduce confusion. Example, `/classify` to be used for classification and `/segment` to be used for segmentation. 

The default endpoint remains to be `/predict`.

