### PR TITLE
Feature: 🚀 Add Audio Content Support to OpenAISpec Request

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -78,8 +78,7 @@ class ImageContent(BaseModel):
 
 
 class InputAudio(BaseModel):
-    data: str
-    """Base64 encoded audio data."""
+    data: str  # base64 encoded audio data.
 
     format: Literal["wav", "mp3"]
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -79,13 +79,11 @@ class ImageContent(BaseModel):
 
 class InputAudio(BaseModel):
     data: str  # base64 encoded audio data.
-
     format: Literal["wav", "mp3"]
 
 
 class AudioContent(BaseModel):
     type: Literal["input_audio"]
-
     input_audio: InputAudio
 
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -77,6 +77,19 @@ class ImageContent(BaseModel):
     image_url: Union[str, ImageContentURL]
 
 
+class InputAudio(BaseModel):
+    data: str
+    """Base64 encoded audio data."""
+
+    format: Literal["wav", "mp3"]
+
+
+class AudioContent(BaseModel):
+    type: Literal["input_audio"]
+
+    input_audio: InputAudio
+
+
 class Function(BaseModel):
     name: str
     description: str
@@ -133,7 +146,7 @@ ResponseFormat = Annotated[
 
 class ChatMessage(BaseModel):
     role: str
-    content: Optional[Union[str, List[Union[TextContent, ImageContent]]]] = None
+    content: Optional[Union[str, List[Union[TextContent, ImageContent, AudioContent]]]] = None
     name: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     tool_call_id: Optional[str] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 import time
 from typing import Generator
 
@@ -191,6 +192,44 @@ def openai_request_data_with_image():
         "frequency_penalty": 0,
         "user": "string",
     }
+
+
+@pytest.fixture
+def openai_request_data_with_audio_wav(openai_request_data):
+    # Create a base64 encoded string from a list of audio data
+    audio_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    encoded_string = base64.b64encode(bytearray(audio_data)).decode("utf-8")
+
+    request_data = openai_request_data.copy()
+    request_data["messages"] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this recording?"},
+                {"type": "input_audio", "input_audio": {"data": encoded_string, "format": "wav"}},
+            ],
+        },
+    ]
+    return request_data
+
+
+@pytest.fixture
+def openai_request_data_with_audio_flac(openai_request_data):
+    # Create a base64 encoded string from a list of audio data
+    audio_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    encoded_string = base64.b64encode(bytearray(audio_data)).decode("utf-8")
+
+    request_data = openai_request_data.copy()
+    request_data["messages"] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this recording?"},
+                {"type": "input_audio", "input_audio": {"data": encoded_string, "format": "flac"}},
+            ],
+        },
+    ]
+    return request_data
 
 
 @pytest.fixture

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -184,7 +184,7 @@ def test_openai_parity_with_image_input():
 
 
 @e2e_from_file("tests/e2e/default_openaispec.py")
-def test_openai_parity_with_image_input(openai_request_data_with_audio_wav):
+def test_openai_parity_with_audio_input(openai_request_data_with_audio_wav):
     client = OpenAI(
         base_url="http://127.0.0.1:8000/v1",
         api_key="lit",  # required, but unused

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -183,6 +183,34 @@ def test_openai_parity_with_image_input():
         )
 
 
+@e2e_from_file("tests/e2e/default_openaispec.py")
+def test_openai_parity_with_image_input(openai_request_data_with_audio_wav):
+    client = OpenAI(
+        base_url="http://127.0.0.1:8000/v1",
+        api_key="lit",  # required, but unused
+    )
+    messages = openai_request_data_with_audio_wav["messages"]
+    response = client.chat.completions.create(
+        model="lit",
+        messages=messages,
+    )
+    assert response.choices[0].message.content == "This is a generated output", (
+        f"Server didn't return expected output\nOpenAI client output: {response}"
+    )
+
+    response = client.chat.completions.create(
+        model="lit",
+        messages=messages,
+        stream=True,
+    )
+
+    expected_outputs = ["This is a generated output", None]
+    for r, expected_out in zip(response, expected_outputs):
+        assert r.choices[0].delta.content == expected_out, (
+            f"Server didn't return expected output.\nOpenAI client output: {r}"
+        )
+
+
 @e2e_from_file("tests/e2e/default_openaispec_tools.py")
 def test_openai_parity_with_tools():
     client = OpenAI(


### PR DESCRIPTION
## What does this PR do?
**🚀 Add Audio Content Support to OpenAISpec Request**

This PR introduces support for the Audio Content in the OpenAISpec request. 

This will extend the spec to handle input audio data, making it more compatible with OpenIAI API.
Reference: [OpenAI API Reference](https://platform.openai.com/docs/api-reference/chat/create?lang=python)

<img width="623" alt="Image" src="https://github.com/user-attachments/assets/022615cd-0db5-4a3b-aa9f-3fe4abac9f82" />

Fixes #438

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?
Yes, I did 😊.