### PR TITLE
Remove warning for inactive request counter in `active_requests` method

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -398,10 +398,6 @@ class LitServer:
     def active_requests(self):
         if self.track_requests and self.active_counters:
             return sum(counter.value for counter in self.active_counters)
-        warnings.warn(
-            "Active request counter is not enabled while using `on_request` callback hook. "
-            "Please set track_requests=True in the LitServer."
-        )
         return None
 
     def register_endpoints(self):


### PR DESCRIPTION
## What does this PR do?

Tracking the number of active requests is an opt-in feature and users should not see the warning if it's not enabled. 

This PR removes a warning message from the `active_requests` method when the active request counter is not enabled. 

```
/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/litserve/server.py:388: UserWarning: Active request counter is not enabled while using `on_request` callback hook. Please set track_requests=True in the LitServer.`
```


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
