### PR TITLE
lint: emergency `docformatter` bump

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,20 @@ repos:
         additional_dependencies: [tomli]
         #args: ["--write-changes"]
 
+  #- repo: https://github.com/pre-commit/mirrors-prettier
+  #  rev: v3.0.3
+  #  hooks:
+  #    - id: prettier
+  #      # https://prettier.io/docs/en/options.html#print-width
+  #      args: ["--print-width=120"]
+
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: ["--in-place"]
+
   - repo: https://github.com/asottile/yesqa
     rev: v1.5.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
   #      args: ["--print-width=120"]
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+    rev: 06907d0267368b49b9180eed423fae5697c1e909 # todo: fix for docformatter after last 1.7.5
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,20 +36,6 @@ repos:
         additional_dependencies: [tomli]
         #args: ["--write-changes"]
 
-  #- repo: https://github.com/pre-commit/mirrors-prettier
-  #  rev: v3.0.3
-  #  hooks:
-  #    - id: prettier
-  #      # https://prettier.io/docs/en/options.html#print-width
-  #      args: ["--print-width=120"]
-
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
-    hooks:
-      - id: docformatter
-        additional_dependencies: [tomli]
-        args: ["--in-place"]
-
   - repo: https://github.com/asottile/yesqa
     rev: v1.5.0
     hooks:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->


## What does this PR do?

Docformatter is breaking the CI. This PR removes it. 

<img width="1296" alt="image" src="https://github.com/user-attachments/assets/7fbc888a-3de2-422e-b14f-4b70b237e442">


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
