### PR TITLE
improve error handling from inference worker processes

### DIFF
--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -26,7 +26,7 @@ from starlette.formparsers import MultiPartParser
 from litserve import LitAPI
 from litserve.callbacks import CallbackRunner, EventTypes
 from litserve.specs.base import LitSpec
-from litserve.utils import LitAPIStatus, dump_exception
+from litserve.utils import LitAPIStatus
 
 mp.allow_connection_pickling()
 
@@ -153,8 +153,7 @@ def run_single_loop(
                 "Please check the error trace for more details.",
                 uid,
             )
-            err_pkl = dump_exception(e)
-            response_queues[response_queue_id].put((uid, (err_pkl, LitAPIStatus.ERROR)))
+            response_queues[response_queue_id].put((uid, (e, LitAPIStatus.ERROR)))
 
 
 def run_batched_loop(
@@ -226,9 +225,8 @@ def run_batched_loop(
                 "LitAPI ran into an error while processing the batched request.\n"
                 "Please check the error trace for more details."
             )
-            err_pkl = dump_exception(e)
             for response_queue_id, uid in zip(response_queue_ids, uids):
-                response_queues[response_queue_id].put((uid, (err_pkl, LitAPIStatus.ERROR)))
+                response_queues[response_queue_id].put((uid, (e, LitAPIStatus.ERROR)))
 
 
 def run_streaming_loop(
@@ -289,7 +287,7 @@ def run_streaming_loop(
                 "Please check the error trace for more details.",
                 uid,
             )
-            response_queues[response_queue_id].put((uid, (dump_exception(e), LitAPIStatus.ERROR)))
+            response_queues[response_queue_id].put((uid, (e, LitAPIStatus.ERROR)))
 
 
 def run_batched_streaming_loop(
@@ -362,8 +360,7 @@ def run_batched_streaming_loop(
                 "LitAPI ran into an error while processing the streaming batched request.\n"
                 "Please check the error trace for more details."
             )
-            err_pkl = dump_exception(e)
-            response_queues[response_queue_id].put((uid, (err_pkl, LitAPIStatus.ERROR)))
+            response_queues[response_queue_id].put((uid, (e, LitAPIStatus.ERROR)))
 
 
 def inference_worker(

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -44,7 +44,7 @@ from litserve.middlewares import MaxSizeMiddleware, RequestCountMiddleware
 from litserve.python_client import client_template
 from litserve.specs import OpenAISpec
 from litserve.specs.base import LitSpec
-from litserve.utils import LitAPIStatus, call_after_stream, load_and_raise
+from litserve.utils import LitAPIStatus, call_after_stream
 
 mp.allow_connection_pickling()
 
@@ -362,7 +362,7 @@ class LitServer:
             response, status = self.response_buffer.pop(uid)
 
             if status == LitAPIStatus.ERROR:
-                load_and_raise(response)
+                raise response
             self._callback_runner.trigger_event(EventTypes.ON_RESPONSE, litserver=self)
             return response
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -27,7 +27,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from litserve.specs.base import LitSpec
-from litserve.utils import LitAPIStatus, azip, load_and_raise
+from litserve.utils import LitAPIStatus, azip
 
 if typing.TYPE_CHECKING:
     from litserve import LitServer
@@ -380,7 +380,7 @@ class OpenAISpec(LitSpec):
             # iterate over n choices
             for i, (response, status) in enumerate(streaming_response):
                 if status == LitAPIStatus.ERROR:
-                    load_and_raise(response)
+                    raise response
                 encoded_response = json.loads(response)
                 logger.debug(encoded_response)
                 chat_msg = ChoiceDelta(**encoded_response)
@@ -424,7 +424,7 @@ class OpenAISpec(LitSpec):
             usage = None
             async for response, status in streaming_response:
                 if status == LitAPIStatus.ERROR:
-                    load_and_raise(response)
+                    raise response
                 # data from LitAPI.encode_response
                 encoded_response = json.loads(response)
                 logger.debug(encoded_response)

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -48,18 +48,6 @@ def dump_exception(exception):
     return pickle.dumps(exception)
 
 
-def load_and_raise(response):
-    try:
-        exception = pickle.loads(response) if isinstance(response, bytes) else response
-        raise exception
-    except pickle.PickleError:
-        logger.exception(
-            f"main process failed to load the exception from the parallel worker process. "
-            f"{response} couldn't be unpickled."
-        )
-        raise
-
-
 async def azip(*async_iterables):
     iterators = [ait.__aiter__() for ait in async_iterables]
     while True:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -166,7 +166,7 @@ def test_batch_predict_string_warning():
 
 class FakeResponseQueue:
     def put(self, *args):
-        raise Exception("Exit loop")
+        raise StopIteration("exit loop")
 
 
 def test_batched_loop():
@@ -188,7 +188,7 @@ def test_batched_loop():
             lit_api_mock,
             lit_api_mock,
             requests_queue,
-            FakeResponseQueue(),
+            [FakeResponseQueue()],
             max_batch_size=2,
             batch_timeout=4,
             callback_runner=NOOP_CB_RUNNER,

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-import pickle
 import re
 import sys
 from unittest.mock import MagicMock, patch
@@ -315,13 +314,7 @@ class PredictErrorAPI(ls.test_examples.SimpleLitAPI):
 
 
 @pytest.mark.asyncio
-@patch("litserve.server.load_and_raise")
-async def test_inject_context(mocked_load_and_raise):
-    def dummy_load_and_raise(resp):
-        raise pickle.loads(resp)
-
-    mocked_load_and_raise.side_effect = dummy_load_and_raise
-
+async def test_inject_context():
     # Test context injection with single loop
     api = IdentityAPI()
     server = LitServer(api)

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -118,7 +118,7 @@ class FakeBatchStreamResponseQueue:
         response, status = args
         if status == LitAPIStatus.FINISH_STREAMING:
             raise StopIteration("interrupt iteration")
-        if status == LitAPIStatus.ERROR and b"interrupt iteration" in response:
+        if status == LitAPIStatus.ERROR and isinstance(response, StopIteration):
             assert self.count // 2 == self.num_streamed_outputs, (
                 f"Loop count must have incremented for " f"{self.num_streamed_outputs} times."
             )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->


## What does this PR do?

- The last of exception adds an unrelated line `load_and_raise raise exception`, which users shouldn't be exposed to since it's an internal part of LitServe.  Sometimes it goes even more verbose. 
- Remove manual pickling of exceptions, since multiprocessing Manager automatically does that. 

This PR simplifies the error handling for better debugging. 

## Scenario

```python
import litserve as ls

class SimpleLitAPI(ls.LitAPI):
    def setup(self, device):
        self.model1 = lambda x: x**2

    def decode_request(self, request):
        return request["input"]

    def predict(self, x):
        output = self.model1(x)
        raise Exception("This is an example error message.")
        return {"output": output}

    def encode_response(self, output):
        return {"output": output}

if __name__ == "__main__":
    server = ls.LitServer(SimpleLitAPI(), accelerator="auto", max_batch_size=1)
    server.run(port=8000)
```

### Before

```
LitAPI ran into an error while processing the request uid=4ec5a56d-9e4f-4a59-9b7e-7b180bdf6aa9.
Please check the error trace for more details.
Traceback (most recent call last):
  File "/Users/aniket/Projects/github/litserve/src/litserve/loops.py", line 134, in run_single_loop
    y = _inject_context(
        ^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/litserve/src/litserve/loops.py", line 55, in _inject_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/example.py", line 20, in predict
    raise Exception("This is an example error message.")
Exception: This is an example error message.
INFO:     127.0.0.1:59161 - "POST /predict HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):

  ...

  File "/Users/aniket/Projects/github/litserve/src/litserve/utils.py", line 54, in load_and_raise
    raise exception
Exception: This is an example error message.
```

###  After

```
LitAPI ran into an error while processing the request uid=daebbe27-14bb-464d-95e0-9c83883efa33.
Please check the error trace for more details.
Traceback (most recent call last):
  File "/Users/aniket/Projects/github/litserve/src/litserve/loops.py", line 134, in run_single_loop
    y = _inject_context(
        ^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/litserve/src/litserve/loops.py", line 55, in _inject_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/example.py", line 20, in predict
    raise Exception("This is an example error message.")
Exception: This is an example error message.
INFO:     127.0.0.1:59242 - "POST /predict HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):

...

  File "/Users/aniket/Projects/github/litserve/src/litserve/server.py", line 365, in predict
    raise response
Exception: This is an example error message.
```


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
