### PR TITLE
Fix: Removes the redundant word "the" from the example snippet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ class SimpleLitAPI(ls.LitAPI):
         return request["input"] 
 
     def predict(self, x):
-        # Run inference on the the AI system, return the output.
+        # Run inference on the AI system, return the output.
         squared = self.model1(x)
         cubed = self.model2(x)
         output = squared + cubed


### PR DESCRIPTION
## What does this PR do?
This PR corrects a typo in the code comments by removing the redundant word "the" from the example snippet.

**Screenshot:**
<img width="802" alt="image" src="https://github.com/user-attachments/assets/26c33b9b-e637-4c9c-9eec-1b80e3f08678">

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
