### PR TITLE
fix: Replace deprecated `dict` method with `model_dump` in OpenAI Spec decode step  

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -289,7 +289,7 @@ class OpenAISpec(LitSpec):
         self, request: ChatCompletionRequest, context_kwargs: Optional[dict] = None
     ) -> List[Dict[str, str]]:
         # returns [{"role": "system", "content": "..."}, ...]
-        return [el.dict() for el in request.messages]
+        return [el.model_dump(by_alias=True, exclude_none=True) for el in request.messages]
 
     def batch(self, inputs):
         return list(inputs)


### PR DESCRIPTION
### **What does this PR do?**  
**fixes:** Replace deprecated `dict` method with `model_dump` in OpenAI Spec decode step  

**Why?**  
- The `dict` method in `BaseModel` is deprecated; switching to `model_dump` ensures compatibility.  

**Changes:**  
- Use `model_dump(by_alias=True, exclude_none=True)` to correctly format output.  
  - `by_alias=True`: Ensures correct alias names (e.g., response format schema).  
  - `exclude_none=True`: Excludes unnecessary fields (e.g., `tool_calls`, `tool_call_id`).  
<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
