### PR TITLE
hotfix: pin starlette dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
-starlette
+starlette!=0.46.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-fastapi >=0.100
+fastapi>=0.100.0
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
+starlette#<0.46.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.100.0
+fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
 starlette#<0.46.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
-starlette#<0.46.0
+starlette

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
-starlette!=0.46.0
+starlette!=0.46.0  # TODO: fix root cause for buffer error

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
-starlette!=0.46.0  # TODO: fix root cause for buffer error
+starlette<0.46.0  # TODO: fix root cause for buffer error


### PR DESCRIPTION
## What does this PR do?  
This PR pins the Starlette dependency to avoid the 0.46.0 release.  

Context:  
The latest version of Starlette (0.46.0) has issues with pickling payload data—  
specifically, the error [cannot pickle '_io.BufferedRandom' object](https://github.com/Lightning-AI/LitServe/issues/443)

>The root cause of the error will be addressed in a separate PR shortly.

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
