### PR TITLE
[Chore] rename setup_server to register_endpoints

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -197,7 +197,7 @@ class LitServer:
             self.devices = [self.device_identifiers(accelerator, device) for device in device_list]
 
         self.inference_workers = self.devices * self.workers_per_device
-        self.setup_server()
+        self.register_endpoints()
 
     def launch_inference_worker(self, num_uvicorn_servers: int):
         manager = mp.Manager()
@@ -288,7 +288,8 @@ class LitServer:
                     yield data
             data_available.clear()
 
-    def setup_server(self):
+    def register_endpoints(self):
+        """Register endpoint routes for the FastAPI app and setup middlewares."""
         workers_ready = False
 
         @self.app.get("/", dependencies=[Depends(self.setup_auth())])


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## ⚠️ How does this PR impact the user? ⚠️

No impact. It's a code readability update. 


---- 


## What does this PR do?

Rename `LitServer.setup_servers` to `register_endpoints` which explains the work of this method. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
