### PR TITLE
moved wrap_litserve_start to utils

### DIFF
--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -17,11 +17,16 @@ import pickle
 import uuid
 from typing import Coroutine, Optional
 from contextlib import contextmanager
-from litserve.server import LitServer
+from typing import TYPE_CHECKING  
+
+
 
 from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
+
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+if TYPE_CHECKING:  
+    from litserve.server import LitServer  
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +77,7 @@ async def azip(*async_iterables):
 
 
 @contextmanager
-def wrap_litserve_start(server: LitServer):
+def wrap_litserve_start(server: "LitServer"):
     server.app.response_queue_id = 0
     if server.lit_spec:
         server.lit_spec.response_queue_id = 0

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -17,16 +17,16 @@ import pickle
 import uuid
 from typing import Coroutine, Optional
 from contextlib import contextmanager
-from typing import TYPE_CHECKING  
-
+from typing import TYPE_CHECKING
 
 
 from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
-if TYPE_CHECKING:  
-    from litserve.server import LitServer  
+
+if TYPE_CHECKING:
+    from litserve.server import LitServer
 
 logger = logging.getLogger(__name__)
 

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -70,6 +70,7 @@ async def azip(*async_iterables):
             break
         yield tuple(results)
 
+
 @contextmanager
 def wrap_litserve_start(server: LitServer):
     server.app.response_queue_id = 0
@@ -80,6 +81,7 @@ def wrap_litserve_start(server: LitServer):
     for p in processes:
         p.terminate()
     manager.shutdown()
+
 
 class MaxSizeMiddleware(BaseHTTPMiddleware):
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager
 import time
 import psutil
 from typing import Generator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from typing import Generator
 from litserve.server import LitServer
 import pytest
 from litserve.api import LitAPI
+from litserve.utils import wrap_litserve_start
 from fastapi import Request, Response
 from fastapi.testclient import TestClient
 
@@ -96,18 +97,6 @@ def simple_stream_api():
 @pytest.fixture()
 def simple_batched_stream_api():
     return SimpleBatchedStreamAPI()
-
-
-@contextmanager
-def wrap_litserve_start(server: LitServer):
-    server.app.response_queue_id = 0
-    if server.lit_spec:
-        server.lit_spec.response_queue_id = 0
-    manager, processes = server.launch_inference_worker(num_uvicorn_servers=1)
-    yield server
-    for p in processes:
-        p.terminate()
-    manager.shutdown()
 
 
 @pytest.fixture()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -18,7 +18,7 @@ from fastapi.testclient import TestClient
 
 from litserve import LitAPI, LitServer
 import litserve.server
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 
 
 class SimpleAuthedLitAPI(LitAPI):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -25,7 +25,7 @@ from httpx import AsyncClient
 
 from litserve import LitAPI, LitServer
 from litserve.server import run_batched_loop
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 
 
 class Linear(nn.Module):

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -14,7 +14,7 @@
 
 from fastapi import Request, Response
 from fastapi.testclient import TestClient
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 from litserve import LitAPI, LitServer
 
 # trivially compressible content

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,7 @@
 import pytest
 from asgi_lifespan import LifespanManager
 from httpx import AsyncClient
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 import litserve as ls
 
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -14,7 +14,7 @@
 
 from fastapi import Request, Response
 from fastapi.testclient import TestClient
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 
 from litserve import LitAPI, LitServer
 

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -23,7 +23,7 @@ import torch
 import torch.nn as nn
 from queue import Queue
 from httpx import AsyncClient
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 
 from unittest.mock import patch, MagicMock
 import pytest

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -14,7 +14,7 @@
 from fastapi.testclient import TestClient
 
 from pydantic import BaseModel
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 from litserve import LitAPI, LitServer
 
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -25,7 +25,7 @@ from httpx import AsyncClient
 
 from litserve import LitAPI, LitServer
 
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 
 
 class SimpleLitAPI(LitAPI):

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -24,7 +24,7 @@ from litserve.examples.openai_spec_example import (
     OpenAIBatchingWithUsage,
     OpenAIWithUsageEncodeResponse,
 )
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 from litserve.specs.openai import OpenAISpec, ChatMessage
 import litserve as ls
 

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -15,7 +15,7 @@ from fastapi import Request, Response
 from fastapi.testclient import TestClient
 
 from litserve import LitAPI, LitServer
-from tests.conftest import wrap_litserve_start
+from litserve.utils import wrap_litserve_start
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
#195 move wrap_litserve_start to utils

i moved the function inside src > litserve > utils and then reimported them inside all the tests files.