### PR TITLE
Feat support OpenAI embedding 

### DIFF
--- a/src/litserve/__init__.py
+++ b/src/litserve/__init__.py
@@ -17,6 +17,16 @@ from litserve.api import LitAPI
 from litserve.callbacks import Callback
 from litserve.loggers import Logger
 from litserve.server import LitServer, Request, Response
-from litserve.specs.openai import OpenAISpec
+from litserve.specs import OpenAIEmbeddingSpec, OpenAISpec
 
-__all__ = ["LitAPI", "LitServer", "Request", "Response", "OpenAISpec", "test_examples", "Callback", "Logger"]
+__all__ = [
+    "LitAPI",
+    "LitServer",
+    "Request",
+    "Response",
+    "OpenAISpec",
+    "OpenAIEmbeddingSpec",
+    "test_examples",
+    "Callback",
+    "Logger",
+]

--- a/src/litserve/specs/__init__.py
+++ b/src/litserve/specs/__init__.py
@@ -1,3 +1,4 @@
 from litserve.specs.openai import OpenAISpec
+from litserve.specs.openai_embedding import OpenAIEmbeddingSpec
 
-__all__ = ["OpenAISpec"]
+__all__ = ["OpenAISpec", "OpenAIEmbeddingSpec"]

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -33,6 +33,10 @@ class EmbeddingRequest(BaseModel):
     dimensions: Optional[int] = None
     encoding_format: Literal["float"] = "float"
 
+    # TODO: Check if this might be a handy helper function
+    def get_input_as_list(self):
+        return self.input if isinstance(self.input, list) else [self.input]
+
 
 class Embedding(BaseModel):
     index: int
@@ -106,9 +110,7 @@ class OpenAIEmbeddingSpec(LitSpec):
         print("OpenAI Embedding Spec is ready.")
 
     def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> List[str]:
-        if isinstance(request.input, str):
-            return [request.input]
-        return request.input
+        return request.get_input_as_list()
 
     def encode_response(self, output: List[List[float]], context_kwargs: Optional[dict] = None) -> dict:
         return {
@@ -141,7 +143,7 @@ class OpenAIEmbeddingSpec(LitSpec):
         logger.debug(response)
 
         # TODO: Validate response and also confirm if UsageInfo should be default or not, as None is also a valid value
-        # maybe move this validate to setup
+        # maybe move this validate to setup for early validation
         self.validate_response(response)
 
         usage = UsageInfo(**response)

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -130,7 +130,6 @@ class OpenAIEmbeddingSpec(LitSpec):
         }
 
     def validate_response(self, response: dict) -> None:
-        # Consider using the pattern: "What's wrong? Why it's wrong? How can I solve it?" when crafting error messages.
         if not isinstance(response, dict):
             raise ValueError(
                 "The response is not a dictionary."

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -1,3 +1,16 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import asyncio
 import inspect
 import logging

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -140,7 +140,8 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         logger.debug(response)
 
-        # TODO: Validate response and also confirm if UsageInfo shoul be default or not, as None is also a valid value
+        # TODO: Validate response and also confirm if UsageInfo should be default or not, as None is also a valid value
+        # maybe move this validate to setup
         self.validate_response(response)
 
         usage = UsageInfo(**response)

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -101,7 +101,8 @@ class OpenAIEmbeddingSpec(LitSpec):
         if inspect.isgeneratorfunction(lit_api.predict):
             raise ValueError(
                 "You are using yield in your predict method, which is used for streaming.",
-                "OpenAIEmbeddingSpec doesn't support streaming because producing embeddings is not a sequential operation.",
+                "OpenAIEmbeddingSpec doesn't support streaming because producing embeddings ",
+                "is not a sequential operation.",
                 "Please consider replacing yield with return in predict.\n",
                 EMBEDDING_API_EXAMPLE,
             )
@@ -110,7 +111,8 @@ class OpenAIEmbeddingSpec(LitSpec):
         if not is_encode_response_original and inspect.isgeneratorfunction(lit_api.encode_response):
             raise ValueError(
                 "You are using yield in your encode_response method, which is used for streaming.",
-                "OpenAIEmbeddingSpec doesn't support streaming because producing embeddings is not a sequential operation.",
+                "OpenAIEmbeddingSpec doesn't support streaming because producing embeddings ",
+                "is not a sequential operation.",
                 "Please consider replacing yield with return in encode_response.\n",
                 EMBEDDING_API_EXAMPLE,
             )

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -102,6 +102,9 @@ class OpenAIEmbeddingSpec(LitSpec):
             raise response
 
         logger.debug(response)
+
+        # TODO: Validate response and also confirm if UsageInfo shoul be default or not, as None is also a valid value
+
         usage = UsageInfo(**response)
         data = [Embedding(index=i, embedding=embedding) for i, embedding in enumerate(response["embeddings"])]
 

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -1,0 +1,86 @@
+import asyncio
+import inspect
+import logging
+import time
+import uuid
+from typing import List, Literal, Optional, Union
+
+from fastapi import Request, Response, status
+from pydantic import BaseModel
+
+from litserve.specs.base import LitSpec
+from litserve.utils import LitAPIStatus
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingRequest(BaseModel):
+    input: Union[str, List[str]]
+    model: str
+    dimensions: Optional[int] = None
+    encoding_format: Literal["float"] = "float"
+
+
+class Embedding(BaseModel):
+    index: int
+    embedding: List[float]
+    object: Literal["embedding"] = "embedding"
+
+
+class UsageInfo(BaseModel):
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+
+
+class EmbeddingResponse(BaseModel):
+    data: List[Embedding]
+    model: str
+    object: Literal["list"] = "list"
+    usage: UsageInfo
+
+
+class OpenAIEmbeddingSpec(LitSpec):
+    def __init__(self):
+        super().__init__()
+        # register the endpoint
+        self.add_endpoint("/v1/embeddings", self.embeddings, ["POST"])
+        self.add_endpoint("/v1/embeddings", self.options_embeddings, ["GET"])
+
+    def setup(self, server: "LitServer"):  # noqa: F821
+        from litserve import LitAPI
+
+        super().setup(server)
+
+        lit_api = self._server.lit_api
+        if inspect.isgeneratorfunction(lit_api.predict):
+            raise ValueError("OpenAI embedding spec does not support streaming predictions.")
+
+        is_encode_response_original = lit_api.encode_response.__code__ is LitAPI.encode_response.__code__
+        if not is_encode_response_original and inspect.isgeneratorfunction(lit_api.encode_response):
+            raise ValueError("OpenAI embedding spec does not support streaming predictions.")
+
+        print("OpenAI Embedding Spec is ready.")
+
+    async def embeddings(self, request: EmbeddingRequest):
+        response_queue_id = self.response_queue_id
+        logger.debug("Received embedding request: %s", request)
+        uid = uuid.uuid4()
+        event = asyncio.Event()
+        self._server.response_buffer[uid] = event
+
+        self._server.request_queue.put_nowait((response_queue_id, uid, time.monotonic(), request.model_copy()))
+        await event.wait()
+
+        response, status = self._server.response_buffer.pop(uid)
+
+        if status == LitAPIStatus.ERROR:
+            raise response
+
+        logger.debug(response)
+        usage = UsageInfo(**response)
+        data = [Embedding(index=i, embedding=embedding) for i, embedding in enumerate(response["embeddings"])]
+
+        return EmbeddingResponse(data=data, model=request.model, usage=usage)
+
+    async def options_embeddings(self, request: Request):
+        return Response(status_code=status.HTTP_200_OK)

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -74,6 +74,18 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         print("OpenAI Embedding Spec is ready.")
 
+    def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> List[str]:
+        if isinstance(request.input, str):
+            return [request.input]
+        return request.input
+
+    def encode_response(self, output: List[List[float]], context_kwargs: Optional[dict] = None) -> dict:
+        return {
+            "embeddings": output,
+            "prompt_tokens": context_kwargs.get("prompt_tokens", 0),
+            "total_tokens": context_kwargs.get("total_tokens", 0),
+        }
+
     async def embeddings(self, request: EmbeddingRequest):
         response_queue_id = self.response_queue_id
         logger.debug("Received embedding request: %s", request)

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -60,7 +60,7 @@ Please follow the example below for guidance on how to use the OpenAI Embedding 
 
 ```python
 import numpy as np
-from typing import List, Union
+from typing import List
 from litserve import LitAPI, OpenAIEmbeddingSpec
 
 
@@ -68,7 +68,7 @@ class TestAPI(LitAPI):
     def setup(self, device):
         self.model = None
 
-    def decode_request(self, request) -> Union[str, List[str]]:
+    def decode_request(self, request) -> List[str]:
         return request.ensure_list()
 
     def predict(self, x) -> List[List[float]]:
@@ -119,7 +119,7 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         print("OpenAI Embedding Spec is ready.")
 
-    def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> Union[str, List[str]]:
+    def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> List[str]:
         return request.ensure_list()
 
     def encode_response(self, output: List[List[float]], context_kwargs: Optional[dict] = None) -> dict:

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -61,7 +61,7 @@ Please follow the below example for guidance on how to use the spec:
 
 ```python
 import numpy as np
-
+from typing import List
 from litserve.api import LitAPI
 
 
@@ -69,15 +69,14 @@ class TestAPI(LitAPI):
     def setup(self, device):
         self.model = None
 
-    def decode_request(self, request):
+    def decode_request(self, request)->List[str]:
         return request.input if isinstance(request.input, list) else [request.input]
 
-    def predict(self, x):
+    def predict(self, x)-> List[List[float]]:
         return np.random.rand(len(x), 768).tolist()
 
-    def encode_response(self, response):
-        return {"embeddings": response}
-
+    def encode_response(self, output)-> dict:
+        return {"embeddings": output}
 ```
 """
 

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -60,7 +60,7 @@ Please follow the example below for guidance on how to use the OpenAI Embedding 
 
 ```python
 import numpy as np
-from typing import List
+from typing import List, Union
 from litserve import LitAPI, OpenAIEmbeddingSpec
 
 
@@ -68,8 +68,8 @@ class TestAPI(LitAPI):
     def setup(self, device):
         self.model = None
 
-    def decode_request(self, request) -> List[str]:
-        return request.input if isinstance(request.input, list) else [request.input]
+    def decode_request(self, request) -> Union[str, List[str]]:
+        return request.ensure_list()
 
     def predict(self, x) -> List[List[float]]:
         return np.random.rand(len(x), 768).tolist()
@@ -119,7 +119,7 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         print("OpenAI Embedding Spec is ready.")
 
-    def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> List[str]:
+    def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> Union[str, List[str]]:
         return request.ensure_list()
 
     def encode_response(self, output: List[List[float]], context_kwargs: Optional[dict] = None) -> dict:

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -165,8 +165,6 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         logger.debug(response)
 
-        # TODO: Validate response and also confirm if UsageInfo should be default or not, as None is also a valid value
-        # maybe move this validate to setup for early validation
         self.validate_response(response)
 
         usage = UsageInfo(**response)

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -32,3 +32,13 @@ class TestEmbedAPIWithYieldPredict(TestEmbedAPI):
 class TestEmbedAPIWithYieldEncodeResponse(TestEmbedAPI):
     def encode_response(self, output):
         yield {"embeddings": output}
+
+
+class TestEmbedAPIWithNonDictOutput(TestEmbedAPI):
+    def encode_response(self, output):
+        return output
+
+
+class TestEmbedAPIWithMissingEmbeddings(TestEmbedAPI):
+    def encode_response(self, output):
+        return {"output": output}

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -8,10 +8,10 @@ class TestAPI(LitAPI):
         self.model = None
 
     def decode_request(self, request):
-        return request
+        return request.input if isinstance(request.input, list) else [request.input]
 
     def predict(self, x):
-        return [np.random.rand(768).tolist()]
+        return np.random.rand(len(x), 768).tolist()
 
     def encode_response(self, response):
         return {"embeddings": response}

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 
 from litserve.api import LitAPI
@@ -7,11 +9,11 @@ class TestAPI(LitAPI):
     def setup(self, device):
         self.model = None
 
-    def decode_request(self, request):
+    def decode_request(self, request)->List[str]:
         return request.input if isinstance(request.input, list) else [request.input]
 
-    def predict(self, x):
+    def predict(self, x)-> List[List[float]]:
         return np.random.rand(len(x), 768).tolist()
 
-    def encode_response(self, response):
-        return {"embeddings": response}
+    def encode_response(self, output)-> dict:
+        return {"embeddings": output}

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -21,9 +21,7 @@ class TestEmbedAPI(LitAPI):
 
 class TestEmbedBatchedAPI(TestEmbedAPI):
     def predict(self, batch) -> List[List[List[float]]]:
-        batch_size = len(batch)
-        num_inputs = len(batch[0])
-        return np.random.rand(batch_size, num_inputs, 768).tolist()
+        return [np.random.rand(len(x), 768).tolist() for x in batch]
 
 
 class TestEmbedAPIWithUsage(TestEmbedAPI):

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from litserve.api import LitAPI
+
+
+class TestAPI(LitAPI):
+    def setup(self, device):
+        self.model = None
+
+    def decode_request(self, request):
+        return request
+
+    def predict(self, x):
+        return [np.random.rand(768).tolist()]
+
+    def encode_response(self, response):
+        return {"embeddings": response}

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -10,7 +10,7 @@ class TestAPI(LitAPI):
         self.model = None
 
     def decode_request(self, request) -> List[str]:
-        return request.input if isinstance(request.input, list) else [request.input]
+        return request.get_input_as_list()
 
     def predict(self, x) -> List[List[float]]:
         return np.random.rand(len(x), 768).tolist()

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -5,7 +5,7 @@ import numpy as np
 from litserve.api import LitAPI
 
 
-class TestAPI(LitAPI):
+class TestEmbedAPI(LitAPI):
     def setup(self, device):
         self.model = None
 
@@ -17,3 +17,18 @@ class TestAPI(LitAPI):
 
     def encode_response(self, output) -> dict:
         return {"embeddings": output}
+
+
+class TestEmbedAPIWithUsage(TestEmbedAPI):
+    def encode_response(self, output) -> dict:
+        return {"embeddings": output, "prompt_tokens": 10, "total_tokens": 10}
+
+
+class TestEmbedAPIWithYieldPredict(TestEmbedAPI):
+    def predict(self, x):
+        yield from np.random.rand(768).tolist()
+
+
+class TestEmbedAPIWithYieldEncodeResponse(TestEmbedAPI):
+    def encode_response(self, output):
+        yield {"embeddings": output}

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -10,7 +10,7 @@ class TestAPI(LitAPI):
         self.model = None
 
     def decode_request(self, request) -> List[str]:
-        return request.get_input_as_list()
+        return request.ensure_list()
 
     def predict(self, x) -> List[List[float]]:
         return np.random.rand(len(x), 768).tolist()

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -19,6 +19,13 @@ class TestEmbedAPI(LitAPI):
         return {"embeddings": output}
 
 
+class TestEmbedBatchedAPI(TestEmbedAPI):
+    def predict(self, batch) -> List[List[List[float]]]:
+        batch_size = len(batch)
+        num_inputs = len(batch[0])
+        return np.random.rand(batch_size, num_inputs, 768).tolist()
+
+
 class TestEmbedAPIWithUsage(TestEmbedAPI):
     def encode_response(self, output) -> dict:
         return {"embeddings": output, "prompt_tokens": 10, "total_tokens": 10}

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -9,11 +9,11 @@ class TestAPI(LitAPI):
     def setup(self, device):
         self.model = None
 
-    def decode_request(self, request)->List[str]:
+    def decode_request(self, request) -> List[str]:
         return request.input if isinstance(request.input, list) else [request.input]
 
-    def predict(self, x)-> List[List[float]]:
+    def predict(self, x) -> List[List[float]]:
         return np.random.rand(len(x), 768).tolist()
 
-    def encode_response(self, output)-> dict:
+    def encode_response(self, output) -> dict:
         return {"embeddings": output}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,3 +265,13 @@ def openai_request_data_with_response_format():
         "frequency_penalty": 0,
         "user": "string",
     }
+
+
+@pytest.fixture
+def openai_embedding_request_data():
+    return {"input": "A beautiful sunset over the beach.", "model": "lit", "encoding_format": "float"}
+
+
+@pytest.fixture
+def openai_embedding_request_data_array():
+    return {"input": ["A beautiful sunset over the beach."] * 4, "model": "lit", "encoding_format": "float"}

--- a/tests/e2e/default_openai_embedding_spec.py
+++ b/tests/e2e/default_openai_embedding_spec.py
@@ -1,0 +1,7 @@
+import litserve as ls
+from litserve import OpenAIEmbeddingSpec
+from litserve.test_examples.openai_embedding_spec_example import TestAPI
+
+if __name__ == "__main__":
+    server = ls.LitServer(TestAPI(), spec=OpenAIEmbeddingSpec())
+    server.run()

--- a/tests/e2e/default_openai_embedding_spec.py
+++ b/tests/e2e/default_openai_embedding_spec.py
@@ -1,7 +1,7 @@
 import litserve as ls
 from litserve import OpenAIEmbeddingSpec
-from litserve.test_examples.openai_embedding_spec_example import TestAPI
+from litserve.test_examples.openai_embedding_spec_example import TestEmbedAPI
 
 if __name__ == "__main__":
-    server = ls.LitServer(TestAPI(), spec=OpenAIEmbeddingSpec())
+    server = ls.LitServer(TestEmbedAPI(), spec=OpenAIEmbeddingSpec())
     server.run()

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -64,9 +64,9 @@ def test_run_with_port():
         client_code = f.read()
         assert ":8080" in client_code, "Could not find 8080 in client.py"
     output = subprocess.run("python client.py", shell=True, capture_output=True, text=True).stdout
-    assert (
-        '{"output":16.0}' in output
-    ), f"tests/simple_server_server_diff_port.py didn't return expected output, got {output}"
+    assert '{"output":16.0}' in output, (
+        f"tests/simple_server_server_diff_port.py didn't return expected output, got {output}"
+    )
     os.remove("client.py")
 
 
@@ -120,9 +120,9 @@ def test_openai_parity():
             {"role": "user", "content": "How are you?"},
         ],
     )
-    assert (
-        response.choices[0].message.content == "This is a generated output"
-    ), f"Server didn't return expected output\nOpenAI client output: {response}"
+    assert response.choices[0].message.content == "This is a generated output", (
+        f"Server didn't return expected output\nOpenAI client output: {response}"
+    )
 
     response = client.chat.completions.create(
         model="lit",
@@ -135,9 +135,9 @@ def test_openai_parity():
 
     expected_outputs = ["This is a generated output", None]
     for r, expected_out in zip(response, expected_outputs):
-        assert (
-            r.choices[0].delta.content == expected_out
-        ), f"Server didn't return expected output.\nOpenAI client output: {r}"
+        assert r.choices[0].delta.content == expected_out, (
+            f"Server didn't return expected output.\nOpenAI client output: {r}"
+        )
 
 
 @e2e_from_file("tests/e2e/default_openaispec.py")
@@ -166,9 +166,9 @@ def test_openai_parity_with_image_input():
         model="lit",
         messages=messages,
     )
-    assert (
-        response.choices[0].message.content == "This is a generated output"
-    ), f"Server didn't return expected output\nOpenAI client output: {response}"
+    assert response.choices[0].message.content == "This is a generated output", (
+        f"Server didn't return expected output\nOpenAI client output: {response}"
+    )
 
     response = client.chat.completions.create(
         model="lit",
@@ -178,9 +178,9 @@ def test_openai_parity_with_image_input():
 
     expected_outputs = ["This is a generated output", None]
     for r, expected_out in zip(response, expected_outputs):
-        assert (
-            r.choices[0].delta.content == expected_out
-        ), f"Server didn't return expected output.\nOpenAI client output: {r}"
+        assert r.choices[0].delta.content == expected_out, (
+            f"Server didn't return expected output.\nOpenAI client output: {r}"
+        )
 
 
 @e2e_from_file("tests/e2e/default_openaispec_tools.py")
@@ -217,12 +217,12 @@ def test_openai_parity_with_tools():
         messages=messages,
         tools=tools,
     )
-    assert (
-        response.choices[0].message.content == ""
-    ), f"Server didn't return expected output\nOpenAI client output: {response}"
-    assert (
-        response.choices[0].message.tool_calls[0].function.name == "get_current_weather"
-    ), f"Server didn't return expected output\nOpenAI client output: {response}"
+    assert response.choices[0].message.content == "", (
+        f"Server didn't return expected output\nOpenAI client output: {response}"
+    )
+    assert response.choices[0].message.tool_calls[0].function.name == "get_current_weather", (
+        f"Server didn't return expected output\nOpenAI client output: {response}"
+    )
 
     response = client.chat.completions.create(
         model="lit",
@@ -232,13 +232,13 @@ def test_openai_parity_with_tools():
 
     expected_outputs = ["", None]
     for r, expected_out in zip(response, expected_outputs):
-        assert (
-            r.choices[0].delta.content == expected_out
-        ), f"Server didn't return expected output.\nOpenAI client output: {r}"
+        assert r.choices[0].delta.content == expected_out, (
+            f"Server didn't return expected output.\nOpenAI client output: {r}"
+        )
         if r.choices[0].delta.tool_calls:
-            assert (
-                r.choices[0].delta.tool_calls[0].function.name == "get_current_weather"
-            ), f"Server didn't return expected output.\nOpenAI client output: {r}"
+            assert r.choices[0].delta.tool_calls[0].function.name == "get_current_weather", (
+                f"Server didn't return expected output.\nOpenAI client output: {r}"
+            )
 
 
 @e2e_from_file("tests/e2e/default_openai_with_batching.py")
@@ -292,9 +292,9 @@ def test_openai_parity_with_response_format():
         messages=messages,
         response_format=response_format,
     )
-    assert (
-        response.choices[0].message.content == output
-    ), f"Server didn't return expected output\nOpenAI client output: {response}"
+    assert response.choices[0].message.content == output, (
+        f"Server didn't return expected output\nOpenAI client output: {response}"
+    )
 
     response = client.chat.completions.create(
         model="lit",
@@ -305,9 +305,9 @@ def test_openai_parity_with_response_format():
 
     expected_outputs = [output, None]
     for r, expected_out in zip(response, expected_outputs):
-        assert (
-            r.choices[0].delta.content == expected_out
-        ), f"Server didn't return expected output.\nOpenAI client output: {r}"
+        assert r.choices[0].delta.content == expected_out, (
+            f"Server didn't return expected output.\nOpenAI client output: {r}"
+        )
 
 
 @e2e_from_file("tests/e2e/default_single_streaming.py")

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -351,4 +351,3 @@ def test_openai_embedding_parity():
     assert len(response.data) == 2, f"Expected 2 embeddings but got {len(response.data)}"
     for data in response.data:
         assert len(data.embedding) == 768, f"Expected 768 dimensions but got {len(data.embedding)}"
-

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -64,9 +64,9 @@ def test_run_with_port():
         client_code = f.read()
         assert ":8080" in client_code, "Could not find 8080 in client.py"
     output = subprocess.run("python client.py", shell=True, capture_output=True, text=True).stdout
-    assert '{"output":16.0}' in output, (
-        f"tests/simple_server_server_diff_port.py didn't return expected output, got {output}"
-    )
+    assert (
+        '{"output":16.0}' in output
+    ), f"tests/simple_server_server_diff_port.py didn't return expected output, got {output}"
     os.remove("client.py")
 
 
@@ -120,9 +120,9 @@ def test_openai_parity():
             {"role": "user", "content": "How are you?"},
         ],
     )
-    assert response.choices[0].message.content == "This is a generated output", (
-        f"Server didn't return expected output\nOpenAI client output: {response}"
-    )
+    assert (
+        response.choices[0].message.content == "This is a generated output"
+    ), f"Server didn't return expected output\nOpenAI client output: {response}"
 
     response = client.chat.completions.create(
         model="lit",
@@ -135,9 +135,9 @@ def test_openai_parity():
 
     expected_outputs = ["This is a generated output", None]
     for r, expected_out in zip(response, expected_outputs):
-        assert r.choices[0].delta.content == expected_out, (
-            f"Server didn't return expected output.\nOpenAI client output: {r}"
-        )
+        assert (
+            r.choices[0].delta.content == expected_out
+        ), f"Server didn't return expected output.\nOpenAI client output: {r}"
 
 
 @e2e_from_file("tests/e2e/default_openaispec.py")
@@ -166,9 +166,9 @@ def test_openai_parity_with_image_input():
         model="lit",
         messages=messages,
     )
-    assert response.choices[0].message.content == "This is a generated output", (
-        f"Server didn't return expected output\nOpenAI client output: {response}"
-    )
+    assert (
+        response.choices[0].message.content == "This is a generated output"
+    ), f"Server didn't return expected output\nOpenAI client output: {response}"
 
     response = client.chat.completions.create(
         model="lit",
@@ -178,9 +178,9 @@ def test_openai_parity_with_image_input():
 
     expected_outputs = ["This is a generated output", None]
     for r, expected_out in zip(response, expected_outputs):
-        assert r.choices[0].delta.content == expected_out, (
-            f"Server didn't return expected output.\nOpenAI client output: {r}"
-        )
+        assert (
+            r.choices[0].delta.content == expected_out
+        ), f"Server didn't return expected output.\nOpenAI client output: {r}"
 
 
 @e2e_from_file("tests/e2e/default_openaispec_tools.py")
@@ -217,12 +217,12 @@ def test_openai_parity_with_tools():
         messages=messages,
         tools=tools,
     )
-    assert response.choices[0].message.content == "", (
-        f"Server didn't return expected output\nOpenAI client output: {response}"
-    )
-    assert response.choices[0].message.tool_calls[0].function.name == "get_current_weather", (
-        f"Server didn't return expected output\nOpenAI client output: {response}"
-    )
+    assert (
+        response.choices[0].message.content == ""
+    ), f"Server didn't return expected output\nOpenAI client output: {response}"
+    assert (
+        response.choices[0].message.tool_calls[0].function.name == "get_current_weather"
+    ), f"Server didn't return expected output\nOpenAI client output: {response}"
 
     response = client.chat.completions.create(
         model="lit",
@@ -232,13 +232,13 @@ def test_openai_parity_with_tools():
 
     expected_outputs = ["", None]
     for r, expected_out in zip(response, expected_outputs):
-        assert r.choices[0].delta.content == expected_out, (
-            f"Server didn't return expected output.\nOpenAI client output: {r}"
-        )
+        assert (
+            r.choices[0].delta.content == expected_out
+        ), f"Server didn't return expected output.\nOpenAI client output: {r}"
         if r.choices[0].delta.tool_calls:
-            assert r.choices[0].delta.tool_calls[0].function.name == "get_current_weather", (
-                f"Server didn't return expected output.\nOpenAI client output: {r}"
-            )
+            assert (
+                r.choices[0].delta.tool_calls[0].function.name == "get_current_weather"
+            ), f"Server didn't return expected output.\nOpenAI client output: {r}"
 
 
 @e2e_from_file("tests/e2e/default_openai_with_batching.py")
@@ -292,9 +292,9 @@ def test_openai_parity_with_response_format():
         messages=messages,
         response_format=response_format,
     )
-    assert response.choices[0].message.content == output, (
-        f"Server didn't return expected output\nOpenAI client output: {response}"
-    )
+    assert (
+        response.choices[0].message.content == output
+    ), f"Server didn't return expected output\nOpenAI client output: {response}"
 
     response = client.chat.completions.create(
         model="lit",
@@ -305,9 +305,9 @@ def test_openai_parity_with_response_format():
 
     expected_outputs = [output, None]
     for r, expected_out in zip(response, expected_outputs):
-        assert r.choices[0].delta.content == expected_out, (
-            f"Server didn't return expected output.\nOpenAI client output: {r}"
-        )
+        assert (
+            r.choices[0].delta.content == expected_out
+        ), f"Server didn't return expected output.\nOpenAI client output: {r}"
 
 
 @e2e_from_file("tests/e2e/default_single_streaming.py")
@@ -326,3 +326,17 @@ def test_e2e_single_streaming():
     expected_values = [4.0, 8.0, 12.0]
     for i, output in enumerate(outputs):
         assert output["output"] == expected_values[i], f"Intermediate output {i} is not expected value"
+
+
+@e2e_from_file("tests/e2e/default_openai_embedding_spec.py")
+def test_openai_embedding_parity():
+    client = OpenAI(
+        base_url="http://127.0.0.1:8000/v1",
+        api_key="lit",  # required, but unused
+    )
+    response = client.embeddings.create(
+        model="lit", input="The food was delicious and the waiter...", encoding_format="float"
+    )
+
+    assert response.status == 200, f"Expected response to be 200 but got {response.status}"
+    print(response)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -332,11 +332,23 @@ def test_e2e_single_streaming():
 def test_openai_embedding_parity():
     client = OpenAI(
         base_url="http://127.0.0.1:8000/v1",
-        api_key="lit",  # required, but unused
+        api_key="lit",
     )
+
+    model = "lit"
+    input_text = "The food was delicious and the waiter was very friendly."
+    input_text_list = [input_text] * 2
     response = client.embeddings.create(
         model="lit", input="The food was delicious and the waiter...", encoding_format="float"
     )
+    assert response.model == model, f"Expected model to be {model} but got {response.model}"
+    assert len(response.data) == 1, f"Expected 1 embeddings but got {len(response.data)}"
+    assert len(response.data[0].embedding) == 768, f"Expected 768 dimensions but got {len(response.data[0].embedding)}"
+    assert isinstance(response.data[0].embedding[0], float), "Expected float datatype but got something else"
 
-    assert response.status == 200, f"Expected response to be 200 but got {response.status}"
-    print(response)
+    response = client.embeddings.create(model="lit", input=input_text_list, encoding_format="float")
+    assert response.model == model, f"Expected model to be {model} but got {response.model}"
+    assert len(response.data) == 2, f"Expected 2 embeddings but got {len(response.data)}"
+    for data in response.data:
+        assert len(data.embedding) == 768, f"Expected 768 dimensions but got {len(data.embedding)}"
+

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -49,9 +49,9 @@ async def test_openai_spec(openai_request_data):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == "This is a generated output"
-            ), "LitAPI predict response should match with the generated output"
+            assert resp.json()["choices"][0]["message"]["content"] == "This is a generated output", (
+                "LitAPI predict response should match with the generated output"
+            )
 
 
 # OpenAIWithUsage
@@ -90,9 +90,9 @@ async def test_openai_spec_with_image(openai_request_data_with_image):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data_with_image, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == "This is a generated output"
-            ), "LitAPI predict response should match with the generated output"
+            assert resp.json()["choices"][0]["message"]["content"] == "This is a generated output", (
+                "LitAPI predict response should match with the generated output"
+            )
 
 
 @pytest.mark.asyncio
@@ -103,9 +103,9 @@ async def test_override_encode(openai_request_data):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == "This is a custom encoded output"
-            ), "LitAPI predict response should match with the generated output"
+            assert resp.json()["choices"][0]["message"]["content"] == "This is a custom encoded output", (
+                "LitAPI predict response should match with the generated output"
+            )
 
 
 @pytest.mark.asyncio
@@ -116,9 +116,9 @@ async def test_openai_spec_with_tools(openai_request_data_with_tools):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             resp = await ac.post("/v1/chat/completions", json=openai_request_data_with_tools, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == ""
-            ), "LitAPI predict response should match with the generated output"
+            assert resp.json()["choices"][0]["message"]["content"] == "", (
+                "LitAPI predict response should match with the generated output"
+            )
             assert resp.json()["choices"][0]["message"]["tool_calls"] == [
                 {
                     "id": "call_1",
@@ -191,9 +191,9 @@ async def test_oai_prepopulated_context(openai_request_data):
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == "This is a"
-            ), "OpenAISpec must return only 3 tokens as specified using `max_tokens` parameter"
+            assert resp.json()["choices"][0]["message"]["content"] == "This is a", (
+                "OpenAISpec must return only 3 tokens as specified using `max_tokens` parameter"
+            )
 
 
 class WrongLitAPI(ls.LitAPI):

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -52,9 +52,9 @@ async def test_openai_spec(openai_request_data):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == "This is a generated output"
-            ), "LitAPI predict response should match with the generated output"
+            assert resp.json()["choices"][0]["message"]["content"] == "This is a generated output", (
+                "LitAPI predict response should match with the generated output"
+            )
 
 
 # OpenAIWithUsage
@@ -93,9 +93,9 @@ async def test_openai_spec_with_image(openai_request_data_with_image):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data_with_image, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == "This is a generated output"
-            ), "LitAPI predict response should match with the generated output"
+            assert resp.json()["choices"][0]["message"]["content"] == "This is a generated output", (
+                "LitAPI predict response should match with the generated output"
+            )
 
 
 @pytest.mark.asyncio
@@ -106,9 +106,9 @@ async def test_override_encode(openai_request_data):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == "This is a custom encoded output"
-            ), "LitAPI predict response should match with the generated output"
+            assert resp.json()["choices"][0]["message"]["content"] == "This is a custom encoded output", (
+                "LitAPI predict response should match with the generated output"
+            )
 
 
 @pytest.mark.asyncio
@@ -119,9 +119,9 @@ async def test_openai_spec_with_tools(openai_request_data_with_tools):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             resp = await ac.post("/v1/chat/completions", json=openai_request_data_with_tools, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == ""
-            ), "LitAPI predict response should match with the generated output"
+            assert resp.json()["choices"][0]["message"]["content"] == "", (
+                "LitAPI predict response should match with the generated output"
+            )
             assert resp.json()["choices"][0]["message"]["tool_calls"] == [
                 {
                     "id": "call_1",
@@ -194,9 +194,9 @@ async def test_oai_prepopulated_context(openai_request_data):
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
-            assert (
-                resp.json()["choices"][0]["message"]["content"] == "This is a"
-            ), "OpenAISpec must return only 3 tokens as specified using `max_tokens` parameter"
+            assert resp.json()["choices"][0]["message"]["content"] == "This is a", (
+                "OpenAISpec must return only 3 tokens as specified using `max_tokens` parameter"
+            )
 
 
 class WrongLitAPI(ls.LitAPI):

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -49,9 +49,9 @@ async def test_openai_spec(openai_request_data):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert resp.json()["choices"][0]["message"]["content"] == "This is a generated output", (
-                "LitAPI predict response should match with the generated output"
-            )
+            assert (
+                resp.json()["choices"][0]["message"]["content"] == "This is a generated output"
+            ), "LitAPI predict response should match with the generated output"
 
 
 # OpenAIWithUsage
@@ -90,9 +90,9 @@ async def test_openai_spec_with_image(openai_request_data_with_image):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data_with_image, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert resp.json()["choices"][0]["message"]["content"] == "This is a generated output", (
-                "LitAPI predict response should match with the generated output"
-            )
+            assert (
+                resp.json()["choices"][0]["message"]["content"] == "This is a generated output"
+            ), "LitAPI predict response should match with the generated output"
 
 
 @pytest.mark.asyncio
@@ -103,9 +103,9 @@ async def test_override_encode(openai_request_data):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
 
-            assert resp.json()["choices"][0]["message"]["content"] == "This is a custom encoded output", (
-                "LitAPI predict response should match with the generated output"
-            )
+            assert (
+                resp.json()["choices"][0]["message"]["content"] == "This is a custom encoded output"
+            ), "LitAPI predict response should match with the generated output"
 
 
 @pytest.mark.asyncio
@@ -116,9 +116,9 @@ async def test_openai_spec_with_tools(openai_request_data_with_tools):
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             resp = await ac.post("/v1/chat/completions", json=openai_request_data_with_tools, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
-            assert resp.json()["choices"][0]["message"]["content"] == "", (
-                "LitAPI predict response should match with the generated output"
-            )
+            assert (
+                resp.json()["choices"][0]["message"]["content"] == ""
+            ), "LitAPI predict response should match with the generated output"
             assert resp.json()["choices"][0]["message"]["tool_calls"] == [
                 {
                     "id": "call_1",
@@ -191,9 +191,9 @@ async def test_oai_prepopulated_context(openai_request_data):
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
             resp = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
-            assert resp.json()["choices"][0]["message"]["content"] == "This is a", (
-                "OpenAISpec must return only 3 tokens as specified using `max_tokens` parameter"
-            )
+            assert (
+                resp.json()["choices"][0]["message"]["content"] == "This is a"
+            ), "OpenAISpec must return only 3 tokens as specified using `max_tokens` parameter"
 
 
 class WrongLitAPI(ls.LitAPI):
@@ -268,14 +268,14 @@ async def test_openai_embedding_spec_validation(openai_request_data):
     with pytest.raises(ValueError, match="You are using yield in your predict method"), wrap_litserve_start(
         server
     ) as server:
-        async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
+        async with LifespanManager(server.app) as manager:
             await manager.shutdown()
 
     server = ls.LitServer(TestEmbedAPIWithYieldEncodeResponse(), spec=OpenAIEmbeddingSpec())
     with pytest.raises(ValueError, match="You are using yield in your encode_response method"), wrap_litserve_start(
         server
     ) as server:
-        async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
+        async with LifespanManager(server.app) as manager:
             await manager.shutdown()
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## How does this PR impact users?
This PR addresses numerous user requests for an Embeddings API similar to [OpenAI’s](https://platform.openai.com/docs/api-reference/embeddings), making it easier for users to quickly get started with embeddings. By introducing this feature, users can now integrate embeddings in a plug-and-play manner, much like the Chat API, enhancing their overall experience and saving valuable setup time.

## What does this PR do?
Fixes #305.
- This PR adds support for an Embeddings specification similar to the [OpenAI Embeddings API](https://platform.openai.com/docs/api-reference/embeddings), allowing users to seamlessly work with embeddings in a way that’s simple and intuitive.

### Usage 
>Below is a sample usage of the new Embeddings API feature.
```python
# server.py
from typing import List

from litserve import LitServer, OpenAIEmbeddingSpec
from litserve.specs.openai_embedding import EmbeddingRequest
from fastembed import TextEmbedding


class EmbeddingAPI(ls.LitAPI):
    def setup(self, device):
        # Initialize the embedding model
        self.model = TextEmbedding(model_name="jinaai/jina-embeddings-v2-small-en")

    def decode_request(self, request: EmbeddingRequest, context: dict) -> List[str]:
        # Extract documents from the request
        documents = request.ensure_list()
       
       # context["prompt_tokens"] = ...
       # context["total_tokens"] = ...
        return documents

    def predict(self, documents) -> List[List[float]]:
        # Generate embeddings for the documents
        return list(self.model.embed(documents))

    def encode_response(self, output: List[List[float]], context: dict) -> dict:
        # Format the output as embeddings
        return {"embeddings": output, **context}


if __name__ == "__main__":
    api = EmbeddingAPI()
    server = ls.LitServer(api, spec=OpenAIEmbeddingSpec())
    # Run the server on port 8000
    server.run(port=8000)

```
Test API
```sh
curl http://localhost:8000/v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{
    "input": "A beautiful sunset over the beach",
    "model": "jinaai/jina-embeddings-v2-small-en",
    "encoding_format": "float"
  }'
```
## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Absolutely! This was a fantastic learning experience and a joy to work on! 🚀🙌
