### PR TITLE
fix: update type hints for _default_unbatch and _spec attributes in LitAPI class 

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -15,7 +15,7 @@ import json
 import warnings
 from abc import ABC, abstractmethod
 from queue import Queue
-from typing import Optional
+from typing import Callable, Optional
 
 from pydantic import BaseModel
 
@@ -24,8 +24,8 @@ from litserve.specs.base import LitSpec
 
 class LitAPI(ABC):
     _stream: bool = False
-    _default_unbatch: callable = None
-    _spec: LitSpec = None
+    _default_unbatch: Optional[Callable] = None
+    _spec: Optional[LitSpec] = None
     _device: Optional[str] = None
     _logger_queue: Optional[Queue] = None
     request_timeout: Optional[float] = None
@@ -76,6 +76,8 @@ class LitAPI(ABC):
 
     def unbatch(self, output):
         """Convert a batched output to a list of outputs."""
+        if self._default_unbatch is None:
+            raise ValueError("Unbatch function is not set.")
         return self._default_unbatch(output)
 
     def encode_response(self, output, **kwargs):

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -77,7 +77,10 @@ class LitAPI(ABC):
     def unbatch(self, output):
         """Convert a batched output to a list of outputs."""
         if self._default_unbatch is None:
-            raise ValueError("Unbatch function is not set.")
+            raise ValueError(
+                "Default implementation for `LitAPI.unbatch` method was not found. "
+                "Please implement the `LitAPI.unbatch` method."
+            )
         return self._default_unbatch(output)
 
     def encode_response(self, output, **kwargs):

--- a/tests/test_litapi.py
+++ b/tests/test_litapi.py
@@ -72,6 +72,12 @@ def test_default_batch_unbatch():
     assert api.unbatch(output) == inputs, "Default unbatch should not change input"
 
 
+def test_default_unbatch_not_implemented():
+    api = TestDefaultBatchedAPI()
+    with pytest.raises(ValueError, match="Default implementation for `LitAPI.unbatch` method was not found."):
+        api.unbatch(None)
+
+
 class TestStreamAPIBatched(TestStreamAPI):
     def predict(self, x):
         for i in range(4):


### PR DESCRIPTION
### **What does this PR do?**  
**fix:** Update type hints for `_default_unbatch` and `_spec` attributes in `LitAPI` class  

**Changes:**  
- `callable` (lowercase) is not a valid type hint; replaced with `Callable` from `typing`.  
-  Update type hints for `_default_unbatch` and `_spec` attributes
- Added a validation check to ensure `_default_unbatch` is set before calling it.  

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
