### PR TITLE
Assert batch size to strictly test `OpenAIEmbeddingSpec` for dynamic batching

### DIFF
--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -306,7 +306,7 @@ async def test_openai_embedding_spec_with_missing_embeddings(openai_embedding_re
 
 class TestOpenAIWithBatching(TestEmbedAPI):
     def predict(self, batch):
-        assert len(batch) == 2, f"Batch size should be 4 but got {len(batch)}"
+        assert len(batch) == 2, f"Batch size should be 2 but got {len(batch)}"
         return [np.random.rand(len(x), 768).tolist() for x in batch]
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->
Improved test = reliability

This PR adds an assert to the batched input in the LitAPI to strictly confirm it's always batched when enabled. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
