### PR TITLE
fix flaky batch timeout test

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -121,48 +121,59 @@ class SlowBatchAPI(SlowLitAPI):
 
 @pytest.mark.asyncio()
 async def test_timeout():
-    api = SlowLitAPI()  # takes 2 second for each prediction
-    server = LitServer(api, accelerator="cpu", devices=1, timeout=1.5)
+    api = SlowLitAPI()  # takes 2 seconds for each prediction
+    server = LitServer(api, accelerator="cpu", devices=1, timeout=2)
 
     with wrap_litserve_start(server) as server:
-        # case 1: first request completes, second request times out in queue
+        # Poll until the server is ready
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
-            await asyncio.sleep(2)  # Give time to start inference workers
+            for _ in range(10):  # retry 10 times
+                try:
+                    await ac.get("/health")
+                    break
+                except Exception:
+                    await asyncio.sleep(0.2)
+
             response1 = asyncio.create_task(ac.post("/predict", json={"input": 4.0}))
             await asyncio.sleep(0.0001)
             response2 = asyncio.create_task(ac.post("/predict", json={"input": 5.0}))
-            await asyncio.wait([response1, response2])
-            assert (
-                response1.result().status_code == 200
-            ), "First request should complete since it's popped from the request queue."
-            assert (
-                response2.result().status_code == 504
-            ), "Server takes longer than specified timeout and request should timeout"
+            responses = await asyncio.gather(response1, response2, return_exceptions=True)
+            assert responses[0].status_code == 200, (
+                "First request should complete since it's popped from" " the request queue."
+            )
+            assert responses[1].status_code == 504, (
+                "Server takes longer than specified timeout and " "request should timeout"
+            )
 
-    # Case 2: first 2 requests finish as a batch and third request times out in queue
     server = LitServer(
         SlowBatchAPI(),
         accelerator="cpu",
-        timeout=1.5,
+        timeout=2,
         max_batch_size=2,
         batch_timeout=0.01,
     )
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
-            await asyncio.sleep(2)  # Give time to start inference workers
+            # wait for the server to be ready
+            for _ in range(10):
+                try:
+                    await ac.get("/health")
+                    break
+                except Exception:
+                    await asyncio.sleep(0.2)
+
             response1 = asyncio.create_task(ac.post("/predict", json={"input": 4.0}))
             response2 = asyncio.create_task(ac.post("/predict", json={"input": 5.0}))
             await asyncio.sleep(0.0001)
             response3 = asyncio.create_task(ac.post("/predict", json={"input": 6.0}))
-            await asyncio.wait([response1, response2, response3])
-            assert (
-                response1.result().status_code == 200
-            ), "Batch: First request should complete since it's popped from the request queue."
-            assert (
-                response2.result().status_code == 200
-            ), "Batch: Second request should complete since it's popped from the request queue."
-
-            assert response3.result().status_code == 504, "Batch: Third request was delayed and should fail"
+            responses = await asyncio.gather(response1, response2, response3, return_exceptions=True)
+            assert responses[0].status_code == 200, (
+                "Batch: First request should complete since it's popped from " "the request queue."
+            )
+            assert responses[1].status_code == 200, (
+                "Batch: Second request should complete since it's popped from " "the request queue."
+            )
+            assert responses[2].status_code == 504, "Batch: Third request was delayed and should fail"
 
     server1 = LitServer(SlowLitAPI(), accelerator="cpu", devices=1, timeout=-1)
     server2 = LitServer(SlowLitAPI(), accelerator="cpu", devices=1, timeout=False)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -138,12 +138,12 @@ async def test_timeout():
             await asyncio.sleep(0.0001)
             response2 = asyncio.create_task(ac.post("/predict", json={"input": 5.0}))
             responses = await asyncio.gather(response1, response2, return_exceptions=True)
-            assert responses[0].status_code == 200, (
-                "First request should complete since it's popped from" " the request queue."
-            )
-            assert responses[1].status_code == 504, (
-                "Server takes longer than specified timeout and " "request should timeout"
-            )
+            assert (
+                responses[0].status_code == 200
+            ), "First request should complete since it's popped from the request queue."
+            assert (
+                responses[1].status_code == 504
+            ), "Server takes longer than specified timeout and request should timeout"
 
 
 @pytest.mark.asyncio()
@@ -171,12 +171,12 @@ async def test_batch_timeout():
             await asyncio.sleep(0.0001)
             response3 = asyncio.create_task(ac.post("/predict", json={"input": 6.0}))
             responses = await asyncio.gather(response1, response2, response3, return_exceptions=True)
-            assert responses[0].status_code == 200, (
-                "Batch: First request should complete since it's popped from " "the request queue."
-            )
-            assert responses[1].status_code == 200, (
-                "Batch: Second request should complete since it's popped from " "the request queue."
-            )
+            assert (
+                responses[0].status_code == 200
+            ), "Batch: First request should complete since it's popped from the request queue."
+            assert (
+                responses[1].status_code == 200
+            ), "Batch: Second request should complete since it's popped from the request queue."
             assert responses[2].status_code == 504, "Batch: Third request was delayed and should fail"
 
     server1 = LitServer(SlowLitAPI(), accelerator="cpu", devices=1, timeout=-1)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue).

Fixes flaky batch timeout test. Before hitting the `/predict` endpoint it first checks if the server has actually started. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
