### PR TITLE
check device format while initialising litserver

### DIFF
--- a/src/litserve/connector.py
+++ b/src/litserve/connector.py
@@ -39,6 +39,16 @@ class _Connector:
         else:
             self._devices = devices
 
+        self.check_devices_and_accelerators()
+
+    def check_devices_and_accelerators(self):
+        """Check if the devices are in a valid fomra and raise an error if they are not."""
+        if self._accelerator in ["cuda", "mps"]:
+            if not isinstance(self._devices, int) and not (isinstance(self._devices, list) and all(isinstance(device, int) for device in self._devices)):
+                raise ValueError(f"devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got {self._devices}")
+        elif self._accelerator != "cpu":
+            raise ValueError(f"accelerator must be one of (cuda, mps, cpu), instead got {self._accelerator}")
+
     @property
     def accelerator(self):
         return self._accelerator

--- a/src/litserve/connector.py
+++ b/src/litserve/connector.py
@@ -44,8 +44,13 @@ class _Connector:
     def check_devices_and_accelerators(self):
         """Check if the devices are in a valid fomra and raise an error if they are not."""
         if self._accelerator in ["cuda", "mps"]:
-            if not isinstance(self._devices, int) and not (isinstance(self._devices, list) and all(isinstance(device, int) for device in self._devices)):
-                raise ValueError(f"devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got {self._devices}")
+            if not isinstance(self._devices, int) and not (
+                isinstance(self._devices, list) and all(isinstance(device, int) for device in self._devices)
+            ):
+                raise ValueError(
+                    "devices must be an integer or a list of integers when using 'cuda' or 'mps', "
+                    f"instead got {self._devices}"
+                )
         elif self._accelerator != "cpu":
             raise ValueError(f"accelerator must be one of (cuda, mps, cpu), instead got {self._accelerator}")
 

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -215,7 +215,6 @@ class LitServer:
 
         accelerator = self._connector.accelerator
         devices = self._connector.devices
-        print(f"accelerator: {accelerator}, devices: {devices}")
         if accelerator == "cpu":
             self.devices = [accelerator]
         elif accelerator in ["cuda", "mps"]:

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -215,6 +215,7 @@ class LitServer:
 
         accelerator = self._connector.accelerator
         devices = self._connector.devices
+        print(f"accelerator: {accelerator}, devices: {devices}")
         if accelerator == "cpu":
             self.devices = [accelerator]
         elif accelerator in ["cuda", "mps"]:
@@ -223,30 +224,8 @@ class LitServer:
                 device_list = range(devices)
             self.devices = [self.device_identifiers(accelerator, device) for device in device_list]
 
-        self.check_devices()
         self.inference_workers = self.devices * self.workers_per_device
         self.register_endpoints()
-
-    def check_devices(self):
-
-        def is_cuda_device(device):
-            import re
-            pattern = r'^cuda:\d+$'
-            return re.match(pattern, device) is not None
-
-        if not isinstance(self.devices, list):
-            devices = [self.devices]
-        else:
-            devices = self.devices
-
-        for device in devices:
-            if isinstance(device, list):
-                device = device[0]
-
-            if not isinstance(device, str):
-                raise ValueError("device must be a string")
-            elif device not in ["cpu", "cuda", "mps"] and not is_cuda_device(device):
-                raise ValueError(f"device must be one of 'cpu', 'cuda', 'mps', or 'cuda:<device_id>' but got {device}")
 
     def launch_inference_worker(self, num_uvicorn_servers: int):
         manager = mp.Manager()

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -223,8 +223,30 @@ class LitServer:
                 device_list = range(devices)
             self.devices = [self.device_identifiers(accelerator, device) for device in device_list]
 
+        self.check_devices()
         self.inference_workers = self.devices * self.workers_per_device
         self.register_endpoints()
+
+    def check_devices(self):
+
+        def is_cuda_device(device):
+            import re
+            pattern = r'^cuda:\d+$'
+            return re.match(pattern, device) is not None
+
+        if not isinstance(self.devices, list):
+            devices = [self.devices]
+        else:
+            devices = self.devices
+
+        for device in devices:
+            if isinstance(device, list):
+                device = device[0]
+
+            if not isinstance(device, str):
+                raise ValueError("device must be a string")
+            elif device not in ["cpu", "cuda", "mps"] and not is_cuda_device(device):
+                raise ValueError(f"device must be one of 'cpu', 'cuda', 'mps', or 'cuda:<device_id>' but got {device}")
 
     def launch_inference_worker(self, num_uvicorn_servers: int):
         manager = mp.Manager()

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -53,6 +53,9 @@ def test_device_identifiers(lifespan_mock, simple_litapi):
     assert server.devices[0][0] == "cuda:1"
     assert server.devices[1][0] == "cuda:2"
 
+    with pytest.raises(ValueError, match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got cpu"):
+        LitServer(simple_litapi, accelerator="cuda", devices="cpu", timeout=10)
+
 
 @pytest.mark.asyncio
 async def test_stream(simple_stream_api):

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -53,7 +53,9 @@ def test_device_identifiers(lifespan_mock, simple_litapi):
     assert server.devices[0][0] == "cuda:1"
     assert server.devices[1][0] == "cuda:2"
 
-    with pytest.raises(ValueError, match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got cpu"):
+    with pytest.raises(
+        ValueError, match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got cpu"
+    ):
         LitServer(simple_litapi, accelerator="cuda", devices="cpu", timeout=10)
 
 

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -53,9 +53,8 @@ def test_device_identifiers(lifespan_mock, simple_litapi):
     assert server.devices[0][0] == "cuda:1"
     assert server.devices[1][0] == "cuda:2"
 
-@pytest.mark.parametrize(
-"devices", ["cpu", ["cpu", "cuda:0"], ["cuda:a", "cuda:1"]]
-)
+
+@pytest.mark.parametrize("devices", ["cpu", ["cpu", "cuda:0"], ["cuda:a", "cuda:1"]])
 def test_device_identifiers_error(simple_litapi, devices):
     with pytest.raises(
         ValueError, match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got .*"

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -53,10 +53,14 @@ def test_device_identifiers(lifespan_mock, simple_litapi):
     assert server.devices[0][0] == "cuda:1"
     assert server.devices[1][0] == "cuda:2"
 
+@pytest.mark.parametrize(
+"devices", ["cpu", ["cpu", "cuda:0"], ["cuda:a", "cuda:1"]]
+)
+def test_device_identifiers_error(simple_litapi, devices):
     with pytest.raises(
-        ValueError, match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got cpu"
+        ValueError, match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got .*"
     ):
-        LitServer(simple_litapi, accelerator="cuda", devices="cpu", timeout=10)
+        LitServer(simple_litapi, accelerator="cuda", devices=devices, timeout=10)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->


## What does this PR do?

Adds a check in the lit server init to ensure device names are correct.
Before, a user could initialize a server like so
```
server = ls.LitServer(
        api, spec=ls.OpenAISpec(), devices="cpu"
    )
```
and this would result in a device list of
```
[['cuda:c'], ['cuda:p'], ['cuda:u']]
```
With this PR, we add a check which informs the user that these are invalid device names.
## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
