### PR TITLE
Fix OpenAISpec with continuous batching loop

### DIFF
--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -756,7 +756,7 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
 
     def mark_completed(self, uid: str) -> None:
         """Mark a request as completed and remove it from the tracked state."""
-        logger.info(f"Marking sequence {uid} as completed")
+        logger.debug(f"Marking sequence {uid} as completed")
         del self.active_sequences[uid]
         del self.response_queue_ids[uid]
 
@@ -839,7 +839,7 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
             if new_batches:
                 # Add new requests to pending_requests and try to process them
                 for response_queue_id, uid, input in new_batches:
-                    logger.info(f"New request: {uid}, {input}")
+                    logger.debug(f"New request: {uid}, {input}")
                     if self.has_capacity(lit_api):
                         self.add_request(uid, input, lit_api, lit_spec)
                         self.response_queue_ids[uid] = response_queue_id
@@ -892,6 +892,7 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
                     uid = step_output.uid
                     response_queue_id = self.response_queue_ids[uid]
 
+                    response_data = lit_api.format_encoded_response(response_data)
                     if status == LitAPIStatus.ERROR:
                         self.put_error_response(response_queues, response_queue_id, uid, response_data)
                         self.mark_completed(uid)


### PR DESCRIPTION
## What does this PR do?

OpenAI Spec endpoints requires the inference worker response to be of type JSON `str`. This PR, formats the encoded_response before putting them in the queue. 


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
