### PR TITLE
keep "minimal dependency CI" minimal

### DIFF
--- a/tests/minimal_run.py
+++ b/tests/minimal_run.py
@@ -21,7 +21,7 @@ import psutil
 
 def main():
     process = subprocess.Popen(
-        ["lightning", "serve", "api", "tests/simple_server.py", "--local"],
+        ["python", "tests/simple_server.py"],
     )
     print("Waiting for server to start...")
     time.sleep(10)


### PR DESCRIPTION
## What does this PR do?

The minimal dependency CI tests that LitServe can run error free with minimal dependency. Removing Lightning SDK command from the test which is causing the CI to freeze and will create a follow up to fix and test that separately.


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
