### PR TITLE
Feat: Evict requests if the client has disconnected

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Use LitServe to deploy any type of model or AI service (embeddings, LLMs, vision
 <strong>Audio:</strong>      <a href="https://lightning.ai/lightning-ai/studios/deploy-open-ai-s-whisper-model">Whisper</a>, <a href="https://lightning.ai/lightning-ai/studios/deploy-an-music-generation-api-with-meta-s-audio-craft">AudioCraft</a>, <a href="https://lightning.ai/lightning-ai/studios/deploy-an-audio-generation-api">StableAudio</a>
 <strong>Vision:</strong>     <a href="https://lightning.ai/lightning-ai/studios/deploy-a-private-api-for-stable-diffusion-2">Stable diffusion 2</a>
 <strong>Speech:</strong>     <a href="https://lightning.ai/lightning-ai/studios/deploy-a-voice-clone-api-coqui-xtts-v2-model">Text-speech (XTTS V2)</a>
+<strong>Classic ML:</strong> <a href="https://lightning.ai/lightning-ai/studios/deploy-random-forest-with-litserve">Random forest</a>, <a href="https://lightning.ai/lightning-ai/studios/deploy-xgboost-with-litserve">XGBoost</a>
 </pre>
     </td>
     <td style="vertical-align: top;">

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -665,7 +665,7 @@ class LitServer:
             response, status = None, None
             try:
                 while not task.done():
-                    if await request.is_disconnected():
+                    if hasattr(request, "is_disconnected") and await request.is_disconnected():
                         task.cancel()
                         break
                 response, status = await task

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -580,6 +580,7 @@ class LitServer:
         return [f"{accelerator}:{device}"]
 
     async def data_streamer(self, q: deque, data_available: asyncio.Event, send_status: bool = False):
+        uid = None
         while True:
             try:
                 await data_available.wait()
@@ -602,8 +603,9 @@ class LitServer:
                         yield data
                 data_available.clear()
             except asyncio.CancelledError:
-                self.request_evicted_status[uid] = True
-                logger.error("Request evicted for the uid=%s", uid)
+                if uid is not None:
+                    self.request_evicted_status[uid] = True
+                    logger.error("Request evicted for the uid=%s", uid)
                 break
             except Exception as e:
                 # Handle other exceptions that might occur

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -665,7 +665,7 @@ class LitServer:
             response, status = None, None
             try:
                 while not task.done():
-                    await asyncio.sleep(0.5)
+                    await asyncio.sleep(0.1)
                     if await request.is_disconnected():
                         task.cancel()
                         break

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -665,7 +665,7 @@ class LitServer:
             response, status = None, None
             try:
                 while not task.done():
-                    await asyncio.sleep(0.1)
+                    await asyncio.sleep(0.5)
                     if await request.is_disconnected():
                         task.cancel()
                         break

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -665,6 +665,7 @@ class LitServer:
             response, status = None, None
             try:
                 while not task.done():
+                    asyncio.sleep(0.01)
                     if hasattr(request, "is_disconnected") and await request.is_disconnected():
                         task.cancel()
                         break

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -263,6 +263,7 @@ def run_streaming_loop(
             )
             for y_enc in y_enc_gen:
                 if request_evicted_status.get(uid):
+                    request_evicted_status.pop(uid)
                     break
                 y_enc = lit_api.format_encoded_response(y_enc)
                 response_queues[response_queue_id].put((uid, (y_enc, LitAPIStatus.OK)))

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -665,7 +665,6 @@ class LitServer:
             response, status = None, None
             try:
                 while not task.done():
-                    await asyncio.sleep(0.1)
                     if await request.is_disconnected():
                         task.cancel()
                         break

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -217,7 +217,13 @@ def run_batched_loop(
                 response_queues[response_queue_id].put((uid, (err_pkl, LitAPIStatus.ERROR)))
 
 
-def run_streaming_loop(lit_api: LitAPI, lit_spec: LitSpec, request_queue: Queue, response_queues: List[Queue]):
+def run_streaming_loop(
+    lit_api: LitAPI,
+    lit_spec: LitSpec,
+    request_queue: Queue,
+    response_queues: List[Queue],
+    request_evicted_status: Dict[str, bool],
+):
     while True:
         try:
             response_queue_id, uid, timestamp, x_enc = request_queue.get(timeout=1.0)
@@ -256,6 +262,8 @@ def run_streaming_loop(lit_api: LitAPI, lit_spec: LitSpec, request_queue: Queue,
                 y_gen,
             )
             for y_enc in y_enc_gen:
+                if request_evicted_status.get(uid):
+                    break
                 y_enc = lit_api.format_encoded_response(y_enc)
                 response_queues[response_queue_id].put((uid, (y_enc, LitAPIStatus.OK)))
             response_queues[response_queue_id].put((uid, ("", LitAPIStatus.FINISH_STREAMING)))
@@ -338,6 +346,7 @@ def inference_worker(
     worker_id: int,
     request_queue: Queue,
     response_queues: List[Queue],
+    request_evicted_status: Dict[str, bool],
     max_batch_size: int,
     batch_timeout: float,
     stream: bool,
@@ -357,7 +366,7 @@ def inference_worker(
         if max_batch_size > 1:
             run_batched_streaming_loop(lit_api, lit_spec, request_queue, response_queues, max_batch_size, batch_timeout)
         else:
-            run_streaming_loop(lit_api, lit_spec, request_queue, response_queues)
+            run_streaming_loop(lit_api, lit_spec, request_queue, response_queues, request_evicted_status)
         return
 
     if max_batch_size > 1:
@@ -397,7 +406,7 @@ async def response_queue_to_buffer(
                 await asyncio.sleep(0.0001)
                 continue
             q, event = buffer[uid]
-            q.append(payload)
+            q.append((uid, payload))
             event.set()
 
     else:
@@ -499,6 +508,7 @@ class LitServer:
         manager = mp.Manager()
         self.workers_setup_status = manager.dict()
         self.request_queue = manager.Queue()
+        self.request_evicted_status = manager.dict()
 
         self.response_queues = []
         for _ in range(num_uvicorn_servers):
@@ -532,6 +542,7 @@ class LitServer:
                     worker_id,
                     self.request_queue,
                     self.response_queues,
+                    self.request_evicted_status,
                     self.max_batch_size,
                     self.batch_timeout,
                     self.stream,
@@ -570,25 +581,34 @@ class LitServer:
 
     async def data_streamer(self, q: deque, data_available: asyncio.Event, send_status: bool = False):
         while True:
-            await data_available.wait()
-            while len(q) > 0:
-                data, status = q.popleft()
-                if status == LitAPIStatus.FINISH_STREAMING:
-                    return
+            try:
+                await data_available.wait()
+                while len(q) > 0:
+                    uid, (data, status) = q.popleft()
+                    if status == LitAPIStatus.FINISH_STREAMING:
+                        return
 
-                if status == LitAPIStatus.ERROR:
-                    logger.error(
-                        "Error occurred while streaming outputs from the inference worker. "
-                        "Please check the above traceback."
-                    )
+                    if status == LitAPIStatus.ERROR:
+                        logger.error(
+                            "Error occurred while streaming outputs from the inference worker. "
+                            "Please check the above traceback."
+                        )
+                        if send_status:
+                            yield data, status
+                        return
                     if send_status:
                         yield data, status
-                    return
-                if send_status:
-                    yield data, status
-                else:
-                    yield data
-            data_available.clear()
+                    else:
+                        yield data
+                data_available.clear()
+            except asyncio.CancelledError:
+                self.request_evicted_status[uid] = True
+                logger.error("Request evicted for the uid=%s", uid)
+                break
+            except Exception as e:
+                # Handle other exceptions that might occur
+                logger.error(f"Exception occurred during streaming: {e}")
+                break
 
     def setup_server(self):
         workers_ready = False
@@ -635,6 +655,7 @@ class LitServer:
 
         async def stream_predict(request: self.request_type, background_tasks: BackgroundTasks) -> self.response_type:
             response_queue_id = self.app.response_queue_id
+            print("response_queue_id=", response_queue_id)
             uid = uuid.uuid4()
             event = asyncio.Event()
             q = deque()

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -658,7 +658,6 @@ class LitServer:
 
         async def stream_predict(request: self.request_type, background_tasks: BackgroundTasks) -> self.response_type:
             response_queue_id = self.app.response_queue_id
-            print("response_queue_id=", response_queue_id)
             uid = uuid.uuid4()
             event = asyncio.Event()
             q = deque()

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -665,7 +665,7 @@ class LitServer:
             response, status = None, None
             try:
                 while not task.done():
-                    asyncio.sleep(0.2)
+                    await asyncio.sleep(1)
                     if hasattr(request, "is_disconnected") and await request.is_disconnected():
                         task.cancel()
                         break

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -665,7 +665,7 @@ class LitServer:
             response, status = None, None
             try:
                 while not task.done():
-                    asyncio.sleep(0.01)
+                    asyncio.sleep(0.2)
                     if hasattr(request, "is_disconnected") and await request.is_disconnected():
                         task.cancel()
                         break

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,12 @@ class SimpleLitAPI(LitAPI):
         return {"output": output}
 
 
+class SimpleDelayedLitAPI(SimpleLitAPI):
+    def predict(self, x):
+        time.sleep(0.5)
+        return self.model(x)
+
+
 class SimpleStreamAPI(LitAPI):
     def setup(self, device) -> None:
         self.sentence = "LitServe is streaming output"
@@ -50,6 +56,14 @@ class SimpleStreamAPI(LitAPI):
 
     def encode_response(self, output: Generator) -> Generator:
         delay = 0.01  # delay for testing timeouts
+        for out in output:
+            time.sleep(delay)
+            yield out.lower()
+
+
+class SimpleDelayedStreamAPI(SimpleStreamAPI):
+    def encode_response(self, output: Generator) -> Generator:
+        delay = 0.2
         for out in output:
             time.sleep(delay)
             yield out.lower()
@@ -89,8 +103,18 @@ def simple_litapi():
 
 
 @pytest.fixture()
+def simple_delayed_litapi():
+    return SimpleDelayedLitAPI()
+
+
+@pytest.fixture()
 def simple_stream_api():
     return SimpleStreamAPI()
+
+
+@pytest.fixture()
+def simple_delayed_stream_api():
+    return SimpleDelayedStreamAPI()
 
 
 @pytest.fixture()

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -135,8 +135,9 @@ async def test_stream_client_disconnection(simple_stream_api, caplog):
 
             # Allow some time for the server to handle the cancellation
             await asyncio.sleep(0.5)
-
             assert "Request evicted for the uid=" in caplog.text, "Server should log client disconnection"
+
+            # TODO: also chec if the task actually stopped in the server
 
 
 @pytest.mark.asyncio

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -137,7 +137,7 @@ async def test_stream_client_disconnection(simple_stream_api, caplog):
             await asyncio.sleep(0.5)
             assert "Request evicted for the uid=" in caplog.text, "Server should log client disconnection"
 
-            # TODO: also chec if the task actually stopped in the server
+            # TODO: also check if the task actually stopped in the server
 
 
 @pytest.mark.asyncio()

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -74,7 +74,7 @@ def test_inference_worker(mock_single_loop, mock_batched_loop):
     mock_single_loop.assert_called_once()
 
 
-@pytest.fixture
+@pytest.fixture()
 def loop_args():
     requests_queue = Queue()
     requests_queue.put((0, "uuid-123", time.monotonic(), 1))  # response_queue_id, uid, timestamp, x_enc
@@ -100,7 +100,7 @@ def test_single_loop(loop_args):
         run_single_loop(lit_api_mock, None, requests_queue, response_queues)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_stream(simple_stream_api):
     server = LitServer(simple_stream_api, stream=True, timeout=10)
     expected_output1 = "prompt=Hello generated_output=LitServe is streaming output".lower().replace(" ", "")
@@ -121,7 +121,7 @@ async def test_stream(simple_stream_api):
             ), "Server returns input prompt and generated output which didn't match."
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_stream_client_disconnection(simple_stream_api, caplog):
     server = LitServer(simple_stream_api, stream=True, timeout=10)
 
@@ -140,7 +140,7 @@ async def test_stream_client_disconnection(simple_stream_api, caplog):
             # TODO: also chec if the task actually stopped in the server
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_batched_stream_server(simple_batched_stream_api):
     server = LitServer(simple_batched_stream_api, stream=True, max_batch_size=4, batch_timeout=2, timeout=30)
     expected_output1 = "Hello LitServe is streaming output".lower().replace(" ", "")
@@ -419,7 +419,7 @@ class PredictErrorAPI(ls.examples.SimpleLitAPI):
         return {"output": input}
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @patch("litserve.server.load_and_raise")
 async def test_inject_context(mocked_load_and_raise):
     def dummy_load_and_raise(resp):

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -13,33 +13,33 @@
 # limitations under the License.
 import asyncio
 import inspect
+import logging
 import pickle
 import re
-import logging
-from asgi_lifespan import LifespanManager
-from litserve import LitAPI
-from fastapi import Request, Response, HTTPException
 import time
+from queue import Queue
+from unittest.mock import MagicMock, patch
+
+import pytest
 import torch
 import torch.nn as nn
-from queue import Queue
+from asgi_lifespan import LifespanManager
+from fastapi import HTTPException, Request, Response
+from fastapi.testclient import TestClient
 from httpx import AsyncClient
-from litserve.utils import wrap_litserve_start
 
-from unittest.mock import patch, MagicMock
-import pytest
-
+import litserve as ls
+from litserve import LitAPI
 from litserve.connector import _Connector
 from litserve.server import (
+    LitAPIStatus,
+    LitServer,
     inference_worker,
+    run_batched_streaming_loop,
     run_single_loop,
     run_streaming_loop,
-    LitAPIStatus,
-    run_batched_streaming_loop,
 )
-from litserve.server import LitServer
-import litserve as ls
-from fastapi.testclient import TestClient
+from litserve.utils import wrap_litserve_start
 
 
 def test_index(sync_testclient):

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -128,13 +128,13 @@ async def test_stream_client_disconnection(simple_stream_api, caplog):
     with wrap_litserve_start(server) as server, caplog.at_level(logging.DEBUG):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             task = asyncio.create_task(ac.post("/predict", json={"prompt": "Hey, How are you doing?" * 2}, timeout=10))
-            await asyncio.sleep(0.4)
+            await asyncio.sleep(0.5)
 
             # Simulate client disconnection by canceling the request
             task.cancel()
 
             # Allow some time for the server to handle the cancellation
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(1)
             assert "Request evicted for the uid=" in caplog.text, "Server should log client disconnection"
 
             # TODO: also check if the task actually stopped in the server

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -127,7 +127,7 @@ async def test_stream_client_disconnection(simple_stream_api, caplog):
 
     with wrap_litserve_start(server) as server, caplog.at_level(logging.DEBUG):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
-            task = asyncio.create_task(ac.post("/predict", json={"prompt": "Hey, How are you doing?" * 10}, timeout=10))
+            task = asyncio.create_task(ac.post("/predict", json={"prompt": "Hey, How are you doing?" * 20}, timeout=10))
             await asyncio.sleep(1)
 
             # Simulate client disconnection by canceling the request

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -74,7 +74,7 @@ def test_inference_worker(mock_single_loop, mock_batched_loop):
     mock_single_loop.assert_called_once()
 
 
-@pytest.fixture()
+@pytest.fixture
 def loop_args():
     requests_queue = Queue()
     requests_queue.put((0, "uuid-123", time.monotonic(), 1))  # response_queue_id, uid, timestamp, x_enc
@@ -100,7 +100,7 @@ def test_single_loop(loop_args):
         run_single_loop(lit_api_mock, None, requests_queue, response_queues)
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_stream(simple_stream_api):
     server = LitServer(simple_stream_api, stream=True, timeout=10)
     expected_output1 = "prompt=Hello generated_output=LitServe is streaming output".lower().replace(" ", "")
@@ -139,7 +139,7 @@ async def test_stream_client_disconnection(simple_stream_api, caplog):
             assert "Request evicted for the uid=" in caplog.text, "Server should log client disconnection"
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_batched_stream_server(simple_batched_stream_api):
     server = LitServer(simple_batched_stream_api, stream=True, max_batch_size=4, batch_timeout=2, timeout=30)
     expected_output1 = "Hello LitServe is streaming output".lower().replace(" ", "")
@@ -418,7 +418,7 @@ class PredictErrorAPI(ls.examples.SimpleLitAPI):
         return {"output": input}
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @patch("litserve.server.load_and_raise")
 async def test_inject_context(mocked_load_and_raise):
     def dummy_load_and_raise(resp):

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -127,8 +127,8 @@ async def test_stream_client_disconnection(simple_stream_api, caplog):
 
     with wrap_litserve_start(server) as server, caplog.at_level(logging.DEBUG):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
-            task = asyncio.create_task(ac.post("/predict", json={"prompt": "Hey, How are you doing?" * 2}, timeout=10))
-            await asyncio.sleep(0.5)
+            task = asyncio.create_task(ac.post("/predict", json={"prompt": "Hey, How are you doing?" * 10}, timeout=10))
+            await asyncio.sleep(1)
 
             # Simulate client disconnection by canceling the request
             task.cancel()

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -66,10 +66,10 @@ def test_device_identifiers(lifespan_mock, simple_litapi):
 @patch("litserve.server.run_batched_loop")
 @patch("litserve.server.run_single_loop")
 def test_inference_worker(mock_single_loop, mock_batched_loop):
-    inference_worker(*[MagicMock()] * 6, max_batch_size=2, batch_timeout=0, stream=False)
+    inference_worker(*[MagicMock()] * 7, max_batch_size=2, batch_timeout=0, stream=False)
     mock_batched_loop.assert_called_once()
 
-    inference_worker(*[MagicMock()] * 6, max_batch_size=1, batch_timeout=0, stream=False)
+    inference_worker(*[MagicMock()] * 7, max_batch_size=1, batch_timeout=0, stream=False)
     mock_single_loop.assert_called_once()
 
 
@@ -175,11 +175,12 @@ def test_streaming_loop():
     fake_stream_api.format_encoded_response = MagicMock(side_effect=lambda x: x)
 
     requests_queue = Queue()
+    request_evicted_status = {}
     requests_queue.put((0, "UUID-1234", time.monotonic(), {"prompt": "Hello"}))
     response_queues = [FakeStreamResponseQueue(num_streamed_outputs)]
 
     with pytest.raises(StopIteration, match="exit loop"):
-        run_streaming_loop(fake_stream_api, fake_stream_api, requests_queue, response_queues)
+        run_streaming_loop(fake_stream_api, fake_stream_api, requests_queue, response_queues, request_evicted_status)
 
     fake_stream_api.predict.assert_called_once_with("Hello")
     fake_stream_api.encode_response.assert_called_once()

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -147,7 +147,7 @@ async def test_stream_client_disconnection(simple_delayed_stream_api, caplog):
     with wrap_litserve_start(server) as server, caplog.at_level(logging.DEBUG):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             task = asyncio.create_task(ac.post("/predict", json={"prompt": "Hey, How are you doing?" * 5}, timeout=10))
-            await asyncio.sleep(1)
+            await asyncio.sleep(2)
             task.cancel()  # simulate client disconnection
             await asyncio.sleep(1)  # wait for the task to stop
             assert "Request evicted for the uid=" in caplog.text


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?
Fixes #165.

This PR addresses the situation when client requests are disconnected before completion. It tracks canceled requests and stops ongoing/running tasks, thereby saving computational resources.

#### Approach
The solution involves checking whether the client has disconnected during both predict and stream predict operations. 
If a disconnection is detected, the system adds the corresponding request ID to the `request_evicted_status` multiprocessing dictionary. 

This dictionary is then monitored by the running loops (both streaming and non-streaming) in worker process. If the worker loop detects that the current running request ID is present in the `request_evicted_status`, it immediately terminates the ongoing task associated with that request.

#### Potential Impacts 
This approach might impact performance due to the additional overhead of monitoring and terminating tasks, which could introduce minor delays in processing. [Benchmarking](https://lightning.ai/lightning-ai/studios/litserve-performance-tuning-and-benchmarking)
![image](https://github.com/user-attachments/assets/f6eb868b-0a08-4843-b969-53bb12b38b2d)

---
#### TODO
- [x] Handle client request disconnection in streaming mode
- [ ]  Handle client request disconnection in non-streaming mode (In progress)
     - Investigating methods to terminate tasks from the worker process (`run_single_loop`).
- [ ] Add/Improve tests (In progress)
     - Exploring ways to verify task termination from the worker process
- [ ] Handle client disconnection for batched requests
     
> Any help or guidance on this PR would be greatly appreciated 🙏. Thank you! 😊

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
