### PR TITLE
fix(Logger): handle unpickleable Logger

### DIFF
--- a/_requirements/test.txt
+++ b/_requirements/test.txt
@@ -13,3 +13,4 @@ transformers
 openai>=1.12.0
 pillow
 numpy <2.0
+prometheus-client>=0.21.0

--- a/_requirements/test.txt
+++ b/_requirements/test.txt
@@ -13,4 +13,3 @@ transformers
 openai>=1.12.0
 pillow
 numpy <2.0
-prometheus-client>=0.21.0

--- a/src/litserve/loggers.py
+++ b/src/litserve/loggers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import functools
 import multiprocessing as mp
+import pickle
 from abc import ABC, abstractmethod
 from typing import List, Optional, Union, TYPE_CHECKING
 
@@ -74,6 +75,14 @@ class Logger(ABC):
         raise NotImplementedError  # pragma: no cover
 
 
+class LoggerProxy:
+    def __init__(self, logger_class):
+        self.logger_class = logger_class
+
+    def create_logger(self):
+        return self.logger_class()
+
+
 class _LoggerConnector:
     """_LoggerConnector is responsible for connecting Logger instances with the LitServer and managing their lifecycle.
 
@@ -120,6 +129,29 @@ class _LoggerConnector:
                         f"with key {key} and value {value}: {e}"
                     )
 
+    @staticmethod
+    def _is_picklable(obj):
+        try:
+            pickle.dumps(obj)
+            return True
+        except (pickle.PicklingError, TypeError, AttributeError):
+            module_logger.warning(f"Logger {obj.__class__.__name__} is not pickleable and might not work properly.")
+            return False
+
+    @staticmethod
+    def _process_logger_queue(logger_proxies: List[LoggerProxy], queue):
+        loggers = [proxy.create_logger() for proxy in logger_proxies]
+        while True:
+            key, value = queue.get()
+            for logger in loggers:
+                try:
+                    logger.process(key, value)
+                except Exception as e:
+                    module_logger.error(
+                        f"{logger.__class__.__name__} ran into an error while processing log for entry "
+                        f"with key {key} and value {value}: {e}"
+                    )
+
     @functools.cache  # Run once per LitServer instance
     def run(self, lit_server: "LitServer"):
         queue = lit_server.logger_queue
@@ -131,12 +163,20 @@ class _LoggerConnector:
         if not self._loggers:
             return
 
-        module_logger.debug(f"Starting logger process with {len(self._loggers)} loggers")
+        # Create proxies for loggers
+        logger_proxies = []
+        for logger in self._loggers:
+            if self._is_picklable(logger):
+                logger_proxies.append(logger)
+            else:
+                logger_proxies.append(LoggerProxy(logger.__class__))
+
+        module_logger.debug(f"Starting logger process with {len(logger_proxies)} loggers")
         ctx = mp.get_context("spawn")
         process = ctx.Process(
             target=_LoggerConnector._process_logger_queue,
             args=(
-                self._loggers,
+                logger_proxies,
                 queue,
             ),
         )

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -155,7 +155,7 @@ class NonPickleableLogger(ls.Logger):
 
     def process(self, key, value):
         with self._lock:
-            print(f"Logged {key}: {value}")
+            print(f"Logged {key}: {value}", flush=True)
 
 
 class PickleTestAPI(ls.test_examples.SimpleLitAPI):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -19,7 +19,6 @@ from fastapi.testclient import TestClient
 
 from unittest.mock import MagicMock
 
-
 from litserve.loggers import Logger, _LoggerConnector
 
 import litserve as ls
@@ -173,4 +172,4 @@ def test_pickle_safety(capfd):
         assert response.json() == {"output": 16.0}
         time.sleep(0.5)
         captured = capfd.readouterr()
-        assert "Logged my-key: 4.0" in captured.out, captured.out
+        assert "Logged my-key: 4.0" in captured.out, f"Expected log not found in captured output {captured}"


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->


## What does this PR do?

Unpickleable Loggers throw error. This PR handles such objects by recreating the unpickleable objects.
https://github.com/Lightning-AI/LitServe/pull/284#issuecomment-2387499979


<details>
<summary><b>Output before and after this PR for a non-pickleable Logger:</b></summary>

```python
import threading
import litserve as ls

class NonPicklableLogger(ls.Logger):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self._lock = threading.Lock()  # Non-picklable resource

    def process(self, key, value):
        with self._lock:
            print(f"Logged {key}: {value}")

class TestAPI(ls.test_examples.SimpleLitAPI):
    def predict(self, x):
        self.log("predict", x)
        return super().predict(x)

if __name__ == '__main__':
    lit_api = TestAPI()
    server = ls.LitServer(lit_api, loggers=NonPicklableLogger())
    server.run()
```
</details>

### Before
```
  File "/Users/aniket/miniconda3/envs/am/lib/python3.10/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/Users/aniket/miniconda3/envs/am/lib/python3.10/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/Users/aniket/miniconda3/envs/am/lib/python3.10/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: cannot pickle '_thread.lock' object
```

### After
```
Setup complete for worker 0.
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
