### PR TITLE
warn users when predict/unbatch output length is not same as  #requests

### DIFF
--- a/src/litserve/__about__.py
+++ b/src/litserve/__about__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.2.6"
+__version__ = "0.2.6.dev3"
 __author__ = "Lightning-AI et al."
 __author_email__ = "community@lightning.ai"
 __license__ = "Apache-2.0"

--- a/src/litserve/__about__.py
+++ b/src/litserve/__about__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.2.6.dev2"
+__version__ = "0.2.6"
 __author__ = "Lightning-AI et al."
 __author_email__ = "community@lightning.ai"
 __license__ = "Apache-2.0"

--- a/src/litserve/loops/simple_loops.py
+++ b/src/litserve/loops/simple_loops.py
@@ -213,7 +213,7 @@ def run_batched_loop(
             y_enc_list = []
             for response_queue_id, y, uid, context in zip(response_queue_ids, outputs, uids, contexts):
                 y_enc = _inject_context(context, lit_api.encode_response, y)
-            y_enc_list.append((response_queue_id, uid, y_enc))
+                y_enc_list.append((response_queue_id, uid, y_enc))
             callback_runner.trigger_event(EventTypes.AFTER_ENCODE_RESPONSE, lit_api=lit_api)
 
             for response_queue_id, uid, y_enc in y_enc_list:

--- a/src/litserve/loops/simple_loops.py
+++ b/src/litserve/loops/simple_loops.py
@@ -209,15 +209,15 @@ def run_batched_loop(
                 )
                 raise HTTPException(500, "Batch size mismatch")
 
-                callback_runner.trigger_event(EventTypes.BEFORE_ENCODE_RESPONSE, lit_api=lit_api)
-                y_enc_list = []
-                for response_queue_id, y, uid, context in zip(response_queue_ids, outputs, uids, contexts):
-                    y_enc = _inject_context(context, lit_api.encode_response, y)
-                y_enc_list.append((response_queue_id, uid, y_enc))
-                callback_runner.trigger_event(EventTypes.AFTER_ENCODE_RESPONSE, lit_api=lit_api)
+            callback_runner.trigger_event(EventTypes.BEFORE_ENCODE_RESPONSE, lit_api=lit_api)
+            y_enc_list = []
+            for response_queue_id, y, uid, context in zip(response_queue_ids, outputs, uids, contexts):
+                y_enc = _inject_context(context, lit_api.encode_response, y)
+            y_enc_list.append((response_queue_id, uid, y_enc))
+            callback_runner.trigger_event(EventTypes.AFTER_ENCODE_RESPONSE, lit_api=lit_api)
 
-                for response_queue_id, uid, y_enc in y_enc_list:
-                    response_queues[response_queue_id].put((uid, (y_enc, LitAPIStatus.OK)))
+            for response_queue_id, uid, y_enc in y_enc_list:
+                response_queues[response_queue_id].put((uid, (y_enc, LitAPIStatus.OK)))
 
         except HTTPException as e:
             for response_queue_id, uid in zip(response_queue_ids, uids):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -230,10 +230,10 @@ def test_collate_requests(batch_timeout, batch_size):
 class BatchSizeMismatchAPI(SimpleBatchLitAPI):
     def predict(self, x):
         assert len(x) == 2, "Expected two concurrent inputs to be batched"
-        return self.model(x)
+        return self.model(x)  # returns a list of length same as len(x)
 
     def unbatch(self, output):
-        return [output]
+        return [output]  # returns a list of length 1
 
 
 @pytest.mark.asyncio
@@ -249,6 +249,6 @@ async def test_batch_size_mismatch():
             response2 = ac.post("/predict", json={"input": 5.0})
             response1, response2 = await asyncio.gather(response1, response2)
         assert response1.status_code == 500
-        assert response1.json() == {"detail": "Batch size mismatch"}
         assert response2.status_code == 500
-        assert response2.json() == {"detail": "Batch size mismatch"}
+        assert response1.json() == {"detail": "Batch size mismatch"}, "unbatch a list of length 1 when batch size is 2"
+        assert response2.json() == {"detail": "Batch size mismatch"}, "unbatch a list of length 1 when batch size is 2"

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -225,3 +225,30 @@ def test_collate_requests(batch_timeout, batch_size):
     )
     assert len(payloads) == batch_size, f"Should have {batch_size} payloads, got {len(payloads)}"
     assert len(timed_out_uids) == 0, "No timed out uids"
+
+
+class BatchSizeMismatchAPI(SimpleBatchLitAPI):
+    def predict(self, x):
+        assert len(x) == 2, "Expected two concurrent inputs to be batched"
+        return self.model(x)
+
+    def unbatch(self, output):
+        return [output]
+
+
+@pytest.mark.asyncio
+async def test_batch_size_mismatch():
+    api = BatchSizeMismatchAPI()
+    server = LitServer(api, accelerator="cpu", devices=1, timeout=10, max_batch_size=2, batch_timeout=4)
+
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            response1 = ac.post("/predict", json={"input": 4.0})
+            response2 = ac.post("/predict", json={"input": 5.0})
+            response1, response2 = await asyncio.gather(response1, response2)
+        assert response1.status_code == 500
+        assert response1.json() == {"detail": "Batch size mismatch"}
+        assert response2.status_code == 500
+        assert response2.json() == {"detail": "Batch size mismatch"}


### PR DESCRIPTION
## What does this PR do?

This PR, helps user find the mistake in LitAPI when the output from `predict`/`unbatch` is not as the same size as of number of requests. 

```py
class ExampleAPI(LitAPI):
    ...
    def predict(self, x):
        return self.model(x)  # returns a list of length same as len(x)

    def unbatch(self, output):
        return [output]   # returns a list of length 1
```

Also, removes a duplicate code. 

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
