### PR TITLE
fix: Starlette dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
-starlette<0.46.0  # TODO: fix root cause for buffer error
+starlette

--- a/src/litserve/loops/base.py
+++ b/src/litserve/loops/base.py
@@ -31,6 +31,8 @@ from litserve.utils import LitAPIStatus
 
 logger = logging.getLogger(__name__)
 # FastAPI writes form files to disk over 1MB by default, which prevents serialization by multiprocessing
+MultiPartParser.max_file_size = sys.maxsize
+# renamed in PR: https://github.com/encode/starlette/pull/2780
 MultiPartParser.spool_max_size = sys.maxsize
 
 

--- a/src/litserve/loops/base.py
+++ b/src/litserve/loops/base.py
@@ -31,7 +31,7 @@ from litserve.utils import LitAPIStatus
 
 logger = logging.getLogger(__name__)
 # FastAPI writes form files to disk over 1MB by default, which prevents serialization by multiprocessing
-MultiPartParser.max_file_size = sys.maxsize
+MultiPartParser.spool_max_size = sys.maxsize
 
 
 def _inject_context(context: Union[List[dict], dict], func, *args, **kwargs):

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -55,6 +55,8 @@ logger = logging.getLogger(__name__)
 LIT_SERVER_API_KEY = os.environ.get("LIT_SERVER_API_KEY")
 
 # FastAPI writes form files to disk over 1MB by default, which prevents serialization by multiprocessing
+MultiPartParser.max_file_size = sys.maxsize
+# renamed in PR: https://github.com/encode/starlette/pull/2780
 MultiPartParser.spool_max_size = sys.maxsize
 
 

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 LIT_SERVER_API_KEY = os.environ.get("LIT_SERVER_API_KEY")
 
 # FastAPI writes form files to disk over 1MB by default, which prevents serialization by multiprocessing
-MultiPartParser.max_file_size = sys.maxsize
+MultiPartParser.spool_max_size = sys.maxsize
 
 
 def no_auth():


### PR DESCRIPTION
## What does this PR do?

Fixes #443 

update `max_file_size` to `spool_max_size`

Starlette changed `max_file_size` name. check pr: https://github.com/encode/starlette/pull/2780

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
