### PR TITLE
Update media type and JSON handling in OpenAISpec 

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -396,7 +396,7 @@ class OpenAISpec(LitSpec):
             usage_info = sum(usage_infos)
             chunk = ChatCompletionChunk(model=model, choices=choices, usage=None)
             logger.debug(chunk)
-            yield f"data: {json.dumps(chunk.model_dump())}\n\n"
+            yield f"data: {chunk.model_dump_json()}\n\n"
 
         choices = [
             ChatCompletionStreamingChoice(

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -365,7 +365,7 @@ class OpenAISpec(LitSpec):
         if request.stream:
             return StreamingResponse(
                 self.streaming_completion(request, responses),
-                media_type="application/x-ndjson",
+                media_type="text/event-stream",
                 background=background_tasks,
             )
 
@@ -394,9 +394,9 @@ class OpenAISpec(LitSpec):
 
             # Only use the last item from encode_response
             usage_info = sum(usage_infos)
-            chunk = ChatCompletionChunk(model=model, choices=choices, usage=None).json()
+            chunk = ChatCompletionChunk(model=model, choices=choices, usage=None)
             logger.debug(chunk)
-            yield f"data: {chunk}\n\n"
+            yield f"data: {json.dumps(chunk.model_dump())}\n\n"
 
         choices = [
             ChatCompletionStreamingChoice(
@@ -410,8 +410,8 @@ class OpenAISpec(LitSpec):
             model=model,
             choices=choices,
             usage=usage_info,
-        ).json()
-        yield f"data: {last_chunk}\n\n"
+        )
+        yield f"data: {json.dumps(last_chunk.model_dump())}\n\n"
         yield "data: [DONE]\n\n"
 
     async def non_streaming_completion(self, request: ChatCompletionRequest, generator_list: List[AsyncGenerator]):

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -411,7 +411,7 @@ class OpenAISpec(LitSpec):
             choices=choices,
             usage=usage_info,
         )
-        yield f"data: {json.dumps(last_chunk.model_dump())}\n\n"
+        yield f"data: {last_chunk.model_dump_json()}\n\n"
         yield "data: [DONE]\n\n"
 
     async def non_streaming_completion(self, request: ChatCompletionRequest, generator_list: List[AsyncGenerator]):


### PR DESCRIPTION
To comply with actual OpenAI API streaming responses i changed the content type and the json handling in the streaming implementation of openAI-spec see #359 

<details>
  <summary><b>Before submitting</b></summary>

- [X] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure to update the docs? --> Not applicable
- [X] Did you write any new necessary tests? --> not necessary 

</details>


How does this PR impact the user? 
As a user, I want to use LitServe to connect to third-party libraries or applications (such as Open WebUI) via openAI streaming API. This PR changes the LitServe OpenAI-spec to fully comply with the OAI streaming API and solve existiing connection issues.


## What does this PR do?

Fixes #359 

- [X] passed 128/129 Tests. 
- [ ]  test: "e2e" - "test run with port" wouldn't run, probably bc of restricted write access (not sure)
- [X] retest with own code (see #359 ) worked. 


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?
YES  💯  
