### PR TITLE
Add --local flag to lightning serve command in minimal_run.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ https://github.com/user-attachments/assets/ff83dab9-0c9f-4453-8dcb-fb9526726344
 
 Self-hosting is ideal for hackers, students, and DIY developers while fully managed hosting is ideal for enterprise developers needing easy autoscaling, security, release management, and 99.995% uptime and observability.
 
-To host on [Lightning AI](https://lightning.ai/deploy), simply add the `--cloud` arg, login and choose the cloud of your choice.
+To host on [Lightning AI](https://lightning.ai/deploy), simply run the command, login and choose the cloud of your choice.
 ```bash
-lightning serve api server.py --cloud
+lightning serve server.py
 ```
 
 &nbsp;

--- a/tests/minimal_run.py
+++ b/tests/minimal_run.py
@@ -21,7 +21,7 @@ import psutil
 
 def main():
     process = subprocess.Popen(
-        ["lightning", "serve", "api", "tests/simple_server.py"],
+        ["lightning", "serve", "api", "tests/simple_server.py", "--local"],
     )
     print("Waiting for server to start...")
     time.sleep(10)


### PR DESCRIPTION
## What does this PR do?

This PR adds the `--local` flag to the `lightning serve` command to ensure the server runs locally.

The command to run server has been changed from default local to opt-in to local so we need to add the `--local` argument. 


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
