### PR TITLE
use `get_running_loop` over `get_event_loop`

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -494,7 +494,7 @@ class LitServer:
 
     async def data_reader(self, read):
         data_available = asyncio.Event()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         loop.add_reader(read.fileno(), data_available.set)
 
         if not read.poll():
@@ -530,7 +530,7 @@ class LitServer:
     async def data_streamer(self, read: Connection, write: Connection, send_status=False):
         data_available = asyncio.Event()
         queue = asyncio.Queue()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def reader():
             try:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

The [official documentation](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) recommends to use `get_running_loop` over `get_event_loop` since the latter has complex behaviour.

> Because this function has rather complex behavior (especially when custom event loop policies are in use), using the [get_running_loop()](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop) function is preferred to [get_event_loop()](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) in coroutines and callbacks.


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
