### PR TITLE
improved logging with sensible defaults

### DIFF
--- a/src/litserve/__init__.py
+++ b/src/litserve/__init__.py
@@ -18,6 +18,9 @@ from litserve.callbacks import Callback
 from litserve.loggers import Logger
 from litserve.server import LitServer, Request, Response
 from litserve.specs import OpenAIEmbeddingSpec, OpenAISpec
+from litserve.utils import configure_logging
+
+configure_logging()
 
 __all__ = [
     "LitAPI",

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -15,6 +15,7 @@ import asyncio
 import dataclasses
 import logging
 import pickle
+import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, AsyncIterator
 
@@ -87,3 +88,46 @@ class WorkerSetupStatus:
     READY: str = "ready"
     ERROR: str = "error"
     FINISHED: str = "finished"
+
+
+def configure_logging(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", stream=sys.stdout
+):
+    """Configure logging for the entire library with sensible defaults.
+
+    Args:
+        level (int): Logging level (default: logging.INFO)
+        format (str): Log message format string
+        stream (file-like): Output stream for logs
+
+    """
+    # Create a library-wide handler
+    handler = logging.StreamHandler(stream)
+
+    # Set formatter with user-configurable format
+    formatter = logging.Formatter(format)
+    handler.setFormatter(formatter)
+
+    # Configure root library logger
+    library_logger = logging.getLogger("litserve")
+    library_logger.setLevel(level)
+    library_logger.addHandler(handler)
+
+    # Prevent propagation to root logger to avoid duplicate logs
+    library_logger.propagate = False
+
+
+def set_log_level(level):
+    """Allow users to set the global logging level for the library."""
+    logging.getLogger("litserve").setLevel(level)
+
+
+def add_log_handler(handler):
+    """Allow users to add custom log handlers.
+
+    Example usage:
+    file_handler = logging.FileHandler('library_logs.log')
+    add_log_handler(file_handler)
+
+    """
+    logging.getLogger("litserve").addHandler(handler)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,60 @@
+import io
+import logging
+
+import pytest
+
+from litserve.utils import add_log_handler, configure_logging, set_log_level
+
+
+@pytest.fixture
+def log_stream():
+    return io.StringIO()
+
+
+def test_configure_logging(log_stream):
+    # Configure logging with test stream
+    configure_logging(level=logging.DEBUG, stream=log_stream)
+
+    # Get logger and log a test message
+    logger = logging.getLogger("litserve")
+    test_message = "Test debug message"
+    logger.debug(test_message)
+
+    # Verify log output
+    log_contents = log_stream.getvalue()
+    assert test_message in log_contents
+    assert "DEBUG" in log_contents
+    assert logger.propagate is False
+
+
+def test_set_log_level():
+    # Set log level to WARNING
+    set_log_level(logging.WARNING)
+
+    # Verify logger level
+    logger = logging.getLogger("litserve")
+    assert logger.level == logging.WARNING
+
+
+def test_add_log_handler():
+    # Create and add a custom handler
+    stream = io.StringIO()
+    custom_handler = logging.StreamHandler(stream)
+    add_log_handler(custom_handler)
+
+    # Verify handler is added
+    logger = logging.getLogger("litserve")
+    assert custom_handler in logger.handlers
+
+    # Test the handler works
+    test_message = "Test handler message"
+    logger.info(test_message)
+    assert test_message in stream.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_logger():
+    yield
+    logger = logging.getLogger("litserve")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)


### PR DESCRIPTION
## What does this PR do?

Users can set their own logging level and format using the `ls.configure_logging(logging.DEBUG)` function.

Fixes https://github.com/Lightning-AI/LitServe/pull/389#issuecomment-2528594260

### Before
![image](https://github.com/user-attachments/assets/3a015551-08c8-40c4-87a7-f2febdecb403)

### After
<img width="1338" alt="image" src="https://github.com/user-attachments/assets/1e7fc8ce-e69c-453e-8d3e-90b708be6e34">


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
