### PR TITLE
implement OpenAI token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ if __name__ == "__main__":
 The OpenAI response includes usage information, which contains the number of tokens for the prompt, generated text, and 
 total tokens for the given request.
 
-With LitServe this can be achieved using the `encode_response` method to yield usage information as follows:
+With LitServe, this can be achieved using the encode_response method to yield usage information as follows:
 
 ```python
 import litserve as ls
@@ -651,11 +651,11 @@ class OpenAIUsageAPI(ls.LitAPI):
     def encode_response(self, output):
         for out in output:
             yield {"role": "assistant", "content": out}
-        # Get the usage info and yield as last output
+        # Get the usage info and yield it as the last output
         yield {"role": "assistant", "content": "", "prompt_tokens": 25, "completion_tokens": 10, "total_tokens": 35}
 ```
 
-An equivalent but simpler approach without the need to override the `encode_response` method is as follows:
+An equivalent, but simpler, approach without the need to override the `encode_response` method is as follows:
 
 ```python
 import litserve as ls

--- a/README.md
+++ b/README.md
@@ -633,6 +633,68 @@ if __name__ == "__main__":
 ```
 &nbsp;
 
+The OpenAI response includes usage information, which contains the number of tokens for the prompt, generated text, and 
+total tokens for the given request.
+
+With LitServe this can be achieved using the `encode_response` method to yield usage information as follows:
+
+```python
+import litserve as ls
+
+class OpenAIUsageAPI(ls.LitAPI):
+    def setup(self, device):
+        self.model = None
+
+    def predict(self, x):
+        yield "10 + 6 is equal to 16."
+
+    def encode_response(self, output):
+        for out in output:
+            yield {"role": "assistant", "content": out}
+        # Get the usage info and yield as last output
+        yield {"role": "assistant", "content": "", "prompt_tokens": 25, "completion_tokens": 10, "total_tokens": 35}
+```
+
+An equivalent but simpler approach without the need to override the `encode_response` method is as follows:
+
+```python
+import litserve as ls
+
+class OpenAIUsageAPI(ls.LitAPI):
+    def setup(self, device):
+        self.model = None
+
+    def predict(self, x):
+        yield {"role": "assistant", "content": "10 + 6 is equal to 16.", "prompt_tokens": 25, "completion_tokens": 10, "total_tokens": 35}
+```
+
+The server response using either of the above approaches would include token usage data as shown below:
+
+```json
+{
+    "id": "chatcmpl-9dEtoQgtrtr3451SZ2s98S",
+    "choices": [
+        {
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+                "content": "10 + 6 is equal to 16.",
+                "role": "assistant",
+                "function_call": null,
+                "tool_calls": null
+            }
+        }
+    ],
+    "created": 1719139092,
+    "model": "gpt-3.5-turbo-0125",
+    "object": "chat.completion",
+    "system_fingerprint": null,
+    "usage": {"completion_tokens": 10, "prompt_tokens": 25, "total_tokens": 35}
+}
+```
+
+
 LitServe's `OpenAISpec` can also handle images in the input. Here is an example:
 
 ```python
@@ -901,7 +963,7 @@ if __name__=="__main__":
 </details>
 
 <details>
-  <summary>Customize the endpoint path</summary>
+  <summary>✅ Customize the endpoint path</summary>
 
 &nbsp;
 

--- a/src/litserve/examples/openai_spec_example.py
+++ b/src/litserve/examples/openai_spec_example.py
@@ -79,7 +79,12 @@ class OpenAIWithUsage(ls.LitAPI):
         self.model = None
 
     def predict(self, x):
-        yield {"content": "This is a generated output", "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
+        yield "This is a generated output"
+
+    def encode_response(self, output):
+        yield {"role": "assistant", "content": ""}
+        for out in output:
+            yield {"role": "assistant", "content": out, "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
 
 
 if __name__ == "__main__":

--- a/src/litserve/examples/openai_spec_example.py
+++ b/src/litserve/examples/openai_spec_example.py
@@ -79,10 +79,23 @@ class OpenAIWithUsage(ls.LitAPI):
         self.model = None
 
     def predict(self, x):
+        yield {
+            "role": "assistant",
+            "content": "10 + 6 is equal to 16.",
+            "prompt_tokens": 25,
+            "completion_tokens": 10,
+            "total_tokens": 35,
+        }
+
+
+class OpenAIWithUsageEncodeResponse(ls.LitAPI):
+    def setup(self, device):
+        self.model = None
+
+    def predict(self, x):
         yield "10 + 6 is equal to 16."
 
     def encode_response(self, output):
-        yield {"role": "assistant", "content": ""}
         for out in output:
             yield {"role": "assistant", "content": out}
 

--- a/src/litserve/examples/openai_spec_example.py
+++ b/src/litserve/examples/openai_spec_example.py
@@ -79,14 +79,14 @@ class OpenAIWithUsage(ls.LitAPI):
         self.model = None
 
     def predict(self, x):
-        yield "This is a generated output"
+        yield "10 + 6 is equal to 16."
 
     def encode_response(self, output):
         yield {"role": "assistant", "content": ""}
         for out in output:
             yield {"role": "assistant", "content": out}
 
-        yield {"role": "assistant", "content": "", "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
+        yield {"role": "assistant", "content": "", "prompt_tokens": 25, "completion_tokens": 10, "total_tokens": 35}
 
 
 class OpenAIBatchingWithUsage(OpenAIWithUsage):
@@ -95,7 +95,7 @@ class OpenAIBatchingWithUsage(OpenAIWithUsage):
 
     def predict(self, x):
         n = len(x)
-        yield ["This is a generated output"] * n
+        yield ["10 + 6 is equal to 16."] * n
 
     def encode_response(self, output_stream_batch, context):
         n = len(context)
@@ -103,7 +103,7 @@ class OpenAIBatchingWithUsage(OpenAIWithUsage):
             yield [{"role": "assistant", "content": out} for out in output_batch]
 
         yield [
-            {"role": "assistant", "content": "", "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
+            {"role": "assistant", "content": "", "prompt_tokens": 25, "completion_tokens": 10, "total_tokens": 35}
         ] * n
 
     def unbatch(self, output):

--- a/src/litserve/examples/openai_spec_example.py
+++ b/src/litserve/examples/openai_spec_example.py
@@ -84,7 +84,30 @@ class OpenAIWithUsage(ls.LitAPI):
     def encode_response(self, output):
         yield {"role": "assistant", "content": ""}
         for out in output:
-            yield {"role": "assistant", "content": out, "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
+            yield {"role": "assistant", "content": out}
+
+        yield {"role": "assistant", "content": "", "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
+
+
+class OpenAIBatchingWithUsage(OpenAIWithUsage):
+    def batch(self, inputs):
+        return inputs
+
+    def predict(self, x):
+        n = len(x)
+        yield ["This is a generated output"] * n
+
+    def encode_response(self, output_stream_batch, context):
+        n = len(context)
+        for output_batch in output_stream_batch:
+            yield [{"role": "assistant", "content": out} for out in output_batch]
+
+        yield [
+            {"role": "assistant", "content": "", "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
+        ] * n
+
+    def unbatch(self, output):
+        return output
 
 
 if __name__ == "__main__":

--- a/src/litserve/examples/openai_spec_example.py
+++ b/src/litserve/examples/openai_spec_example.py
@@ -93,7 +93,8 @@ class OpenAIWithUsageEncodeResponse(ls.LitAPI):
         self.model = None
 
     def predict(self, x):
-        yield "10 + 6 is equal to 16."
+        # streaming tokens
+        yield from ["10", " +", " ", "6", " is", " equal", " to", " ", "16", "."]
 
     def encode_response(self, output):
         for out in output:

--- a/src/litserve/examples/openai_spec_example.py
+++ b/src/litserve/examples/openai_spec_example.py
@@ -74,6 +74,14 @@ class OpenAIBatchContext(ls.LitAPI):
             assert ctx["temperature"] == 1.0, f"context {ctx} is not 1.0"
 
 
+class OpenAIWithUsage(ls.LitAPI):
+    def setup(self, device):
+        self.model = None
+
+    def predict(self, x):
+        yield {"content": "This is a generated output", "prompt_tokens": 5, "completion_tokens": 10}
+
+
 if __name__ == "__main__":
     server = ls.LitServer(TestAPIWithCustomEncode(), spec=OpenAISpec())
     server.run(port=8000)

--- a/src/litserve/examples/openai_spec_example.py
+++ b/src/litserve/examples/openai_spec_example.py
@@ -79,7 +79,7 @@ class OpenAIWithUsage(ls.LitAPI):
         self.model = None
 
     def predict(self, x):
-        yield {"content": "This is a generated output", "prompt_tokens": 5, "completion_tokens": 10}
+        yield {"content": "This is a generated output", "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
 
 
 if __name__ == "__main__":

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -341,21 +341,21 @@ class OpenAISpec(LitSpec):
         usage = None
         async for streaming_response in azip(*pipe_responses):
             choices = []
-            usage_info = {}
+            usage_infos = []
             for i, (response, status) in enumerate(streaming_response):
                 if status == LitAPIStatus.ERROR:
                     load_and_raise(response)
                 encoded_response = json.loads(response)
                 logger.debug(encoded_response)
                 chat_msg = ChoiceDelta(**encoded_response)
-                usage_info[i] = UsageInfo(**encoded_response)
+                usage_infos.append(UsageInfo(**encoded_response))
                 choice = ChatCompletionStreamingChoice(
                     index=i, delta=chat_msg, system_fingerprint="", finish_reason=None
                 )
 
                 choices.append(choice)
 
-            chunk = ChatCompletionChunk(model=model, choices=choices, usage=sum(usage_info.values())).json()
+            chunk = ChatCompletionChunk(model=model, choices=choices, usage=sum(usage_infos)).json()
             logger.debug(chunk)
             yield f"data: {chunk}\n\n"
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -20,7 +20,7 @@ import time
 import typing
 import uuid
 from enum import Enum
-from typing import AsyncGenerator, Dict, List, Literal, Optional, Union, Generator
+from typing import AsyncGenerator, Dict, List, Literal, Optional, Union, Iterator
 
 from fastapi import BackgroundTasks, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
@@ -100,6 +100,12 @@ class ChatMessage(BaseModel):
     name: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     tool_call_id: Optional[str] = None
+
+
+class ChatMessageWithUsage(ChatMessage):
+    prompt_tokens: Optional[int] = 0
+    total_tokens: Optional[int] = 0
+    completion_tokens: Optional[int] = 0
 
 
 class ChoiceDelta(ChatMessage):
@@ -284,7 +290,7 @@ class OpenAISpec(LitSpec):
 
     def encode_response(
         self, output_generator: Union[Dict[str, str], List[Dict[str, str]]], context_kwargs: Optional[dict] = None
-    ) -> Generator[Dict, None, None]:
+    ) -> Iterator[Union[ChatMessage, ChatMessageWithUsage]]:
         for output in output_generator:
             logger.debug(output)
             yield self._encode_response(output)

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -356,6 +356,7 @@ class OpenAISpec(LitSpec):
 
                 choices.append(choice)
 
+            # Only use the last item from encode_response
             usage_info = sum(usage_infos)
             chunk = ChatCompletionChunk(model=model, choices=choices, usage=None).json()
             logger.debug(chunk)
@@ -402,6 +403,6 @@ class OpenAISpec(LitSpec):
             msg = {"role": "assistant", "content": content, "tool_calls": tool_calls}
             choice = ChatCompletionResponseChoice(index=i, message=msg, finish_reason="stop")
             choices.append(choice)
-            usage_infos.append(usage)  # always use the last item from encode_response
+            usage_infos.append(usage)  # Only use the last item from encode_response
 
         return ChatCompletionResponse(model=model, choices=choices, usage=sum(usage_infos))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,31 @@ def openai_request_data():
 
 
 @pytest.fixture()
+def openai_response_data():
+    return {
+        "id": "chatcmpl-9dEtoQu4g45g3431SZ2s98S",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "logprobs": None,
+                "message": {
+                    "content": "10 + 6 is equal to 16.",
+                    "role": "assistant",
+                    "function_call": None,
+                    "tool_calls": None,
+                },
+            }
+        ],
+        "created": 1719139092,
+        "model": "gpt-3.5-turbo-0125",
+        "object": "chat.completion",
+        "system_fingerprint": None,
+        "usage": {"completion_tokens": 10, "prompt_tokens": 25, "total_tokens": 35},
+    }
+
+
+@pytest.fixture()
 def openai_request_data_with_image():
     return {
         "model": "lit",

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -22,6 +22,7 @@ from litserve.examples.openai_spec_example import (
     TestAPIWithToolCalls,
     OpenAIWithUsage,
     OpenAIBatchingWithUsage,
+    OpenAIWithUsageEncodeResponse,
 )
 from litserve.specs.openai import OpenAISpec, ChatMessage
 import litserve as ls
@@ -40,10 +41,15 @@ async def test_openai_spec(openai_request_data):
         ), "LitAPI predict response should match with the generated output"
 
 
+# OpenAIWithUsage
 @pytest.mark.asyncio()
 @pytest.mark.parametrize(
     ("api", "batch_size"),
-    [(OpenAIBatchingWithUsage(), 2), (OpenAIWithUsage(), 1)],
+    [
+        (OpenAIWithUsage(), 1),
+        (OpenAIWithUsageEncodeResponse(), 1),
+        (OpenAIBatchingWithUsage(), 2),
+    ],
 )
 async def test_openai_token_usage(api, batch_size, openai_request_data, openai_response_data):
     server = ls.LitServer(api, spec=ls.OpenAISpec(), max_batch_size=batch_size, batch_timeout=0.01)

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -46,13 +46,17 @@ async def test_openai_token_usage(openai_request_data):
         resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
         assert resp.status_code == 200, "Status code should be 200"
         result = resp.json()
-
-        assert (
-            result["choices"][0]["message"]["content"] == "This is a generated output"
-        ), "LitAPI predict response should match with the generated output"
+        content = result["choices"][0]["message"]["content"]
+        assert content == "This is a generated output", "LitAPI predict response should match with the generated output"
         assert result["usage"]["prompt_tokens"] == 5
         assert result["usage"]["completion_tokens"] == 10
         assert result["usage"]["total_tokens"] == 15
+
+        # with streaming
+        # TODO: test with streaming and batching
+        openai_request_data["stream"] = True
+        resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
+        assert resp.status_code == 200, "Status code should be 200"
 
 
 @pytest.mark.asyncio()

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -50,7 +50,9 @@ async def test_openai_token_usage(openai_request_data):
         assert (
             result["choices"][0]["message"]["content"] == "This is a generated output"
         ), "LitAPI predict response should match with the generated output"
-        assert result["usage"]["completion_tokens"] == 15
+        assert result["usage"]["prompt_tokens"] == 5
+        assert result["usage"]["completion_tokens"] == 10
+        assert result["usage"]["total_tokens"] == 15
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

RIght now we don't provide a way to track prompt tokens and completion tokens and send a dummy value in the response.

This PR will proposes a way to track and update the usage info for `completion_tokens`, `prompt_tokens` and `total_tokens`. 


### Proposal

Return the `prompt_tokens` and `completion_tokens` along with the generated content and LitServe will automatically update it and send in response.

```python
class OpenAIWithUsage(ls.LitAPI):
    def setup(self, device):
        self.model = None

    def predict(self, x):
        yield {"role": "assistant", "content": "This is a generated output", "prompt_tokens": 5, "completion_tokens": 10}

```


Just added test for the expected flow right now, if you approve @lantiga this proposal then I can update the rest asap.


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
