### PR TITLE
Enable true concurrency in async streaming loop and add tests

### DIFF
--- a/src/litserve/__about__.py
+++ b/src/litserve/__about__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.2.10.dev0"
+__version__ = "0.2.10"
 __author__ = "Lightning-AI et al."
 __author_email__ = "community@lightning.ai"
 __license__ = "Apache-2.0"

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -191,7 +191,6 @@ class StreamingLoop(DefaultLoop):
                     response_queue_id, uid, timestamp, x_enc = request_queue.get(timeout=1.0)
                     logger.debug("uid=%s", uid)
                 except (Empty, ValueError):
-                    await asyncio.sleep(0.1)  # Add small delay to prevent CPU spinning
                     continue
 
                 if (lit_api.request_timeout and lit_api.request_timeout != -1) and (

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -189,7 +189,9 @@ class StreamingLoop(DefaultLoop):
             pending_tasks = set()
             while True:
                 try:
-                    response_queue_id, uid, timestamp, x_enc = await event_loop.run_in_executor(None, request_queue.get, 1.0)
+                    response_queue_id, uid, timestamp, x_enc = await event_loop.run_in_executor(
+                        None, request_queue.get, 1.0
+                    )
                     logger.debug("uid=%s", uid)
                 except (Empty, ValueError):
                     continue

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -187,6 +187,7 @@ class StreamingLoop(DefaultLoop):
         async def process_requests():
             event_loop = asyncio.get_running_loop()
             pending_tasks = set()
+
             while True:
                 try:
                     response_queue_id, uid, timestamp, x_enc = await event_loop.run_in_executor(

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -191,6 +191,7 @@ class StreamingLoop(DefaultLoop):
                     response_queue_id, uid, timestamp, x_enc = request_queue.get(timeout=1.0)
                     logger.debug("uid=%s", uid)
                 except (Empty, ValueError):
+                    await asyncio.sleep(0.1)  # Add small delay to prevent CPU spinning
                     continue
 
                 if (lit_api.request_timeout and lit_api.request_timeout != -1) and (

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -185,10 +185,11 @@ class StreamingLoop(DefaultLoop):
         callback_runner: CallbackRunner,
     ):
         async def process_requests():
+            event_loop = asyncio.get_running_loop()
             pending_tasks = set()
             while True:
                 try:
-                    response_queue_id, uid, timestamp, x_enc = request_queue.get(timeout=1.0)
+                    response_queue_id, uid, timestamp, x_enc = await event_loop.run_in_executor(None, request_queue.get, 1.0)
                     logger.debug("uid=%s", uid)
                 except (Empty, ValueError):
                     continue
@@ -213,7 +214,8 @@ class StreamingLoop(DefaultLoop):
                         lit_spec,
                         transport,
                         callback_runner,
-                    )
+                    ),
+                    name=f"streaming_request_{uid}",
                 )
                 pending_tasks.add(task)
                 task.add_done_callback(pending_tasks.discard)

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -584,8 +584,6 @@ async def test_concurrent_async_inference(num_requests):
             transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             sleep(2)  # Sleep a bit to ensure the server is ready
-            resp = await ac.get("/health")
-            assert resp.status_code == 200, "Health check should return 200 (OK)"
 
             tasks = [ac.post("/predict", json={"input": 5.0}, timeout=10) for _ in range(num_requests)]
             start = time.perf_counter()
@@ -668,8 +666,6 @@ async def test_concurrent_async_streaming_inference(num_requests):
             transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             sleep(2)  # Sleep a bit to ensure the server is ready
-            resp = await ac.get("/health")
-            assert resp.status_code == 200, "Health check should return 200 (OK)"
 
             # Prepare concurrent streaming requests using the parameterized num_requests
             tasks = [ac.post("/predict", json={"input": 4.0}, timeout=10) for _ in range(num_requests)]

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -688,6 +688,6 @@ async def test_concurrent_async_streaming_inference(num_requests):
                 assert chunks == list(range(5)), "Expected output to be a sequence of integers from 0 to 4"
 
             # All requests should finish in just over the streaming time for one request
-            assert elapsed < 3 + 4, (
-                f"Expected all requests to finish in just over 3s, plus some overhead, but took {elapsed:.2f}s."
+            assert elapsed < 4 + 4, (
+                f"Expected all requests to finish in just over 4s, plus some overhead, but took {elapsed:.2f}s."
             )

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -566,24 +566,16 @@ async def test_async_litapi():
             assert resp.json()["output"] == 25.0, "output from Identity server must be same as input"
 
 
-class TestSleepAsyncLitAPI(ls.LitAPI):
-    def setup(self, device):
-        self.model = None
-
-    async def decode_request(self, request):
-        return request["input"]
-
+class TestSleepAsyncLitAPI(TestAsyncLitAPI):
     async def predict(self, x):
         # simulate a long-running task
         await asyncio.sleep(4)
         return x**2
 
-    async def encode_response(self, output):
-        return {"output": output}
-
 
 @pytest.mark.asyncio
-async def test_concurrent_async_inference():
+@pytest.mark.parametrize("num_requests", [10, 50, 100])
+async def test_concurrent_async_inference(num_requests):
     """Test that async API processes requests concurrently (not sequentially)."""
     api = TestSleepAsyncLitAPI(enable_async=True)
     server = LitServer(api)
@@ -592,7 +584,9 @@ async def test_concurrent_async_inference():
             transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             sleep(2)  # Sleep a bit to ensure the server is ready
-            num_requests = 10
+            resp = await ac.get("/health")
+            assert resp.status_code == 200, "Health check should return 200 (OK)"
+
             tasks = [ac.post("/predict", json={"input": 5.0}, timeout=10) for _ in range(num_requests)]
             start = time.perf_counter()
             responses = await asyncio.gather(*tasks)
@@ -655,3 +649,45 @@ async def test_async_stream_litapi():
                     chunks.append(json.loads(line)["output"])
             assert len(chunks) == 5, "Expected 5 chunks of output"
             assert chunks == list(range(5)), "Expected output to be a sequence of integers from 0 to 4"
+
+
+class TestSleepAsyncStreamLitAPI(TestAsyncStreamLitAPI):
+    async def predict(self, x):
+        for i in range(5):
+            await asyncio.sleep(0.5)  # Simulate streaming delay
+            yield i
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("num_requests", [10, 50, 100])
+async def test_concurrent_async_streaming_inference(num_requests):
+    api = TestSleepAsyncStreamLitAPI(enable_async=True)
+    server = LitServer(api, stream=True)
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            sleep(2)  # Sleep a bit to ensure the server is ready
+            resp = await ac.get("/health")
+            assert resp.status_code == 200, "Health check should return 200 (OK)"
+
+            # Prepare concurrent streaming requests using the parameterized num_requests
+            tasks = [ac.post("/predict", json={"input": 4.0}, timeout=10) for _ in range(num_requests)]
+            start = time.perf_counter()
+            responses = await asyncio.gather(*tasks)
+            elapsed = time.perf_counter() - start
+
+            # Collect and check streamed outputs for each response
+            for resp in responses:
+                assert resp.status_code == 200, "Server response should be 200 (OK)"
+                chunks = []
+                async for line in resp.aiter_lines():
+                    if line.strip():
+                        chunks.append(json.loads(line)["output"])
+                assert len(chunks) == 5, "Expected 5 chunks of output"
+                assert chunks == list(range(5)), "Expected output to be a sequence of integers from 0 to 4"
+
+            # All requests should finish in just over the streaming time for one request
+            assert elapsed < 3 + 4, (
+                f"Expected all requests to finish in just over 3s, plus some overhead, but took {elapsed:.2f}s."
+            )


### PR DESCRIPTION
## What does this PR do ?

Follow-up to #478
The async streaming loop now processes tasks concurrently, so new requests don't have to wait for previous ones to finish.

Also, adds tests for async streaming functionality and concurrent request handling.