### PR TITLE
Add custom healthcheck path

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -113,6 +113,7 @@ class LitServer:
         max_batch_size: int = 1,
         batch_timeout: float = 0.0,
         api_path: str = "/predict",
+        healthcheck_path: str = "/health",
         stream: bool = False,
         spec: Optional[LitSpec] = None,
         max_payload_size=None,
@@ -144,6 +145,12 @@ class LitServer:
                 "api_path must start with '/'. "
                 "Please provide a valid api path like '/predict', '/classify', or '/v1/predict'"
             )
+        
+        if not healthcheck_path.startswith("/"):
+            raise ValueError(
+                "healthcheck_path must start with '/'. "
+                "Please provide a valid api path like '/health', '/healthcheck', or '/v1/health'"
+            )
 
         # Check if the batch and unbatch methods are overridden in the lit_api instance
         batch_overridden = lit_api.batch.__code__ is not LitAPI.batch.__code__
@@ -156,6 +163,7 @@ class LitServer:
             )
 
         self.api_path = api_path
+        self.healthcheck_path = healthcheck_path
         self.track_requests = track_requests
         lit_api.stream = stream
         lit_api.request_timeout = timeout
@@ -324,7 +332,7 @@ class LitServer:
         async def index(request: Request) -> Response:
             return Response(content="litserve running")
 
-        @self.app.get("/health", dependencies=[Depends(self.setup_auth())])
+        @self.app.get(self.healthcheck_path, dependencies=[Depends(self.setup_auth())])
         async def health(request: Request) -> Response:
             nonlocal workers_ready
             if not workers_ready:

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -14,6 +14,7 @@
 import asyncio
 import re
 import sys
+from time import sleep
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -352,6 +353,18 @@ def test_custom_api_path():
     url = server.api_path
     with wrap_litserve_start(server) as server, TestClient(server.app) as client:
         response = client.post(url, json={"input": 4.0})
+        assert response.status_code == 200, "Server response should be 200 (OK)"
+
+def test_custom_healthcheck_path():
+    with pytest.raises(ValueError, match="healthcheck_path must start with '/'. "):
+        LitServer(ls.test_examples.SimpleLitAPI(), healthcheck_path="customhealth")
+
+    server = LitServer(ls.test_examples.SimpleLitAPI(), healthcheck_path="/v1/custom_health")
+    url = server.healthcheck_path
+    with wrap_litserve_start(server) as server, TestClient(server.app) as client:
+        # Sleep a bit to ensure the server is ready
+        sleep(3)
+        response = client.get(url)
         assert response.status_code == 200, "Server response should be 200 (OK)"
 
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -70,6 +70,24 @@ def test_workers_health():
         assert response.status_code == 200
         assert response.text == "ok"
 
+def test_workers_health_custom_path():
+    server = LitServer(SlowSetupLitAPI(), accelerator="cpu", healthcheck_path="/my_server/health", devices=1, timeout=5, workers_per_device=2)
+
+    with wrap_litserve_start(server) as server, TestClient(server.app) as client:
+        response = client.get("/my_server/health")
+        assert response.status_code == 503
+        assert response.text == "not ready"
+
+        time.sleep(1)
+        response = client.get("/my_server/health")
+        assert response.status_code == 503
+        assert response.text == "not ready"
+
+        time.sleep(3)
+        response = client.get("/my_server/health")
+        assert response.status_code == 200
+        assert response.text == "ok"
+
 
 def make_load_request(server, outputs):
     with TestClient(server.app) as client:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs? - I would if I knew where to do that.
- [x] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
As a user, I need to use a healthcheck path with a custom prefix. This will allow users to choose a custom path for the healthcheck endpoint.
-->


## What does this PR do?

Fixes #341 by adding a `healthcheck_path` property to the LitServer class, defaulting to the current path of `/health`.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?
I did!
