### PR TITLE
Fix: Make OpenAIEmbedding work when token usage info is not set

### DIFF
--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -63,7 +63,6 @@ import numpy as np
 from typing import List
 from litserve import LitAPI, OpenAIEmbeddingSpec
 
-
 class TestAPI(LitAPI):
     def setup(self, device):
         self.model = None
@@ -129,7 +128,7 @@ class OpenAIEmbeddingSpec(LitSpec):
         }
         return {"embeddings": output} | usage
 
-    def validate_response(self, response: dict) -> None:
+    def _validate_response(self, response: dict) -> None:
         if not isinstance(response, dict):
             raise ValueError(
                 f"Expected response to be a dictionary, but got type {type(response)}.",
@@ -147,10 +146,6 @@ class OpenAIEmbeddingSpec(LitSpec):
                 "Please ensure that your response contains the key 'embeddings'.\n"
                 f"{EMBEDDING_API_EXAMPLE}"
             )
-        if "prompt_tokens" not in response:
-            response["prompt_tokens"] = 0
-        if "total_tokens" not in response:
-            response["total_tokens"] = 0
 
     async def embeddings(self, request: EmbeddingRequest):
         response_queue_id = self.response_queue_id
@@ -169,7 +164,7 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         logger.debug(response)
 
-        self.validate_response(response)
+        self._validate_response(response)
 
         usage = UsageInfo(**response)
         data = [Embedding(index=i, embedding=embedding) for i, embedding in enumerate(response["embeddings"])]

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -284,19 +284,17 @@ async def test_openai_embedding_spec_validation(openai_request_data):
 
 @pytest.mark.asyncio
 async def test_openai_embedding_spec_with_non_dict_output(openai_embedding_request_data):
-    spec = OpenAIEmbeddingSpec()
-    server = ls.LitServer(TestEmbedAPIWithNonDictOutput(), spec=spec)
+    server = ls.LitServer(TestEmbedAPIWithNonDictOutput(), spec=ls.OpenAIEmbeddingSpec())
 
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:
-            with pytest.raises(ValueError, match="The response is not a dictionary"):
+            with pytest.raises(ValueError, match="Expected response to be a dictionary"):
                 await ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10)
 
 
 @pytest.mark.asyncio
 async def test_openai_embedding_spec_with_missing_embeddings(openai_embedding_request_data):
-    spec = OpenAIEmbeddingSpec()
-    server = ls.LitServer(TestEmbedAPIWithMissingEmbeddings(), spec=spec)
+    server = ls.LitServer(TestEmbedAPIWithMissingEmbeddings(), spec=OpenAIEmbeddingSpec())
 
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(app=manager.app, base_url="http://test") as ac:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->


## What does this PR do?

OpenAIEmbeddingSpec requires to set token usage in the `context` otherwise it fails with the following example. This PR, makes it work and set usage to `0` when not provided. 

**Error**
```
  File "/Users/aniket/Projects/github/LitServe/src/litserve/api.py", line 90, in encode_response
    return self._spec.encode_response(output, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/src/litserve/specs/openai_embedding.py", line 128, in encode_response
    "prompt_tokens": context_kwargs.get("prompt_tokens", 0),
                     ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

**Code**

```python
import litserve as ls
from sentence_transformers import SentenceTransformer

class EmbeddingsAPI(ls.LitAPI):
    def setup(self, device):
        self.model = SentenceTransformer('all-MiniLM-L6-v2', device=device)

    def predict(self, inputs):
        embeddings = self.model.encode(inputs)
        return embeddings

if __name__ == "__main__":
    api = EmbeddingsAPI()
    server = ls.LitServer(api, spec=ls.OpenAIEmbeddingSpec())
    server.run(port=8000)
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
