### PR TITLE
Move batch size to LitAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class SimpleLitAPI(ls.LitAPI):
 # (STEP 2) - START THE SERVER
 if __name__ == "__main__":
     # scale with advanced features (batching, GPUs, etc...)
-    server = ls.LitServer(SimpleLitAPI(), accelerator="auto", max_batch_size=1)
+    server = ls.LitServer(SimpleLitAPI(max_batch_size=1), accelerator="auto")
     server.run(port=8000)
 ```
 

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -30,6 +30,23 @@ class LitAPI(ABC):
     _logger_queue: Optional[Queue] = None
     request_timeout: Optional[float] = None
 
+    def __init__(self, max_batch_size: int = 1, batch_timeout: float = 0.0):
+        """Initialize a LitAPI instance.
+
+        Args:
+            max_batch_size: Maximum number of requests to process in a batch.
+            batch_timeout: Maximum time to wait for a batch to fill before processing.
+
+        """
+
+        if max_batch_size <= 0:
+            raise ValueError("max_batch_size must be greater than 0")
+
+        if batch_timeout < 0:
+            raise ValueError("batch_timeout must be greater than or equal to 0")
+        self.max_batch_size = max_batch_size
+        self.batch_timeout = batch_timeout
+
     @abstractmethod
     def setup(self, device):
         """Setup the model so it can be called in `predict`."""
@@ -116,8 +133,10 @@ class LitAPI(ABC):
     def device(self, value):
         self._device = value
 
-    def pre_setup(self, max_batch_size: int, spec: Optional[LitSpec]):
-        self.max_batch_size = max_batch_size
+    def pre_setup(self, spec: Optional[LitSpec], timeout):
+        if self.batch_timeout > timeout and timeout not in (False, -1):
+            raise ValueError("batch_timeout must be less than timeout")
+
         if self.stream:
             self._default_unbatch = self._unbatch_stream
         else:

--- a/src/litserve/loops/continuous_batching_loop.py
+++ b/src/litserve/loops/continuous_batching_loop.py
@@ -120,8 +120,6 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
         lit_api: LitAPI,
         lit_spec: Optional[LitSpec],
         request_queue: Queue,
-        max_batch_size: Optional[int] = None,
-        batch_timeout: Optional[float] = None,
         response_queues: List[Queue] = None,
     ) -> List[Tuple[str, Any]]:
         """Fill available capacity with pending and new requests."""
@@ -151,8 +149,6 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
         lit_api: LitAPI,
         lit_spec: Optional[LitSpec],
         request_queue: Queue,
-        max_batch_size: int,
-        batch_timeout: float,
         response_queues: List[Queue],
     ):
         logger.info("Running prefill in background")
@@ -164,8 +160,6 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
                     lit_api,
                     lit_spec,
                     request_queue,
-                    max_batch_size,
-                    batch_timeout,
                     response_queues,
                 )
                 await asyncio.sleep(0)
@@ -187,8 +181,6 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
         worker_id: int,
         request_queue: Queue,
         transport: MessageTransport,
-        max_batch_size: int,
-        batch_timeout: float,
         stream: bool,
         workers_setup_status: Dict[int, str],
         callback_runner: CallbackRunner,

--- a/src/litserve/loops/loops.py
+++ b/src/litserve/loops/loops.py
@@ -45,8 +45,6 @@ def inference_worker(
     worker_id: int,
     request_queue: Queue,
     transport: MessageTransport,
-    max_batch_size: int,
-    batch_timeout: float,
     stream: bool,
     workers_setup_status: Dict[int, str],
     callback_runner: CallbackRunner,
@@ -71,7 +69,7 @@ def inference_worker(
         logging.info(f"LitServe will use {lit_spec.__class__.__name__} spec")
 
     if loop == "auto":
-        loop = get_default_loop(stream, max_batch_size)
+        loop = get_default_loop(stream, lit_api.max_batch_size)
 
     loop(
         lit_api,
@@ -80,8 +78,6 @@ def inference_worker(
         worker_id,
         request_queue,
         transport,
-        max_batch_size,
-        batch_timeout,
         stream,
         workers_setup_status,
         callback_runner,

--- a/src/litserve/loops/simple_loops.py
+++ b/src/litserve/loops/simple_loops.py
@@ -125,8 +125,6 @@ class SingleLoop(DefaultLoop):
         worker_id: int,
         request_queue: Queue,
         transport: MessageTransport,
-        max_batch_size: int,
-        batch_timeout: float,
         stream: bool,
         workers_setup_status: Dict[int, str],
         callback_runner: CallbackRunner,
@@ -141,16 +139,12 @@ class BatchedLoop(DefaultLoop):
         lit_spec: LitSpec,
         request_queue: Queue,
         transport: MessageTransport,
-        max_batch_size: int,
-        batch_timeout: float,
         callback_runner: CallbackRunner,
     ):
         while True:
             batches, timed_out_uids = collate_requests(
                 lit_api,
                 request_queue,
-                max_batch_size,
-                batch_timeout,
             )
 
             for response_queue_id, uid in timed_out_uids:
@@ -236,8 +230,6 @@ class BatchedLoop(DefaultLoop):
         worker_id: int,
         request_queue: Queue,
         transport: MessageTransport,
-        max_batch_size: int,
-        batch_timeout: float,
         stream: bool,
         workers_setup_status: Dict[int, str],
         callback_runner: CallbackRunner,
@@ -247,7 +239,5 @@ class BatchedLoop(DefaultLoop):
             lit_spec,
             request_queue,
             transport,
-            max_batch_size,
-            batch_timeout,
             callback_runner,
         )

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -113,8 +113,6 @@ class StreamingLoop(DefaultLoop):
         worker_id: int,
         request_queue: Queue,
         transport: MessageTransport,
-        max_batch_size: int,
-        batch_timeout: float,
         stream: bool,
         workers_setup_status: Dict[int, str],
         callback_runner: CallbackRunner,
@@ -129,16 +127,12 @@ class BatchedStreamingLoop(DefaultLoop):
         lit_spec: LitSpec,
         request_queue: Queue,
         transport: MessageTransport,
-        max_batch_size: int,
-        batch_timeout: float,
         callback_runner: CallbackRunner,
     ):
         while True:
             batches, timed_out_uids = collate_requests(
                 lit_api,
                 request_queue,
-                max_batch_size,
-                batch_timeout,
             )
             for response_queue_id, uid in timed_out_uids:
                 logger.error(
@@ -218,8 +212,6 @@ class BatchedStreamingLoop(DefaultLoop):
         worker_id: int,
         request_queue: Queue,
         transport: MessageTransport,
-        max_batch_size: int,
-        batch_timeout: float,
         stream: bool,
         workers_setup_status: Dict[int, str],
         callback_runner: CallbackRunner,
@@ -229,7 +221,5 @@ class BatchedStreamingLoop(DefaultLoop):
             lit_spec,
             request_queue,
             transport,
-            max_batch_size,
-            batch_timeout,
             callback_runner,
         )

--- a/tests/e2e/default_batched_streaming.py
+++ b/tests/e2e/default_batched_streaming.py
@@ -33,5 +33,5 @@ class SimpleStreamAPI(ls.LitAPI):
 
 
 if __name__ == "__main__":
-    server = ls.LitServer(SimpleStreamAPI(), stream=True, max_batch_size=4, batch_timeout=0.2, fast_queue=True)
+    server = ls.LitServer(SimpleStreamAPI(max_batch_size=4, batch_timeout=0.2), stream=True, fast_queue=True)
     server.run(port=8000)

--- a/tests/e2e/default_batching.py
+++ b/tests/e2e/default_batching.py
@@ -14,6 +14,6 @@
 import litserve as ls
 
 if __name__ == "__main__":
-    api = ls.test_examples.SimpleBatchedAPI()
-    server = ls.LitServer(api, max_batch_size=4, batch_timeout=0.05)
+    api = ls.test_examples.SimpleBatchedAPI(max_batch_size=4, batch_timeout=0.05)
+    server = ls.LitServer(api)
     server.run(port=8000)

--- a/tests/e2e/default_openai_with_batching.py
+++ b/tests/e2e/default_openai_with_batching.py
@@ -2,6 +2,6 @@ import litserve as ls
 from litserve.test_examples.openai_spec_example import OpenAIBatchContext
 
 if __name__ == "__main__":
-    api = OpenAIBatchContext()
-    server = ls.LitServer(api, spec=ls.OpenAISpec(), max_batch_size=2, batch_timeout=0.5, fast_queue=True)
+    api = OpenAIBatchContext(max_batch_size=2, batch_timeout=0.5)
+    server = ls.LitServer(api, spec=ls.OpenAISpec(), fast_queue=True)
     server.run(port=8000)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -28,8 +28,8 @@ async def test_simple_pytorch_api():
 
 @pytest.mark.asyncio
 async def test_simple_batched_api():
-    api = ls.test_examples.SimpleBatchedAPI()
-    server = ls.LitServer(api, max_batch_size=4, batch_timeout=0.1)
+    api = ls.test_examples.SimpleBatchedAPI(max_batch_size=4, batch_timeout=0.1)
+    server = ls.LitServer(api)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -91,9 +91,9 @@ async def test_stream(simple_stream_api, use_zmq):
 @pytest.mark.parametrize("use_zmq", [True, False])
 @pytest.mark.asyncio
 async def test_batched_stream_server(simple_batched_stream_api, use_zmq):
-    server = LitServer(
-        simple_batched_stream_api, stream=True, max_batch_size=4, batch_timeout=2, timeout=30, fast_queue=use_zmq
-    )
+    simple_batched_stream_api.max_batch_size = 4
+    simple_batched_stream_api.batch_timeout = 2
+    server = LitServer(simple_batched_stream_api, stream=True, timeout=30, fast_queue=use_zmq)
     expected_output1 = "Hello LitServe is streaming output".lower().replace(" ", "")
     expected_output2 = "World LitServe is streaming output".lower().replace(" ", "")
 

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -372,7 +372,7 @@ async def test_inject_context():
     assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
 
     # Test context injection with batched loop
-    server = LitServer(IdentityBatchedAPI(), max_batch_size=2, batch_timeout=0.01)
+    server = LitServer(IdentityBatchedAPI(max_batch_size=2, batch_timeout=0.01))
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"
@@ -381,7 +381,7 @@ async def test_inject_context():
     assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
 
     # Test context injection with batched streaming loop
-    server = LitServer(IdentityBatchedStreamingAPI(), max_batch_size=2, batch_timeout=0.01, stream=True)
+    server = LitServer(IdentityBatchedStreamingAPI(max_batch_size=2, batch_timeout=0.01), stream=True)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -70,7 +70,9 @@ async def test_openai_spec(openai_request_data):
     ],
 )
 async def test_openai_token_usage(api, batch_size, openai_request_data, openai_response_data):
-    server = ls.LitServer(api, spec=ls.OpenAISpec(), max_batch_size=batch_size, batch_timeout=0.01)
+    api.max_batch_size = batch_size
+    api.batch_timeout = 0.01
+    server = ls.LitServer(api, spec=ls.OpenAISpec())
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"
@@ -113,7 +115,9 @@ class OpenAIWithUsagePerToken(ls.LitAPI):
     ],
 )
 async def test_openai_per_token_usage(api, batch_size, openai_request_data, openai_response_data):
-    server = ls.LitServer(api, spec=ls.OpenAISpec(), max_batch_size=batch_size, batch_timeout=0.01)
+    api.max_batch_size = batch_size
+    api.batch_timeout = 0.01
+    server = ls.LitServer(api, spec=ls.OpenAISpec())
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"
@@ -399,7 +403,8 @@ class TestOpenAIWithBatching(TestEmbedAPI):
 
 @pytest.mark.asyncio
 async def test_openai_embedding_spec_with_batching(openai_embedding_request_data, openai_embedding_request_data_array):
-    server = ls.LitServer(TestOpenAIWithBatching(), spec=ls.OpenAIEmbeddingSpec(), max_batch_size=2, batch_timeout=10)
+    api = TestOpenAIWithBatching(max_batch_size=2, batch_timeout=10)
+    server = ls.LitServer(api, spec=ls.OpenAIEmbeddingSpec())
 
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(


### PR DESCRIPTION
## What does this PR do?

Batch size is closely attached to LitAPI for batched processing. LitServer doesn't make any use of this value. 

Decoupling batch size and batch timeout from LitServer will help in enabling multiple endpoints with a cleaner architecture. 

### Old

```py
api = LitAPI()
server = LitServer(api, batch_size=4)
```

### New

```py
api = LitAPI(batch_size=4)
server = LitServer(api)
```


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
