### PR TITLE
async support for streaming loop

### DIFF
--- a/src/litserve/loops/loops.py
+++ b/src/litserve/loops/loops.py
@@ -28,11 +28,25 @@ logger = logging.getLogger(__name__)
 
 
 def get_default_loop(stream: bool, max_batch_size: int, enable_async: bool = False) -> _BaseLoop:
+    """Get the default loop based on the stream flag, batch size, and async support.
+
+    Args:
+        stream: Whether streaming is enabled
+        max_batch_size: Maximum batch size
+        enable_async: Whether async support is enabled (supports both coroutines and async generators)
+
+    Returns:
+        The appropriate loop implementation
+
+    Raises:
+        ValueError: If async and batching are enabled together (not supported)
+
+    """
     if enable_async:
-        if stream:
-            raise ValueError("Async streaming is not supported. Please use enable_async=False with streaming.")
         if max_batch_size > 1:
             raise ValueError("Async batching is not supported. Please use enable_async=False with batching.")
+        if stream:
+            return StreamingLoop()  # StreamingLoop now supports async
         return SingleLoop()  # Only SingleLoop supports async currently
 
     if stream:

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -191,9 +191,6 @@ class StreamingLoop(DefaultLoop):
                     logger.debug("uid=%s", uid)
                 except (Empty, ValueError):
                     continue
-                except KeyboardInterrupt:
-                    self.kill()
-                    return
 
                 if (lit_api.request_timeout and lit_api.request_timeout != -1) and (
                     time.monotonic() - timestamp > lit_api.request_timeout

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import logging
 import time
 from queue import Empty, Queue
@@ -20,7 +21,7 @@ from fastapi import HTTPException
 
 from litserve import LitAPI
 from litserve.callbacks import CallbackRunner, EventTypes
-from litserve.loops.base import DefaultLoop, _inject_context, collate_requests
+from litserve.loops.base import DefaultLoop, _async_inject_context, _inject_context, collate_requests
 from litserve.specs.base import LitSpec
 from litserve.transport.base import MessageTransport
 from litserve.utils import LitAPIStatus, PickleableHTTPException
@@ -108,6 +109,120 @@ class StreamingLoop(DefaultLoop):
                 )
                 self.put_error_response(transport, response_queue_id, uid, e)
 
+    async def _process_streaming_request(
+        self,
+        request,
+        lit_api: LitAPI,
+        lit_spec: Optional[LitSpec],
+        transport: MessageTransport,
+        callback_runner: CallbackRunner,
+    ):
+        response_queue_id, uid, timestamp, x_enc = request
+        try:
+            context = {}
+            if hasattr(lit_spec, "populate_context"):
+                lit_spec.populate_context(context, x_enc)
+
+            callback_runner.trigger_event(EventTypes.BEFORE_DECODE_REQUEST, lit_api=lit_api)
+            x = await _async_inject_context(
+                context,
+                lit_api.decode_request,
+                x_enc,
+            )
+            callback_runner.trigger_event(EventTypes.AFTER_DECODE_REQUEST, lit_api=lit_api)
+
+            callback_runner.trigger_event(EventTypes.BEFORE_PREDICT, lit_api=lit_api)
+            y_gen = await _async_inject_context(
+                context,
+                lit_api.predict,
+                x,
+            )
+            callback_runner.trigger_event(EventTypes.AFTER_PREDICT, lit_api=lit_api)
+
+            callback_runner.trigger_event(EventTypes.BEFORE_ENCODE_RESPONSE, lit_api=lit_api)
+
+            # When using async, predict should return an async generator
+            # and encode_response should handle async generators
+            async for item in y_gen:
+                # For each item from predict, pass to encode_response
+                # The _async_inject_context already handles async generators correctly
+                enc_result = await _async_inject_context(
+                    context,
+                    lit_api.encode_response,
+                    [item],  # Wrap in list since encode_response expects an iterable
+                )
+
+                # encode_response should also return an async generator
+                async for y_enc in enc_result:
+                    y_enc = lit_api.format_encoded_response(y_enc)
+                    self.put_response(transport, response_queue_id, uid, y_enc, LitAPIStatus.OK)
+
+            self.put_response(transport, response_queue_id, uid, "", LitAPIStatus.FINISH_STREAMING)
+            callback_runner.trigger_event(EventTypes.AFTER_ENCODE_RESPONSE, lit_api=lit_api)
+
+        except HTTPException as e:
+            self.put_response(
+                transport=transport,
+                response_queue_id=response_queue_id,
+                uid=uid,
+                response_data=PickleableHTTPException.from_exception(e),
+                status=LitAPIStatus.ERROR,
+            )
+        except Exception as e:
+            logger.exception(
+                "LitAPI ran into an error while processing the streaming request uid=%s.\n"
+                "Please check the error trace for more details.",
+                uid,
+            )
+            self.put_error_response(transport, response_queue_id, uid, e)
+
+    def run_streaming_loop_async(
+        self,
+        lit_api: LitAPI,
+        lit_spec: Optional[LitSpec],
+        request_queue: Queue,
+        transport: MessageTransport,
+        callback_runner: CallbackRunner,
+    ):
+        async def process_requests():
+            while True:
+                try:
+                    response_queue_id, uid, timestamp, x_enc = request_queue.get(timeout=1.0)
+                    logger.debug("uid=%s", uid)
+                except (Empty, ValueError):
+                    continue
+                except KeyboardInterrupt:
+                    self.kill()
+                    return
+
+                if (lit_api.request_timeout and lit_api.request_timeout != -1) and (
+                    time.monotonic() - timestamp > lit_api.request_timeout
+                ):
+                    logger.error(
+                        f"Request {uid} was waiting in the queue for too long ({lit_api.request_timeout} seconds) and "
+                        "has been timed out. "
+                        "You can adjust the timeout by providing the `timeout` argument to LitServe(..., timeout=30)."
+                    )
+                    self.put_response(
+                        transport, response_queue_id, uid, HTTPException(504, "Request timed out"), LitAPIStatus.ERROR
+                    )
+                    continue
+
+                await self._process_streaming_request(
+                    (response_queue_id, uid, timestamp, x_enc),
+                    lit_api,
+                    lit_spec,
+                    transport,
+                    callback_runner,
+                )
+
+        loop = asyncio.get_event_loop()
+
+        try:
+            loop.run_until_complete(process_requests())
+        except KeyboardInterrupt:
+            self.kill()
+
     def __call__(
         self,
         lit_api: LitAPI,
@@ -120,7 +235,10 @@ class StreamingLoop(DefaultLoop):
         workers_setup_status: Dict[int, str],
         callback_runner: CallbackRunner,
     ):
-        self.run_streaming_loop(lit_api, lit_spec, request_queue, transport, callback_runner)
+        if lit_api.enable_async:
+            self.run_streaming_loop_async(lit_api, lit_spec, request_queue, transport, callback_runner)
+        else:
+            self.run_streaming_loop(lit_api, lit_spec, request_queue, transport, callback_runner)
 
 
 class BatchedStreamingLoop(DefaultLoop):

--- a/tests/e2e/default_async_streaming.py
+++ b/tests/e2e/default_async_streaming.py
@@ -1,0 +1,36 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import litserve as ls
+
+
+class AsyncAPI(ls.LitAPI):
+    def setup(self, device) -> None:
+        self.model = lambda x: x
+
+    async def decode_request(self, request):
+        return request["input"]
+
+    async def predict(self, x):
+        for i in range(10):
+            yield self.model(i)
+
+    async def encode_response(self, output):
+        for out in output:
+            yield {"output": out}
+
+
+if __name__ == "__main__":
+    api = AsyncAPI(enable_async=True)
+    server = ls.LitServer(api, stream=True)
+    server.run(port=8000)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -379,3 +379,14 @@ def test_openai_embedding_parity():
     assert len(response.data) == 2, f"Expected 2 embeddings but got {len(response.data)}"
     for data in response.data:
         assert len(data.embedding) == 768, f"Expected 768 dimensions but got {len(data.embedding)}"
+
+
+@e2e_from_file("tests/e2e/default_async_streaming.py")
+def test_e2e_default_async_streaming():
+    resp = requests.post("http://127.0.0.1:8000/predict", json={"input": 4.0}, headers=None, stream=True)
+    outputs = []
+    for line in resp.iter_lines():
+        if line:
+            outputs.append(json.loads(line.decode("utf-8"))["output"])
+
+    assert outputs == list(range(10)), "server didn't return expected output"

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -602,11 +602,10 @@ def test_get_default_loop():
 
 def test_get_default_loop_enable_async():
     lit_api = MagicMock()
-    lit_api.stream = True
-    lit_api.max_batch_size = 1
+    lit_api.max_batch_size = 2
     lit_api.enable_async = True
     with pytest.raises(
-        ValueError, match="Async streaming is not supported. Please use enable_async=False with streaming."
+        ValueError, match="Async batching is not supported. Please use enable_async=False with batching."
     ):
         ls.loops.get_default_loop(lit_api.stream, lit_api.max_batch_size, lit_api.enable_async)
 


### PR DESCRIPTION
## What does this PR do?

Follow up to https://github.com/Lightning-AI/LitServe/pull/477, users would be able to run streaming APIs with async. 

```python
import litserve as ls

class AsyncAPI(ls.LitAPI):
    def setup(self, device) -> None:
        self.model = lambda x: x

    async def decode_request(self, request):
        return request["input"]

    async def predict(self, x):
        for i in range(10):
            yield self.model(i)

    async def encode_response(self, output):
        for out in output:
            yield {"output": out}

if __name__ == "__main__":
    api = AsyncAPI(enable_async=True)
    server = ls.LitServer(api, stream=True)
    server.run(port=8000)
```

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
