### PR TITLE
support openai image_url with detail settings

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -61,9 +61,20 @@ class TextContent(BaseModel):
     text: str
 
 
+class ImageDetail(str, Enum):
+    auto: str = "auto"
+    low: str = "low"
+    high: str = "high"
+
+
+class ImageContentURL(BaseModel):
+    url: str
+    detail: ImageDetail = ImageDetail.auto
+
+
 class ImageContent(BaseModel):
     type: str
-    image_url: str
+    image_url: Union[str, ImageContentURL]
 
 
 class Function(BaseModel):

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -144,7 +144,7 @@ def test_openai_parity_with_image_input():
                     "image_url": {
                         "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
                         "detail": "low",
-                    }
+                    },
                 },
             ],
         },

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -141,7 +141,10 @@ def test_openai_parity_with_image_input():
                 {"type": "text", "text": "What's in this image?"},
                 {
                     "type": "image_url",
-                    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                    "image_url": {
+                        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                        "detail": "low",
+                    }
                 },
             ],
         },


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

The OpenAI multimodal API uses a new format for image_url, which has two sub-fields 'url' and 'detail'. Please check [Reference](https://platform.openai.com/docs/guides/vision). This PR will support this new format.   

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
