### PR TITLE
[fix] continuous batching - fix prefill

### DIFF
--- a/src/litserve/loops/continuous_batching_loop.py
+++ b/src/litserve/loops/continuous_batching_loop.py
@@ -131,7 +131,9 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
             self.response_queue_ids[uid] = response_queue_id
 
         while True:
-            request = await asyncio.to_thread(self.get_request, request_queue, timeout=None, block=True)
+            request = await asyncio.to_thread(self.get_request, request_queue, timeout=None, block=False)
+            if request is None:
+                break
             if self.has_capacity(lit_api):
                 response_queue_id, uid, _, input = request
                 logger.debug(f"New request: {uid}, {input}")

--- a/src/litserve/loops/continuous_batching_loop.py
+++ b/src/litserve/loops/continuous_batching_loop.py
@@ -131,7 +131,7 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
             self.response_queue_ids[uid] = response_queue_id
 
         while True:
-            request = await asyncio.to_thread(self.get_request, request_queue, timeout=None, block=False)
+            request = await asyncio.to_thread(self.get_request, request_queue, timeout=1, block=True)
             if request is None:
                 break
             if self.has_capacity(lit_api):


### PR DESCRIPTION
prefill is stuck in `get_request` from queue even though `pending_requests` has some items. 

## What does this PR do?

In the case that there are pending requests to process, but the API has signalled it has no capacity, the continuous batching loop will attempt to fetch incoming requests. 

If no new requests come in, due to the dequeuing being blocking, the loop will halt while waiting for requests, while pending requests are not being serviced. This patch fixes this behaviour.


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
