### PR TITLE
fix: reponse format JSONSchema key fix

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -117,7 +117,7 @@ class ResponseFormatJSONObject(BaseModel):
 class JSONSchema(BaseModel):
     name: str
     description: Optional[str] = None
-    schema: Optional[Dict[str, object]] = Field(None, alias="schema")
+    schema_: Optional[Dict[str, object]] = Field(None, alias="schema")
     strict: Optional[bool] = False
 
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -117,7 +117,7 @@ class ResponseFormatJSONObject(BaseModel):
 class JSONSchema(BaseModel):
     name: str
     description: Optional[str] = None
-    schema_def: Optional[Dict[str, object]] = Field(None, alias="schema")
+    schema: Optional[Dict[str, object]] = Field(None, alias="schema")
     strict: Optional[bool] = False
 
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -405,7 +405,7 @@ class OpenAISpec(LitSpec):
             usage_info = sum(usage_infos)
             chunk = ChatCompletionChunk(model=model, choices=choices, usage=None)
             logger.debug(chunk)
-            yield f"data: {chunk.model_dump_json()}\n\n"
+            yield f"data: {chunk.model_dump_json(by_alias=True)}\n\n"
 
         choices = [
             ChatCompletionStreamingChoice(
@@ -420,7 +420,7 @@ class OpenAISpec(LitSpec):
             choices=choices,
             usage=usage_info,
         )
-        yield f"data: {last_chunk.model_dump_json()}\n\n"
+        yield f"data: {last_chunk.model_dump_json(by_alias=True)}\n\n"
         yield "data: [DONE]\n\n"
 
     async def non_streaming_completion(self, request: ChatCompletionRequest, generator_list: List[AsyncGenerator]):


### PR DESCRIPTION
## What does this PR do?

This PR fixes openai.BadRequestError 400 - missing required parameter related to response_format.json_schema.schema. The issue was caused by a naming mismatch in JSONSchema parsing when handling response formats. This is a simple fix that ensures proper parameter inclusion.

<details>
  <summary><b>Before submitting</b></summary>

- [x ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [v] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [v] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>


## How does this PR impact the user?
✅ Resolves incorrect request failures due to mismatch JSONSchema parameters. 

## Did you have fun?
Absolutely!