### PR TITLE
Add Exception handling test for Async LitAPI Loops

### DIFF
--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -605,14 +605,14 @@ async def test_concurrent_async_inference():
             assert elapsed < 4 + 4, f"Expected all requests to finish in just over 4s, but took {elapsed:.2f}s."
 
 
-class TestAsyncHTTPExceptionLitAPI(TestAsyncLitAPI):
+class TestHTTPExceptionAsyncLitAPI(TestAsyncLitAPI):
     async def decode_request(self, request):
         raise HTTPException(status_code=501, detail="decode request is bad")
 
 
 @pytest.mark.asyncio
-async def test_async_http_exception():
-    server = LitServer(TestAsyncHTTPExceptionLitAPI(enable_async=True))
+async def test_error_propagation_in_async_litapi():
+    server = LitServer(TestHTTPExceptionAsyncLitAPI(enable_async=True))
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"
@@ -620,3 +620,6 @@ async def test_async_http_exception():
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
             assert resp.status_code == 501, "Server raises 501 error"
             assert resp.json() == {"detail": "decode request is bad"}, "decode request is bad"
+
+
+

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -620,6 +620,3 @@ async def test_error_propagation_in_async_litapi():
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
             assert resp.status_code == 501, "Server raises 501 error"
             assert resp.json() == {"detail": "decode request is bad"}, "decode request is bad"
-
-
-

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -603,3 +603,20 @@ async def test_concurrent_async_inference():
 
             # All requests should finish in just over 4s, plus some overhead
             assert elapsed < 4 + 4, f"Expected all requests to finish in just over 4s, but took {elapsed:.2f}s."
+
+
+class TestAsyncHTTPExceptionLitAPI(TestAsyncLitAPI):
+    async def decode_request(self, request):
+        raise HTTPException(status_code=501, detail="decode request is bad")
+
+
+@pytest.mark.asyncio
+async def test_async_http_exception():
+    server = LitServer(TestAsyncHTTPExceptionLitAPI(enable_async=True))
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
+            assert resp.status_code == 501, "Server raises 501 error"
+            assert resp.json() == {"detail": "decode request is bad"}, "decode request is bad"


### PR DESCRIPTION
## What does this PR do?

Follow-up to #479
> [would be nice follow up PR to ensure that errors from the background task (asyncio.create_task) are propagated to users properly.](https://github.com/Lightning-AI/LitServe/pull/479#pullrequestreview-2824617594)

Introduce a test to validate the handling of HTTP exceptions in the asynchronous LitAPI, ensuring proper error responses are returned.