### PR TITLE
Fix: Support files > 1MB

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -19,6 +19,7 @@ import multiprocessing as mp
 import os
 import pickle
 import shutil
+import sys
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -30,6 +31,7 @@ from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request, R
 from fastapi.responses import StreamingResponse
 from fastapi.security import APIKeyHeader
 from starlette.middleware.gzip import GZipMiddleware
+from starlette.formparsers import MultiPartParser
 
 from litserve import LitAPI
 from litserve.connector import _Connector
@@ -45,6 +47,9 @@ LIT_SERVER_API_KEY = os.environ.get("LIT_SERVER_API_KEY")
 
 # timeout when we need to poll or wait indefinitely for a result in a loop.
 LONG_TIMEOUT = 100
+
+# FastAPI writes form files to disk over 1MB by default, which prevents serialization by multiprocessing
+MultiPartParser.max_file_size = sys.maxsize
 
 
 def _inject_context(context: Union[List[dict], dict], func, *args, **kwargs):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR allows files that are larger than 1MB to be uploaded.

For files larger than 1MB uploaded with FastAPI, it creates a [SpooledTemporaryFile](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile) which is partially written to disk as [described here](https://fastapi.tiangolo.com/tutorial/request-files/#uploadfile).  This prevents pickling of the form by the multiprocess library and crashes the request.

This PR sets the limit to an extremely large number so the file is always kept entirely in memory.  This allows the file to be serialized correctly.  Effectively, this limits the max file size for LitServe to the amount of RAM available on the machine.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
