### PR TITLE
remove request_timeout from LitAPI.pre_setup(...)

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -133,9 +133,9 @@ class LitAPI(ABC):
     def device(self, value):
         self._device = value
 
-    def pre_setup(self, spec: Optional[LitSpec], timeout):
-        if self.batch_timeout > timeout and timeout not in (False, -1):
-            raise ValueError("batch_timeout must be less than timeout")
+    def pre_setup(self, spec: Optional[LitSpec]):
+        if self.batch_timeout > self.request_timeout and self.request_timeout not in (False, -1):
+            raise ValueError("batch_timeout must be less than request_timeout")
 
         if self.stream:
             self._default_unbatch = self._unbatch_stream

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -245,7 +245,7 @@ class LitServer:
         self.timeout = timeout
         lit_api.stream = stream
         lit_api.request_timeout = self.timeout
-        lit_api.pre_setup(spec=spec, timeout=timeout)
+        lit_api.pre_setup(spec=spec)
         self._loop.pre_setup(lit_api, spec=spec)
         self.app = FastAPI(lifespan=self.lifespan)
         self.app.response_queue_id = None


### PR DESCRIPTION
## What does this PR do?

Removes request_timeout from LitAPI.pre_setup. This is an internal API change, users are not impacted. simplifies code base for multiple endpoint. 

### Key changes 
- Changed the pre_setup method signature to remove the timeout parameter.
- Updated all calls to pre_setup across the codebase to use request_timeout.
- Adjusted tests to reflect the changes in pre_setup method usage.


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
