### PR TITLE
feat: add lightning cli dynamically 

### DIFF
--- a/.github/workflows/ci-minimal-dependency-check.yml
+++ b/.github/workflows/ci-minimal-dependency-check.yml
@@ -30,4 +30,4 @@ jobs:
           pip list
 
       - name: Tests
-        run: python tests/minimal_run.py
+        run: lightning serve api tests/minimal_run.py

--- a/.github/workflows/ci-minimal-dependency-check.yml
+++ b/.github/workflows/ci-minimal-dependency-check.yml
@@ -30,4 +30,4 @@ jobs:
           pip list
 
       - name: Tests
-        run: lightning serve api tests/minimal_run.py
+        run: python tests/minimal_run.py

--- a/setup.py
+++ b/setup.py
@@ -111,8 +111,6 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     entry_points={
-        "console_scripts": [
-            "litserve=litserve.__main__:main",
-        ],
+        "console_scripts": ["litserve=litserve.__main__:main", "lightning=litserve.cli:main"],
     },
 )

--- a/src/litserve/cli.py
+++ b/src/litserve/cli.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 import subprocess
 import sys
 

--- a/src/litserve/cli.py
+++ b/src/litserve/cli.py
@@ -1,0 +1,17 @@
+import importlib
+import subprocess
+import sys
+
+
+def _ensure_lightning_installed():
+    if not importlib.util.find_spec("lightning_sdk"):
+        print("Lightning CLI not found. Installing...")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-U", "lightning-sdk"])
+
+
+def main():
+    _ensure_lightning_installed()
+
+    # Forward CLI arguments to the real lightning command
+    cli_args = sys.argv[1:]
+    subprocess.run(["lightning"] + cli_args)

--- a/tests/minimal_run.py
+++ b/tests/minimal_run.py
@@ -21,10 +21,10 @@ import psutil
 
 def main():
     process = subprocess.Popen(
-        ["python", "tests/simple_server.py"],
+        ["lightning", "serve", "api", "tests/simple_server.py"],
     )
     print("Waiting for server to start...")
-    time.sleep(5)
+    time.sleep(10)
     try:
         url = "http://127.0.0.1:8000/predict"
         data = json.dumps({"input": 4.0}).encode("utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,9 +42,7 @@ def test_ensure_lightning_installed(mock_check_call, mock_find_spec):
 
 
 def test_lightning_serve_help():
-    result = subprocess.run("lightning serve --help", shell=True, capture_output=True, text=True)
-    result_text = result.stdout + result.stderr
-    assert "Serve a LitServe model." in result_text, "CLI did not print help message"
+    subprocess.run("lightning serve --help", shell=True, capture_output=True, text=True)
     from lightning_sdk import __version__
 
     assert __version__ is not None, "Lightning SDK version not found"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import sys
 from unittest.mock import patch
 
@@ -39,10 +38,3 @@ def test_ensure_lightning_installed(mock_check_call, mock_find_spec):
     mock_find_spec.return_value = False
     _ensure_lightning_installed()
     mock_check_call.assert_called_once_with([sys.executable, "-m", "pip", "install", "-U", "lightning-sdk"])
-
-
-def test_lightning_serve_help():
-    subprocess.run("lightning serve --help", shell=True, capture_output=True, text=True)
-    from lightning_sdk import __version__
-
-    assert __version__ is not None, "Lightning SDK version not found"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,3 +45,6 @@ def test_lightning_serve_help():
     result = subprocess.run("lightning serve --help", shell=True, capture_output=True, text=True)
     result_text = result.stdout + result.stderr
     assert "Serve a LitServe model." in result_text, "CLI did not print help message"
+    from lightning_sdk import __version__
+
+    assert __version__ is not None, "Lightning SDK version not found"


### PR DESCRIPTION
## What does this PR do?

Let users run LitServe models using the Lightning CLI. 

- After SDK installation the litserve's `lightning` command is replaced from the SDK CLI. 

<img width="879" alt="image" src="https://github.com/user-attachments/assets/5d477b94-e27e-4716-9d1e-50d41e08c45c" />

<img width="889" alt="image" src="https://github.com/user-attachments/assets/5273041d-208f-463a-a84b-277d9437fca3" />


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
