### PR TITLE
moving max_batch_size in README to inside SimpleLitAPI()

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class SimpleLitAPI(ls.LitAPI):
 # (STEP 2) - START THE SERVER
 if __name__ == "__main__":
     # scale with advanced features (batching, GPUs, etc...)
-    server = ls.LitServer(SimpleLitAPI(), accelerator="auto", max_batch_size=1)
+    server = ls.LitServer(SimpleLitAPI(max_batch_size=1), accelerator="auto")
     server.run(port=8000)
 ```
 


### PR DESCRIPTION
## What does this PR do?

Moves the max_batch_size parameter in the README Quick Start to inside SimpleLitAPI. This is fixing documentation due to a recent migration of batch size parameters to within the LitServe API instead of the LitServer itself. As a user, I look to the Quick Start to understand the purpose of LitServe. This PR allows for those in the future to not encounter the DeprecationWarning or eventually not be able to run the Quick Start.

(This is my first open-source contribution, just trying to understand the whole process before I work on more technical open issues!)

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [✅] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [✅] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
