### PR TITLE
Add tests for async loop processing

### DIFF
--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -158,10 +158,10 @@ def test_run_single_loop_with_async(async_loop_args, monkeypatch):
     # Patch kill to do nothing in test
     monkeypatch.setattr(loop, "kill", lambda: None)
 
-    try:  # noqa: SIM105
+    # Expected to break the loop in test
+    import contextlib
+    with contextlib.suppress(KeyboardInterrupt):
         loop._run_single_loop_with_async(lit_api_mock, None, requests_queue, mock_transport, NOOP_CB_RUNNER)
-    except KeyboardInterrupt:
-        pass  # Expected to break the loop in test
 
     response = asyncio.get_event_loop().run_until_complete(mock_transport.areceive(consumer_id=0))
     assert response == ("uuid-123", ({"output": 1}, ls.utils.LitAPIStatus.OK))

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -160,6 +160,7 @@ def test_run_single_loop_with_async(async_loop_args, monkeypatch):
 
     # Expected to break the loop in test
     import contextlib
+
     with contextlib.suppress(KeyboardInterrupt):
         loop._run_single_loop_with_async(lit_api_mock, None, requests_queue, mock_transport, NOOP_CB_RUNNER)
 

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -96,7 +96,7 @@ def async_loop_args():
 
     lit_api_mock = MagicMock()
     lit_api_mock.request_timeout = 1
-    lit_api_mock.decode_request = AsyncMock(side_effect=lambda x: x.get("input", 0))
+    lit_api_mock.decode_request = AsyncMock(side_effect=lambda x: x["input"])
     lit_api_mock.predict = AsyncMock(side_effect=lambda x: x**2)
     lit_api_mock.encode_response = AsyncMock(side_effect=lambda x: {"output": x})
     return lit_api_mock, requests_queue

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -96,7 +96,7 @@ def async_loop_args():
 
     lit_api_mock = MagicMock()
     lit_api_mock.request_timeout = 1
-    lit_api_mock.decode_request = AsyncMock(side_effect=lambda x: x["input"])
+    lit_api_mock.decode_request = AsyncMock(side_effect=lambda x: x.get("input", 0))
     lit_api_mock.predict = AsyncMock(side_effect=lambda x: x**2)
     lit_api_mock.encode_response = AsyncMock(side_effect=lambda x: {"output": x})
     return lit_api_mock, requests_queue


### PR DESCRIPTION
## What does this PR do?
Follow-up to #482

Introduce tests for `_process_single_request` and `_run_single_loop_with_async` for processing async requests.
> increases the test coverage overall from 85% to 86%.

<img width="1290" alt="image" src="https://github.com/user-attachments/assets/5d23f87d-11f4-45c1-a858-bb31d85e84fe" />
