### PR TITLE
feat: Add ability to customize authorization method

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,16 @@ LIT_SERVER_API_KEY=supersecretkey python main.py
 
 Clients are expected to auth with the same API key set in the `X-API-Key` HTTP header.
 
+Alternatively, implement a method named `authorize` in the LitAPI subclass to provide custom authentication:
+
+```python
+from fastapi import HTTPException, Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+def authorize(self, auth: HTTPAuthorizationCredentials = Depends(HTTPBearer())):
+    raise HTTPException(status_code=401, detail="Not authorized")
+```
+
 </details>
 
 <details>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,94 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import Request, Response, HTTPException, Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.testclient import TestClient
+
+from litserve import LitAPI, LitServer
+import litserve.server
+
+
+class SimpleAuthedLitAPI(LitAPI):
+    def setup(self, device):
+        self.model = lambda x: x**2
+
+    def decode_request(self, request: Request):
+        return request["input"]
+
+    def predict(self, x):
+        return self.model(x)
+
+    def encode_response(self, output) -> Response:
+        return {"output": output}
+
+    def authorize(self, auth: HTTPAuthorizationCredentials = Depends(HTTPBearer())):
+        if auth.scheme != "Bearer" or auth.credentials != "1234":
+            raise HTTPException(status_code=401, detail="Bad token")
+
+
+def test_authorized_custom():
+    server = LitServer(SimpleAuthedLitAPI(), accelerator="cpu", devices=1, workers_per_device=1)
+
+    with TestClient(server.app) as client:
+        input = {"input": 4.0}
+        response = client.post("/predict", headers={"Authorization": "Bearer 1234"}, json=input)
+        assert response.status_code == 200
+
+
+def test_not_authorized_custom():
+    server = LitServer(SimpleAuthedLitAPI(), accelerator="cpu", devices=1, workers_per_device=1)
+
+    with TestClient(server.app) as client:
+        input = {"input": 4.0}
+        response = client.post("/predict", headers={"Authorization": "Bearer wrong"}, json=input)
+        assert response.status_code == 401
+
+
+class SimpleLitAPI(LitAPI):
+    def setup(self, device):
+        self.model = lambda x: x**2
+
+    def decode_request(self, request: Request):
+        return request["input"]
+
+    def predict(self, x):
+        return self.model(x)
+
+    def encode_response(self, output) -> Response:
+        return {"output": output}
+
+
+def test_authorized_api_key():
+    litserve.server.LIT_SERVER_API_KEY = "abcd"
+    server = LitServer(SimpleLitAPI(), accelerator="cpu", devices=1, workers_per_device=1)
+
+    with TestClient(server.app) as client:
+        input = {"input": 4.0}
+        response = client.post("/predict", headers={"X-API-Key": "abcd"}, json=input)
+        assert response.status_code == 200
+
+    litserve.server.LIT_SERVER_API_KEY = None
+
+
+def test_not_authorized_api_key():
+    litserve.server.LIT_SERVER_API_KEY = "abcd"
+    server = LitServer(SimpleLitAPI(), accelerator="cpu", devices=1, workers_per_device=1)
+
+    with TestClient(server.app) as client:
+        input = {"input": 4.0}
+        response = client.post("/predict", headers={"X-API-Key": "wrong"}, json=input)
+        assert response.status_code == 401
+
+    litserve.server.LIT_SERVER_API_KEY = None


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [No] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure to update the docs?
- [X] Did you write any new necessary tests?

</details>

## What does this PR do?

Currently, the only method to secure a LitServe endpoint is by providing an `X-API-Key`, which much be a global value.  This excludes a wide-range of common authentication methods.  This PR adds the ability to provide your own authentication method to a LitAPI.  Example usage is added to the docs and tests

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
