### PR TITLE
git: Handle None values in ChatMessage content

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -313,7 +313,7 @@ class OpenAISpec(LitSpec):
     def _encode_response(self, output: Union[Dict[str, str], List[Dict[str, str]]]) -> Dict:
         logger.debug(output)
         if output is None:
-            message = {"role": "assistant", "content": None} 
+            message = {"role": "assistant", "content": None}
         elif isinstance(output, str):
             message = {"role": "assistant", "content": output}
         elif self.validate_chat_message(output):

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -133,7 +133,7 @@ ResponseFormat = Annotated[
 
 class ChatMessage(BaseModel):
     role: str
-    content: Union[str, List[Union[TextContent, ImageContent]]]
+    content: Optional[Union[str, List[Union[TextContent, ImageContent]]]] = None
     name: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     tool_call_id: Optional[str] = None
@@ -312,9 +312,10 @@ class OpenAISpec(LitSpec):
 
     def _encode_response(self, output: Union[Dict[str, str], List[Dict[str, str]]]) -> Dict:
         logger.debug(output)
-        if isinstance(output, str):
+        if output is None:
+            message = {"role": "assistant", "content": None} 
+        elif isinstance(output, str):
             message = {"role": "assistant", "content": output}
-
         elif self.validate_chat_message(output):
             message = output
         elif isinstance(output, dict) and "content" in output:
@@ -448,7 +449,7 @@ class OpenAISpec(LitSpec):
                 if chat_msg.tool_calls:
                     tool_calls = chat_msg.tool_calls
 
-            content = "".join(msgs)
+            content = "".join(msg for msg in msgs if msg is not None)
             msg = {"role": "assistant", "content": content, "tool_calls": tool_calls}
             choice = ChatCompletionResponseChoice(index=i, message=msg, finish_reason="stop")
             choices.append(choice)


### PR DESCRIPTION
## What does this PR do?

Fixes None values in ChatMessage content.
This PR aligns the `ChatMessage` model with the OpenAI API spec by allowing `content` to be either a `string` or `null`. It also updates the `non_streaming_completion` method to handle `None` values, preventing potential `TypeError` during message concatenation.

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [v] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [v] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## 💡 How Does This PR Impact Users?
✅ Improved OpenAI API Compatibility:
Users integrating with the OpenAI API will no longer face errors when the content field is null (which is always the case when OpenAI returns a function call). This ensures smooth interoperability, especially when handling function calls.
✅ Flexible Function Call Handling:
When OpenAI returns function calls with `null` content, users can now decide whether to handle these functions directly in the `predict` function, providing greater flexibility in managing LLM responses.



## PR review
Focus on the changes to the `ChatMessage` model and `non_streaming_completion` method.

## Did you have fun?
Absolutely! 🙃
