### PR TITLE
Avoiding counting active requests in /health and /metrics

### DIFF
--- a/src/litserve/middlewares.py
+++ b/src/litserve/middlewares.py
@@ -61,7 +61,7 @@ class RequestCountMiddleware(BaseHTTPMiddleware):
         self.active_counter = active_counter
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
+        if scope["type"] != "http" or (scope["type"] == "http" and scope["path"] in ["/health", "/metrics"]):
             await self.app(scope, receive, send)
             return
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
The current active requests flow keeps track of the number of active requests in the pipeline using a middleware implemented in #325. However, in a K8s deployment where we are continuously scraping for `/health` or `/metics` endpoints, we do not want to include those requests in the total number of requests aggregated. This PR helps avoid incrementing the request counter for this value without which the default value is always 1 whereas it should be 0.

-->


## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
