### PR TITLE
remove busy wait from data_streamer

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -479,7 +479,7 @@ class LitServer:
 
         def reader():
             try:
-                while read.poll():  # Check if there's data available to read
+                while read.poll(0.001):  # Check if there's data available to read
                     response, status = read.recv()
                     queue.put_nowait((response, status))
                     data_available.set()

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -480,7 +480,7 @@ class LitServer:
             if not read.poll():
                 await data_available.wait()
                 data_available.clear()
-            if read.poll():
+            if read.poll(0.001):
                 response, status = read.recv()
                 if status == LitAPIStatus.FINISH_STREAMING:
                     asyncio.get_event_loop().remove_reader(read.fileno())

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -534,6 +534,8 @@ class LitServer:
                             "Please check the above traceback."
                         )
                         loop.remove_reader(read.fileno())
+                        if send_status:
+                            yield response, status
                         return
                     if send_status:
                         yield response, status

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -505,7 +505,7 @@ class LitServer:
 
         def reader():
             try:
-                while read.poll(0.001):  # Check if there's data available to read
+                while read.poll():  # Check if there's data available to read
                     response, status = read.recv()
                     queue.put_nowait((response, status))
                     data_available.set()

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -474,7 +474,8 @@ class LitServer:
 
     async def data_streamer(self, read: Connection, write: Connection):
         data_available = asyncio.Event()
-        asyncio.get_event_loop().add_reader(read.fileno(), data_available.set)
+        loop = asyncio.get_event_loop()
+        loop.add_reader(read.fileno(), data_available.set)
         while True:
             # Calling poll blocks the event loop, so keep the timeout low
             if not read.poll():
@@ -483,14 +484,14 @@ class LitServer:
             if read.poll(0.001):
                 response, status = read.recv()
                 if status == LitAPIStatus.FINISH_STREAMING:
-                    asyncio.get_event_loop().remove_reader(read.fileno())
+                    loop.remove_reader(read.fileno())
                     return
                 if status == LitAPIStatus.ERROR:
                     logger.error(
                         "Error occurred while streaming outputs from the inference worker. "
                         "Please check the above traceback."
                     )
-                    asyncio.get_event_loop().remove_reader(read.fileno())
+                    loop.remove_reader(read.fileno())
                     return
                 yield response
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

`data_streamer` polls the multiprocessing Pipe Connection for new data and busy waiting causes async loop to hang as discovered in #133.

* This PR, removes the busy polling and uses async queue to consume high speed data.

* When speed of LitAPI generator (prediction, let's say a for loop of 1B) then consumption speed of data_streamer fails to keep up that pace and data is lost. This PR makes sure that all the data is consumed in a go whenever it's available.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
