### PR TITLE
fix openai usage info for non-streaming response

### DIFF
--- a/src/litserve/loops.py
+++ b/src/litserve/loops.py
@@ -919,6 +919,7 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
             for uid, response_queue_id in self.response_queue_ids.items():
                 self.put_error_response(response_queues, response_queue_id, uid, e)
             self.response_queue_ids.clear()
+            self.active_sequences.clear()
 
 
 def inference_worker(

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -443,6 +443,7 @@ class OpenAISpec(LitSpec):
                 logger.debug(encoded_response)
                 chat_msg = ChatMessage(**encoded_response)
                 usage = UsageInfo(**encoded_response)
+                usage_infos.append(usage)  # Aggregate usage info across all choices
                 msgs.append(chat_msg.content)
                 if chat_msg.tool_calls:
                     tool_calls = chat_msg.tool_calls
@@ -451,6 +452,5 @@ class OpenAISpec(LitSpec):
             msg = {"role": "assistant", "content": content, "tool_calls": tool_calls}
             choice = ChatCompletionResponseChoice(index=i, message=msg, finish_reason="stop")
             choices.append(choice)
-            usage_infos.append(usage)  # Only use the last item from encode_response
 
         return ChatCompletionResponse(model=model, choices=choices, usage=sum(usage_infos))


### PR DESCRIPTION
## What does this PR do?

Aggregate the usage_info for all the generations properly in case of non-streaming response. 

In current main branch, UsageInfo for the following code will return `completion tokens=1` which is incorrect and it should aggregate all the usage infos. This PR fixes that. 

```py
class OpenAIWithUsagePerToken(ls.LitAPI):
    def setup(self, device):
        self.model = None

    def predict(self, x):
        for i in range(1, 6):
            yield {
                "role": "assistant",
                "content": f"{i}",
                "prompt_tokens": 0,
                "completion_tokens": 1,
                "total_tokens": 1,
            }
```

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
