### PR TITLE
add continuous batching loop 1/n

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+## What does this PR do?
+
+Fixes # (issue).
+
+
 <details>
   <summary><b>Before submitting</b></summary>
 
@@ -23,9 +28,6 @@ PRs without this will not be merged.
 -->
 
 
-## What does this PR do?
-
-Fixes # (issue).
 
 ## PR review
 

--- a/src/litserve/__about__.py
+++ b/src/litserve/__about__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.2.6.dev0"
+__version__ = "0.2.6.dev1"
 __author__ = "Lightning-AI et al."
 __author_email__ = "community@lightning.ai"
 __license__ = "Apache-2.0"

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -114,6 +114,7 @@ class LitAPI(ABC):
         self._device = value
 
     def _sanitize(self, max_batch_size: int, spec: Optional[LitSpec]):
+        self.max_batch_size = max_batch_size
         if self.stream:
             self._default_unbatch = self._unbatch_stream
         else:

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -680,7 +680,6 @@ class ContinuousBatchingLoop(LitLoop):
 
                 # Check completion conditions
                 is_finished = token == lit_api.eos_token or seq["current_length"] >= self.max_sequence_length
-                is_finished = token == lit_api.eos_token or seq["current_length"] >= self.max_sequence_length
 
                 if is_finished:
                     # Encode final response for completed sequence

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -23,7 +23,6 @@ from queue import Empty, Queue
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import HTTPException
-from rich.progress import track
 from starlette.formparsers import MultiPartParser
 
 from litserve import LitAPI
@@ -697,10 +696,6 @@ class ContinuousBatchingLoop(LitLoop):
             self.active_sequences.clear()
             return responses
 
-    def request_finished(self, lit_api: LitAPI, lit_spec: Optional[LitSpec]) -> bool:
-        """Check if all sequences are processed."""
-        return len(self.active_sequences) == 0
-
     def prefill(
         self,
         pending_requests: List[Tuple[str, Any]],
@@ -777,7 +772,7 @@ class ContinuousBatchingLoop(LitLoop):
                 prev_outputs = responses
 
                 # Send responses for all sequences (both streaming and completed)
-                for step_output in track(responses, description="Processing responses"):
+                for step_output in responses:
                     logger.debug(f"Processing response: {step_output}")
                     status = step_output.status
                     response_data = step_output.output

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -20,7 +20,7 @@ import time
 from abc import ABC
 from dataclasses import dataclass
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import HTTPException
 from starlette.formparsers import MultiPartParser
@@ -29,9 +29,6 @@ from litserve import LitAPI
 from litserve.callbacks import CallbackRunner, EventTypes
 from litserve.specs.base import LitSpec
 from litserve.utils import LitAPIStatus, PickleableHTTPException, WorkerSetupStatus
-
-if TYPE_CHECKING:
-    pass
 
 mp.allow_connection_pickling()
 

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -619,16 +619,16 @@ class LitLoop(_BaseLoop):
 
 class ContinuousBatchingLoop(LitLoop):
     def add_request(self, uid: str, request: Any, lit_api: LitAPI, lit_spec: Optional[LitSpec]) -> None:
-        pass
+        raise NotImplementedError
 
     def step(self, lit_api: LitAPI, lit_spec: Optional[LitSpec]) -> List[Tuple[str, Tuple[Any, LitAPIStatus]]]:
-        pass
+        raise NotImplementedError
 
     def has_capacity(self, lit_api: LitAPI) -> bool:
-        pass
+        raise NotImplementedError
 
     def request_finished(self, lit_api: LitAPI, lit_spec: Optional[LitSpec]) -> bool:
-        pass
+        raise NotImplementedError
 
     def put_responses(
         self,

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -648,7 +648,12 @@ class ContinuousBatchingLoop(LitLoop):
 
     def has_capacity(self, lit_api: LitAPI) -> bool:
         """Check if we can add more sequences based on current batch."""
-        return len(self.active_sequences) < lit_api.max_batch_size
+        capacity = len(self.active_sequences) < lit_api.max_batch_size
+        if not capacity:
+            logger.info(
+                f"No capacity: {len(self.active_sequences)} active sequences, max batch size: {lit_api.max_batch_size}"
+            )
+        return capacity
 
     def step(
         self, prev_outputs: Optional[List[StepOutput]], lit_api: LitAPI, lit_spec: Optional[LitSpec]

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -679,7 +679,7 @@ class ContinuousBatchingLoop(LitLoop):
                 seq["current_length"] += 1
 
                 # Check completion conditions
-                is_finished = token == lit_api.eos_token or seq["current_length"] >= self.max_sequence_length
+                is_finished = lit_api.is_finished(uid, token, self.max_sequence_length)
 
                 if is_finished:
                     # Encode final response for completed sequence

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -19,7 +19,7 @@ import sys
 import time
 from abc import ABC
 from queue import Empty, Queue
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import HTTPException
 from starlette.formparsers import MultiPartParser
@@ -571,6 +571,89 @@ class BatchedStreamingLoop(_BaseLoop):
             batch_timeout,
             callback_runner,
         )
+
+def notify_timed_out_requests(response_queues: List[Queue], timed_out_uids: List[Tuple[int, str]], ):
+    for response_queue_id, uid in timed_out_uids:
+        logger.error(f"Request {uid} was waiting in the queue for too long and has been timed out.")
+        response_queues[response_queue_id].put((uid, (HTTPException(504, "Request timed out"), LitAPIStatus.ERROR)))
+
+class LitLoop(_BaseLoop):
+    def __init__(self):
+        self._context = {}
+
+    def get_batch_requests(self, lit_api: LitAPI, request_queue: Queue, max_batch_size: int, batch_timeout: float):
+        if max_batch_size <= 1:
+            raise ValueError("max_batch_size must be greater than 1")
+
+        batches, timed_out_uids = collate_requests(
+            lit_api,
+            request_queue,
+            max_batch_size,
+            batch_timeout,
+        )
+        return batches, timed_out_uids
+
+    def get_request(self, request_queue: Queue, timeout: float=1.0):
+        response_queue_id, uid, timestamp, x_enc = request_queue.get(timeout=timeout)
+        return response_queue_id, uid, timestamp, x_enc
+    
+    def populate_context(self, lit_spec: LitSpec, request: Any):
+        if lit_spec and hasattr(lit_spec, "populate_context"):
+            lit_spec.populate_context(self._context, request)
+
+    def put_response(self, response_queues: List[Queue], response_queue_id: int, uid: str, response_data: Any, status: LitAPIStatus)->None:
+        response_queues[response_queue_id].put((uid, (response_data, status)))
+
+    def put_error_response(self, response_queues: List[Queue], response_queue_id: int, uid: str, error: Exception)->None:
+        response_queues[response_queue_id].put((uid, (error, LitAPIStatus.ERROR)))
+
+class ContinuousBatchingLoop(LitLoop):
+    def add_request(self, uid: str, request: Any, lit_api: LitAPI, lit_spec: Optional[LitSpec])->None:
+        pass
+
+    def step(self, lit_api: LitAPI, lit_spec: Optional[LitSpec])-> List[Tuple[str, Tuple[Any, LitAPIStatus]]]:
+        pass
+    
+    def has_capacity(self, lit_api: LitAPI)-> bool:
+        pass
+
+    def request_finished(self, lit_api: LitAPI, lit_spec: Optional[LitSpec])-> bool:
+        pass
+
+    def put_responses(self, response_queues: List[Queue], response_queue_ids: List[int], responses: List[Tuple[str, Tuple[Any, LitAPIStatus]]])->None:
+        for response_queue_id, response in zip(response_queue_ids, responses):
+            uid, (response_data, status) = response
+            print(f"Putting response {response_data} with status {status} for uid {uid}")
+            if status == LitAPIStatus.ERROR:
+                logger.exception(f"Error processing request {response_data}")
+                self.put_error_response(response_queues, response_queue_id, uid, response_data)
+            else:
+                self.put_response(response_queues, response_queue_id, uid, response_data, status)
+
+    
+
+    def loop(self, response_queue_ids: List[int], uids: List[str], inputs: List[Any], lit_api: LitAPI, lit_spec: Optional[LitSpec], device: str, worker_id: int, request_queue: Queue, response_queues: List[Queue], max_batch_size: int, batch_timeout: float, stream: bool, workers_setup_status: Dict[int, str], callback_runner: CallbackRunner):
+        while True:
+            if self.has_capacity(lit_api) and len(inputs) > 0:
+                input = inputs.pop(0)
+                uid = uids.pop(0)
+                input = lit_api.decode_request(input)
+                self.add_request(uid, input, lit_api, lit_spec)  # Adds the request to the batch
+
+            responses = self.step(lit_api, lit_spec)  # Returns a list of (uid, (response_data, status))
+            self.put_responses(response_queues, response_queue_ids, responses)
+            if self.request_finished(lit_api, lit_spec) and len(inputs) == 0:
+                break
+
+    def run(self, lit_api: LitAPI, lit_spec: Optional[LitSpec], device: str, worker_id: int, request_queue: Queue, response_queues: List[Queue], max_batch_size: int, batch_timeout: float, stream: bool, workers_setup_status: Dict[int, str], callback_runner: CallbackRunner):
+        batches, timed_out_uids = self.get_batch_requests(lit_api, request_queue, max_batch_size, batch_timeout)
+
+        notify_timed_out_requests(response_queues, timed_out_uids)
+        if batches:
+            response_queue_ids, uids, inputs = zip(*batches)
+            self.populate_context(lit_spec, inputs)
+            self.loop(response_queue_ids, list(uids), list(inputs), lit_api, lit_spec, device, worker_id, request_queue, response_queues, max_batch_size, batch_timeout, stream, workers_setup_status, callback_runner)
+
 
 
 def inference_worker(


### PR DESCRIPTION
## What does this PR do?

Allow users to quickly write a customizable continuous batching loop.

This is one of the first PRs to add a simple continuous batching loop and subjected to change till we are in `0.2.6.dev*`. I will be making multiple PRs to clean this up and add tests. 

### Example with vLLM engine

```python
from vllm import LLMEngine, EngineArgs, SamplingParams
from litserve.loops import ContinuousBatchingLoop, Output
from litserve.utils import LitAPIStatus
import litserve as ls

class LitVLLM(ls.LitAPI):
    def setup(self, device):
        engine_args = EngineArgs(model="meta-llama/Llama-3.2-1B", device=device, max_model_len=2048)
        self.engine = LLMEngine.from_engine_args(engine_args)

    def decode_request(self, request: dict) -> dict:
        return request

    def predict(self, x):
        # vLLM engine.generate is called in the loop
        yield x

    def encode_response(self, x: str):
        yield x


class vLLMLoop(ContinuousBatchingLoop):
    def __init__(self, max_sequence_length: int = 2048):
        super().__init__(max_sequence_length)
        self.uids = {}  # Maps vLLM request_id (str) to original uid

    def add_request(self, uid: str, request, lit_api: vLLMAPI, lit_spec) -> None:
        super().add_request(uid, request, lit_api, lit_spec)
        request_id = str(uid)
        sampling_params = SamplingParams(
            temperature=request.get("temperature", 0.0),
            max_tokens=request.get("max_tokens", 10)
        )
        lit_api.engine.add_request(
            request_id=request_id,
            prompt=request["prompt"],
            params=sampling_params
        )
        self.uids[request_id] = uid

    def step(self, prev_outputs, lit_api: vLLMAPI, lit_spec):
        request_outputs = lit_api.engine.step()
        outputs = []
        
        for request_output in request_outputs:
            if request_output.request_id not in self.uids:
                continue

            original_uid = self.uids[request_output.request_id]
            token_id = request_output.outputs[0].token_ids[-1]
            output = lit_api.engine.get_tokenizer().decode([token_id])
            outputs.append(Output(
                uid=original_uid,
                output=output,
                status=LitAPIStatus.OK
            ))

            if request_output.finished:
                outputs.append(Output(
                    uid=original_uid,
                    output="",
                    status=LitAPIStatus.FINISH_STREAMING
                ))
                del self.uids[request_output.request_id]

        return outputs

if __name__ == "__main__":
    loop = vLLMLoop()
    api = LitVLLM()
    server = ls.LitServer(api, loop=loop, max_batch_size=4, stream=True, timeout=-1)
    server.run()
```


Result of 4 concurrent requests: 

https://github.com/user-attachments/assets/08a8a88f-1179-4a71-9284-730282c2db0b


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
