### PR TITLE
Add image size control in openai.py

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -75,6 +75,8 @@ class ImageContentURL(BaseModel):
 class ImageContent(BaseModel):
     type: str
     image_url: Union[str, ImageContentURL]
+    resized_height: Optional[int] = None
+    resized_width: Optional[int] = None
 
 
 class Function(BaseModel):


### PR DESCRIPTION

When using litserve with a multimodal model （Qwen2-VL）, add resized_height and resized_width parameters to control the image size and prevent out-of-memory (OOM) issues. However, this feature does not work as expected.
:
```
messages=[
            {
                "role": "user",
                "content": [
                    {"type": "text", "text": prompt},
                    {
                        "type": "image",
                        "image_url": image_url,
                        "resized_height": 280,
                        "resized_width": 420
                    },
                ],
            }
        ],
```
This pr add the option params `resized_height` and `resized_width` to the `ImageContent`
```
class ImageContent(BaseModel):
    type: str
    image_url: Union[str, ImageContentURL]
    resized_height: Optional[int] = None
    resized_width: Optional[int] = None
```
And this modification does not affect the existing interface.
The key words  `resized_height` and `resized_width` are from Qwen2-VL package `qwen-vl-utils`:
[https://github.com/QwenLM/Qwen2-VL/blob/9806089cd7ebc341c3a77556e9cb18d2005853ad/qwen-vl-utils/src/qwen_vl_utils/vision_process.py#L105](https://github.com/QwenLM/Qwen2-VL/blob/9806089cd7ebc341c3a77556e9cb18d2005853ad/qwen-vl-utils/src/qwen_vl_utils/vision_process.py#L105)

## What does this PR do?

Fixes # (issue).


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
