### PR TITLE
remove starlette from the main dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
-starlette


### PR DESCRIPTION
## What does this PR do?
This PR removes `starlette` from `requirements.txt`. It was temporarily added and pinned in #445 to address an issue, which has since been resolved in #456.

Since `starlette` is already included as a dependency of `fastapi` and there's no version pin required anymore, we can safely remove it.


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
