### PR TITLE
fix custom HTTPException with argument names

### DIFF
--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -26,7 +26,7 @@ from starlette.formparsers import MultiPartParser
 from litserve import LitAPI
 from litserve.callbacks import CallbackRunner, EventTypes
 from litserve.specs.base import LitSpec
-from litserve.utils import LitAPIStatus, dump_exceptions
+from litserve.utils import LitAPIStatus, dump_exception
 
 mp.allow_connection_pickling()
 
@@ -153,7 +153,7 @@ def run_single_loop(
                 "Please check the error trace for more details.",
                 uid,
             )
-            err_pkl = dump_exceptions(e)
+            err_pkl = dump_exception(e)
             response_queues[response_queue_id].put((uid, (err_pkl, LitAPIStatus.ERROR)))
 
 
@@ -226,7 +226,7 @@ def run_batched_loop(
                 "LitAPI ran into an error while processing the batched request.\n"
                 "Please check the error trace for more details."
             )
-            err_pkl = dump_exceptions(e)
+            err_pkl = dump_exception(e)
             for response_queue_id, uid in zip(response_queue_ids, uids):
                 response_queues[response_queue_id].put((uid, (err_pkl, LitAPIStatus.ERROR)))
 
@@ -289,7 +289,7 @@ def run_streaming_loop(
                 "Please check the error trace for more details.",
                 uid,
             )
-            response_queues[response_queue_id].put((uid, (dump_exceptions(e), LitAPIStatus.ERROR)))
+            response_queues[response_queue_id].put((uid, (dump_exception(e), LitAPIStatus.ERROR)))
 
 
 def run_batched_streaming_loop(
@@ -362,7 +362,7 @@ def run_batched_streaming_loop(
                 "LitAPI ran into an error while processing the streaming batched request.\n"
                 "Please check the error trace for more details."
             )
-            err_pkl = dump_exceptions(e)
+            err_pkl = dump_exception(e)
             response_queues[response_queue_id].put((uid, (err_pkl, LitAPIStatus.ERROR)))
 
 

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -46,7 +46,7 @@ class PickleableHTTPException(HTTPException):
         return (HTTPException, (self.status_code, self.detail))
 
 
-def dump_exceptions(exception):
+def dump_exception(exception):
     if isinstance(exception, HTTPException):
         exception = PickleableHTTPException.from_exception(exception)
     return pickle.dumps(exception)

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -35,6 +35,23 @@ class LitAPIStatus:
     FINISH_STREAMING = "FINISH_STREAMING"
 
 
+class PickleableHTTPException(HTTPException):
+    @staticmethod
+    def from_exception(exc: HTTPException):
+        status_code = exc.status_code
+        detail = exc.detail
+        return PickleableHTTPException(status_code, detail)
+
+    def __reduce__(self):
+        return (HTTPException, (self.status_code, self.detail))
+
+
+def dump_exceptions(exception):
+    if isinstance(exception, HTTPException):
+        exception = PickleableHTTPException.from_exception(exception)
+    return pickle.dumps(exception)
+
+
 def load_and_raise(response):
     try:
         exception = pickle.loads(response) if isinstance(response, bytes) else response

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -368,11 +368,22 @@ class TestHTTPExceptionAPI(ls.test_examples.SimpleLitAPI):
         raise HTTPException(501, "decode request is bad")
 
 
+class TestHTTPExceptionAPI2(ls.test_examples.SimpleLitAPI):
+    def decode_request(self, request):
+        raise HTTPException(status_code=400, detail="decode request is bad")
+
+
 def test_http_exception():
     server = LitServer(TestHTTPExceptionAPI())
     with wrap_litserve_start(server) as server, TestClient(server.app) as client:
         response = client.post("/predict", json={"input": 4.0})
         assert response.status_code == 501, "Server raises 501 error"
+        assert response.text == '{"detail":"decode request is bad"}', "decode request is bad"
+
+    server = LitServer(TestHTTPExceptionAPI2())
+    with wrap_litserve_start(server) as server, TestClient(server.app) as client:
+        response = client.post("/predict", json={"input": 4.0})
+        assert response.status_code == 400, "Server raises 400 error"
         assert response.text == '{"detail":"decode request is bad"}', "decode request is bad"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import pickle
+
+from fastapi import HTTPException
+
+from litserve.utils import dump_exception
+
+
+def test_dump_exception():
+    e1 = dump_exception(HTTPException(status_code=404, detail="Not Found"))
+    assert isinstance(e1, bytes)
+
+    exc = HTTPException(400, "Custom Lit error")
+    isinstance(pickle.loads(dump_exception(exc)), HTTPException)
+    assert pickle.loads(dump_exception(exc)).detail == "Custom Lit error"
+    assert pickle.loads(dump_exception(exc)).status_code == 400


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->


## What does this PR do?
Fixes #301 : custom Exception `HTTPException(detail="...", status_code=400)` doesn't work. This PR fixes that. 

- `fastapi.HTTPException` is not pickleable, we add a `__reduce__` method and put the correct exception in the multiprocessing queue. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
