### PR TITLE
Add meaningful error message if response queues are not initialized

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -549,7 +549,9 @@ class LitServer:
         loop = asyncio.get_running_loop()
 
         if not hasattr(self, "response_queues") or not self.response_queues:
-            raise RuntimeError("Response queues have not been initialized, please ensure that LitServer.launch_inference_worker was called!")
+            raise RuntimeError(
+                "Response queues have not been initialized, please ensure that LitServer.launch_inference_worker was called!"
+            )
 
         response_queue = self.response_queues[app.response_queue_id]
         response_executor = ThreadPoolExecutor(max_workers=len(self.devices * self.workers_per_device))

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -549,7 +549,7 @@ class LitServer:
         loop = asyncio.get_running_loop()
 
         if not hasattr(self, "response_queues") or not self.response_queues:
-            raise RuntimeError("Response queues have not been initialized.")
+            raise RuntimeError("Response queues have not been initialized, please ensure that LitServer.launch_inference_worker was called!")
 
         response_queue = self.response_queues[app.response_queue_id]
         response_executor = ThreadPoolExecutor(max_workers=len(self.devices * self.workers_per_device))

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -548,6 +548,9 @@ class LitServer:
     async def lifespan(self, app: FastAPI):
         loop = asyncio.get_running_loop()
 
+        if not hasattr(self, "response_queues") or not self.response_queues:
+            raise RuntimeError("Response queues have not been initialized.")
+
         response_queue = self.response_queues[app.response_queue_id]
         response_executor = ThreadPoolExecutor(max_workers=len(self.devices * self.workers_per_device))
         future = response_queue_to_buffer(response_queue, self.response_buffer, self.stream, response_executor)

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -548,7 +548,9 @@ class LitServer:
 
         if not hasattr(self, "response_queues") or not self.response_queues:
             raise RuntimeError(
-                "Response queues have not been initialized, please ensure that LitServer.launch_inference_worker was called!"
+                "Response queues have not been initialized. "
+                "Please make sure to call the 'launch_inference_worker' method of "
+                "the LitServer class to initialize the response queues."
             )
 
         response_queue = self.response_queues[app.response_queue_id]


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Adds a meaningful error message if the response queue has not been initialized. Otherwise, you see an 

```
AttributeError: 'LitServer' object has no attribute 'response_queue
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
