### PR TITLE
Add `loop.pre_setup` to allow fine-grained LitAPI validation based on inference loop

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -119,15 +119,6 @@ class LitAPI(ABC):
         else:
             self._default_unbatch = self._unbatch_no_stream
 
-        # we will sanitize regularly if no spec
-        # in case, we have spec then:
-        # case 1: spec implements a streaming API
-        # Case 2: spec implements a non-streaming API
-        if spec:
-            # TODO: Implement sanitization
-            self._spec = spec
-            return
-
     def set_logger_queue(self, queue: Queue):
         """Set the queue for logging events."""
 

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -24,6 +24,7 @@ from litserve.specs.base import LitSpec
 
 class LitAPI(ABC):
     _stream: bool = False
+    _max_batch_size: int = 1
     _default_unbatch: callable = None
     _spec: LitSpec = None
     _device: Optional[str] = None
@@ -112,12 +113,23 @@ class LitAPI(ABC):
     def device(self, value):
         self._device = value
 
+    @property
+    def max_batch_size(self):
+        return self._max_batch_size
+
+    @max_batch_size.setter
+    def max_batch_size(self, value):
+        self._max_batch_size = value
+
     def pre_setup(self, max_batch_size: int, spec: Optional[LitSpec]):
         self.max_batch_size = max_batch_size
         if self.stream:
             self._default_unbatch = self._unbatch_stream
         else:
             self._default_unbatch = self._unbatch_no_stream
+
+        if spec:
+            self._spec = spec
 
     def set_logger_queue(self, queue: Queue):
         """Set the queue for logging events."""

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -24,7 +24,6 @@ from litserve.specs.base import LitSpec
 
 class LitAPI(ABC):
     _stream: bool = False
-    _max_batch_size: int = 1
     _default_unbatch: callable = None
     _spec: LitSpec = None
     _device: Optional[str] = None
@@ -112,14 +111,6 @@ class LitAPI(ABC):
     @device.setter
     def device(self, value):
         self._device = value
-
-    @property
-    def max_batch_size(self):
-        return self._max_batch_size
-
-    @max_batch_size.setter
-    def max_batch_size(self, value):
-        self._max_batch_size = value
 
     def pre_setup(self, max_batch_size: int, spec: Optional[LitSpec]):
         self.max_batch_size = max_batch_size

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -441,6 +441,9 @@ class _BaseLoop(ABC):
 
     """
 
+    def pre_setup(self, lit_api: LitAPI, spec: Optional[LitSpec]):
+        pass
+
     def __call__(
         self,
         lit_api: LitAPI,
@@ -487,7 +490,65 @@ class _BaseLoop(ABC):
         raise NotImplementedError
 
 
-class SingleLoop(_BaseLoop):
+class DefaultLoop(_BaseLoop):
+    def pre_setup(self, lit_api: LitAPI, spec: Optional[LitSpec]):
+        original = lit_api.unbatch.__code__ is LitAPI.unbatch.__code__
+        if (
+            lit_api.stream
+            and lit_api.max_batch_size > 1
+            and not all([
+                inspect.isgeneratorfunction(lit_api.predict),
+                inspect.isgeneratorfunction(lit_api.encode_response),
+                (original or inspect.isgeneratorfunction(lit_api.unbatch)),
+            ])
+        ):
+            raise ValueError(
+                """When `stream=True` with max_batch_size > 1, `lit_api.predict`, `lit_api.encode_response` and
+                `lit_api.unbatch` must generate values using `yield`.
+
+             Example:
+
+                def predict(self, inputs):
+                    ...
+                    for i in range(max_token_length):
+                        yield prediction
+
+                def encode_response(self, outputs):
+                    for output in outputs:
+                        encoded_output = ...
+                        yield encoded_output
+
+                def unbatch(self, outputs):
+                    for output in outputs:
+                        unbatched_output = ...
+                        yield unbatched_output
+             """
+            )
+
+        if lit_api.stream and not all([
+            inspect.isgeneratorfunction(lit_api.predict),
+            inspect.isgeneratorfunction(lit_api.encode_response),
+        ]):
+            raise ValueError(
+                """When `stream=True` both `lit_api.predict` and
+             `lit_api.encode_response` must generate values using `yield`.
+
+             Example:
+
+                def predict(self, inputs):
+                    ...
+                    for i in range(max_token_length):
+                        yield prediction
+
+                def encode_response(self, outputs):
+                    for output in outputs:
+                        encoded_output = ...
+                        yield encoded_output
+             """
+            )
+
+
+class SingleLoop(DefaultLoop):
     def __call__(
         self,
         lit_api: LitAPI,
@@ -505,7 +566,7 @@ class SingleLoop(_BaseLoop):
         run_single_loop(lit_api, lit_spec, request_queue, response_queues, callback_runner)
 
 
-class BatchedLoop(_BaseLoop):
+class BatchedLoop(DefaultLoop):
     def __call__(
         self,
         lit_api: LitAPI,
@@ -531,7 +592,7 @@ class BatchedLoop(_BaseLoop):
         )
 
 
-class StreamingLoop(_BaseLoop):
+class StreamingLoop(DefaultLoop):
     def __call__(
         self,
         lit_api: LitAPI,
@@ -549,7 +610,7 @@ class StreamingLoop(_BaseLoop):
         run_streaming_loop(lit_api, lit_spec, request_queue, response_queues, callback_runner)
 
 
-class BatchedStreamingLoop(_BaseLoop):
+class BatchedStreamingLoop(DefaultLoop):
     def __call__(
         self,
         lit_api: LitAPI,
@@ -840,15 +901,7 @@ def inference_worker(
         logging.info(f"LitServe will use {lit_spec.__class__.__name__} spec")
 
     if loop == "auto":
-        loop = (
-            BatchedStreamingLoop()
-            if stream and max_batch_size > 1
-            else StreamingLoop()
-            if stream
-            else BatchedLoop()
-            if max_batch_size > 1
-            else SingleLoop()
-        )
+        loop = get_default_loop(stream, max_batch_size)
 
     loop(
         lit_api,
@@ -862,4 +915,16 @@ def inference_worker(
         stream,
         workers_setup_status,
         callback_runner,
+    )
+
+
+def get_default_loop(stream: bool, max_batch_size: int) -> _BaseLoop:
+    return (
+        BatchedStreamingLoop()
+        if stream and max_batch_size > 1
+        else StreamingLoop()
+        if stream
+        else BatchedLoop()
+        if max_batch_size > 1
+        else SingleLoop()
     )

--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -492,6 +492,15 @@ class _BaseLoop(ABC):
 
 class DefaultLoop(_BaseLoop):
     def pre_setup(self, lit_api: LitAPI, spec: Optional[LitSpec]):
+        # we will sanitize regularly if no spec
+        # in case, we have spec then:
+        # case 1: spec implements a streaming API
+        # Case 2: spec implements a non-streaming API
+        if spec:
+            # TODO: Implement sanitization
+            lit_api._spec = spec
+            return
+
         original = lit_api.unbatch.__code__ is LitAPI.unbatch.__code__
         if (
             lit_api.stream

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -40,7 +40,7 @@ from litserve import LitAPI
 from litserve.callbacks.base import Callback, CallbackRunner, EventTypes
 from litserve.connector import _Connector
 from litserve.loggers import Logger, _LoggerConnector
-from litserve.loops import _BaseLoop, get_default_loop, inference_worker
+from litserve.loops import LitLoop, get_default_loop, inference_worker
 from litserve.middlewares import MaxSizeMiddleware, RequestCountMiddleware
 from litserve.python_client import client_template
 from litserve.specs import OpenAISpec
@@ -113,7 +113,7 @@ class LitServer:
         spec: Optional[LitSpec] = None,
         max_payload_size=None,
         track_requests: bool = False,
-        loop: Optional[Union[str, _BaseLoop]] = "auto",
+        loop: Optional[Union[str, LitLoop]] = "auto",
         callbacks: Optional[Union[List[Callback], Callback]] = None,
         middlewares: Optional[list[Union[Callable, tuple[Callable, dict]]]] = None,
         loggers: Optional[Union[Logger, List[Logger]]] = None,
@@ -200,7 +200,7 @@ class LitServer:
                 "but the max_batch_size parameter was not set."
             )
 
-        self._loop = loop
+        self._loop: LitLoop = loop
         self.api_path = api_path
         self.healthcheck_path = healthcheck_path
         self.info_path = info_path

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -154,7 +154,7 @@ def test_max_batch_size_warning():
 
 def test_batch_predict_string_warning():
     api = ls.test_examples.SimpleBatchedAPI()
-    api._sanitize(2, None)
+    api.pre_setup(2, None)
     api.predict = MagicMock(return_value="This is a string")
 
     mock_input = torch.tensor([[1.0], [2.0]])

--- a/tests/test_litapi.py
+++ b/tests/test_litapi.py
@@ -65,7 +65,7 @@ class TestStreamAPI(ls.LitAPI):
 
 def test_default_batch_unbatch():
     api = TestDefaultBatchedAPI()
-    api._sanitize(max_batch_size=4, spec=None)
+    api.pre_setup(max_batch_size=4, spec=None)
     inputs = [1, 2, 3, 4]
     output = api.batch(inputs)
     assert output == inputs, "Default batch should not change input"
@@ -81,7 +81,7 @@ class TestStreamAPIBatched(TestStreamAPI):
 def test_default_batch_unbatch_stream():
     api = TestStreamAPIBatched()
     api.stream = True
-    api._sanitize(max_batch_size=4, spec=None)
+    api.pre_setup(max_batch_size=4, spec=None)
     inputs = [1, 2, 3, 4]
     expected_output = [[0, 0, 0, 0], [1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12]]
     output = api.batch(inputs)
@@ -93,7 +93,7 @@ def test_default_batch_unbatch_stream():
 
 def test_custom_batch_unbatch():
     api = TestCustomBatchedAPI()
-    api._sanitize(max_batch_size=4, spec=None)
+    api.pre_setup(max_batch_size=4, spec=None)
     inputs = [1, 2, 3, 4]
     output = api.batch(inputs)
     assert np.all(output == np.array(inputs)), "Custom batch stacks input as numpy array"
@@ -102,7 +102,7 @@ def test_custom_batch_unbatch():
 
 def test_batch_unbatch_stream():
     api = TestStreamAPI()
-    api._sanitize(max_batch_size=4, spec=None)
+    api.pre_setup(max_batch_size=4, spec=None)
     inputs = [1, 2, 3, 4]
     output = api.batch(inputs)
     output = api.predict(output)
@@ -128,7 +128,7 @@ def test_decode_request():
 
 def test_decode_request_with_openai_spec():
     api = ls.test_examples.TestAPI()
-    api._sanitize(max_batch_size=1, spec=ls.OpenAISpec())
+    api.pre_setup(max_batch_size=1, spec=ls.OpenAISpec())
     request = ChatCompletionRequest(messages=[{"role": "system", "content": "Hello"}])
     decoded_request = api.decode_request(request)
     assert decoded_request[0]["content"] == "Hello", "Decode request should return the input message"
@@ -136,7 +136,7 @@ def test_decode_request_with_openai_spec():
 
 def test_decode_request_with_openai_spec_wrong_request():
     api = ls.test_examples.TestAPI()
-    api._sanitize(max_batch_size=1, spec=ls.OpenAISpec())
+    api.pre_setup(max_batch_size=1, spec=ls.OpenAISpec())
     with pytest.raises(AttributeError, match="object has no attribute 'messages'"):
         api.decode_request({"input": "Hello"})
 
@@ -149,7 +149,7 @@ def test_encode_response():
 
 def test_encode_response_with_openai_spec():
     api = ls.test_examples.TestAPI()
-    api._sanitize(max_batch_size=1, spec=ls.OpenAISpec())
+    api.pre_setup(max_batch_size=1, spec=ls.OpenAISpec())
     response = "This is a LLM generated text".split()
     generated_tokens = []
     for output in api.encode_response(response):
@@ -166,7 +166,7 @@ def test_encode_response_with_openai_spec_dict_token_usage():
 
     generated_tokens = []
     api = ls.test_examples.TestAPI()
-    api._sanitize(max_batch_size=1, spec=ls.OpenAISpec())
+    api.pre_setup(max_batch_size=1, spec=ls.OpenAISpec())
 
     for output in api.encode_response(predict()):
         assert output["role"] == "assistant", "Role should be assistant"
@@ -181,7 +181,7 @@ def test_encode_response_with_custom_spec_api():
                 yield {"content": output}
 
     api = ls.test_examples.TestAPI()
-    api._sanitize(max_batch_size=1, spec=CustomSpecAPI())
+    api.pre_setup(max_batch_size=1, spec=CustomSpecAPI())
     response = "This is a LLM generated text".split()
     generated_tokens = []
     for output in api.encode_response(response):
@@ -191,7 +191,7 @@ def test_encode_response_with_custom_spec_api():
 
 def test_encode_response_with_openai_spec_invalid_input():
     api = ls.test_examples.TestAPI()
-    api._sanitize(max_batch_size=1, spec=ls.OpenAISpec())
+    api.pre_setup(max_batch_size=1, spec=ls.OpenAISpec())
     response = 10
     with pytest.raises(TypeError, match="object is not iterable"):
         next(api.encode_response(response))
@@ -202,7 +202,7 @@ def test_encode_response_with_openai_spec_invalid_predict_output():
         yield {"hello": "world"}
 
     api = ls.test_examples.TestAPI()
-    api._sanitize(max_batch_size=1, spec=ls.OpenAISpec())
+    api.pre_setup(max_batch_size=1, spec=ls.OpenAISpec())
     with pytest.raises(HTTPException, match=r"Malformed output from LitAPI.predict"):
         next(api.encode_response(predict()))
 

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -479,3 +479,19 @@ def test_loop_with_server():
     with wrap_litserve_start(server) as server, TestClient(server.app) as client:
         response = client.post("/predict", json={"input": 4.0})
         assert response.json() == {"output": 1600.0}  # use LitAPI.load_cache to multiply the input by 10
+
+
+def test_get_default_loop():
+    loop = ls.loops.get_default_loop(stream=False, max_batch_size=1)
+    assert isinstance(loop, ls.loops.SingleLoop), "SingleLoop must be returned when stream=False"
+
+    loop = ls.loops.get_default_loop(stream=False, max_batch_size=4)
+    assert isinstance(loop, ls.loops.BatchedLoop), "BatchedLoop must be returned when stream=False and max_batch_size>1"
+
+    loop = ls.loops.get_default_loop(stream=True, max_batch_size=1)
+    assert isinstance(loop, ls.loops.StreamingLoop), "StreamingLoop must be returned when stream=True"
+
+    loop = ls.loops.get_default_loop(stream=True, max_batch_size=4)
+    assert isinstance(loop, ls.loops.BatchedStreamingLoop), (
+        "BatchedStreamingLoop must be returned when stream=True and max_batch_size>1"
+    )

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -258,7 +258,7 @@ def test_run_single_loop_timeout():
 def test_run_batched_loop():
     lit_api = ls.test_examples.SimpleBatchedAPI()
     lit_api.setup(None)
-    lit_api._sanitize(2, None)
+    lit_api.pre_setup(2, None)
     assert lit_api.model is not None, "Setup must initialize the model"
     lit_api.request_timeout = 1
 
@@ -292,7 +292,7 @@ def test_run_batched_loop_timeout():
     ls.configure_logging(stream=stream)
     lit_api = ls.test_examples.SimpleBatchedAPI()
     lit_api.setup(None)
-    lit_api._sanitize(2, None)
+    lit_api.pre_setup(2, None)
     assert lit_api.model is not None, "Setup must initialize the model"
     lit_api.request_timeout = 0.1
 
@@ -388,7 +388,7 @@ def off_test_run_batched_streaming_loop(openai_request_data):
     lit_api.request_timeout = 1
     lit_api.stream = True
     spec = ls.OpenAISpec()
-    lit_api._sanitize(2, spec)
+    lit_api.pre_setup(2, spec)
 
     request_queue = Queue()
     # response_queue_id, uid, timestamp, x_enc


### PR DESCRIPTION
## What does this PR do?

This PR allows fine-grained validation of LitAPI based on inference loop. 

Default loops - will have the same validation as of now but new inference loops such as continuous batching will be able to add more validations such as check `lit_api.predict_start` method exists and won't force a global structure of validation. 


For example, the following example will fail with the current global validation and forces to implement predict as generator:

```python
from vllm import LLMEngine, EngineArgs, SamplingParams
from litserve.loops import ContinuousBatchingLoop, Output
from litserve.utils import LitAPIStatus
import litserve as ls

class LitVLLM(ls.LitAPI):
    def setup(self, device):
        engine_args = EngineArgs(model="meta-llama/Llama-3.2-1B", device=device, max_model_len=2048)
        self.engine = LLMEngine.from_engine_args(engine_args)

    def decode_request(self, request: dict) -> dict:
        return request

class vLLMLoop(ContinuousBatchingLoop):
    def __init__(self, max_sequence_length: int = 2048):
        super().__init__(max_sequence_length)
        self.uids = {}  # Maps vLLM request_id (str) to original uid

    def add_request(self, uid: str, request, lit_api: LitVLLM, lit_spec) -> None:
        super().add_request(uid, request, lit_api, lit_spec)
        request_id = str(uid)
        sampling_params = SamplingParams(
            temperature=request.get("temperature", 0.0),
            max_tokens=request.get("max_tokens", 10)
        )
        lit_api.engine.add_request(
            request_id=request_id,
            prompt=request["prompt"],
            params=sampling_params
        )
        self.uids[request_id] = uid

    def step(self, prev_outputs, lit_api: vLLMAPI, lit_spec):
        request_outputs = lit_api.engine.step()
        outputs = []

        for request_output in request_outputs:
            if request_output.request_id not in self.uids:
                continue

            original_uid = self.uids[request_output.request_id]
            token_id = request_output.outputs[0].token_ids[-1]
            output = lit_api.engine.get_tokenizer().decode([token_id])
            outputs.append(Output(
                uid=original_uid,
                output=output,
                status=LitAPIStatus.OK
            ))

            if request_output.finished:
                outputs.append(Output(
                    uid=original_uid,
                    output="",
                    status=LitAPIStatus.FINISH_STREAMING
                ))
                del self.uids[request_output.request_id]

        return outputs

if __name__ == "__main__":
    loop = vLLMLoop()
    api = LitVLLM()
    server = ls.LitServer(api, loop=loop, max_batch_size=4, stream=True, timeout=-1)
    server.run()
```


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
