### PR TITLE
fix OpenAI embedding spec for batching

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -176,6 +176,7 @@ Streaming example:
 
         if spec:
             self._spec = spec
+            spec._max_batch_size = self.max_batch_size
             spec.pre_setup(self)
 
     def set_logger_queue(self, queue: Queue):

--- a/src/litserve/loops/simple_loops.py
+++ b/src/litserve/loops/simple_loops.py
@@ -326,11 +326,14 @@ class BatchedLoop(DefaultLoop):
                 outputs = lit_api.unbatch(y)
 
                 if len(outputs) != num_inputs:
+                    actual = len(outputs)
                     logger.error(
-                        f"LitAPI.predict/unbatch returned {len(outputs)} outputs, but expected {num_inputs}. "
-                        "Please check the predict/unbatch method of the LitAPI implementation."
+                        f"LitAPI.predict/unbatch returned {actual} outputs, but expected {num_inputs}. "
+                        "This suggests a possible issue in the predict or unbatch implementation.\n"
+                        "Hint: Ensure that LitAPI.predict returns a list with one prediction per input — "
+                        "the length of the returned list should match the number of inputs."
                     )
-                    raise HTTPException(500, "Batch size mismatch")
+                    raise HTTPException(500, detail="Batch size mismatch")
 
                 callback_runner.trigger_event(EventTypes.BEFORE_ENCODE_RESPONSE.value, lit_api=lit_api)
                 y_enc_list = []

--- a/src/litserve/specs/__init__.py
+++ b/src/litserve/specs/__init__.py
@@ -1,4 +1,12 @@
-from litserve.specs.openai import OpenAISpec
-from litserve.specs.openai_embedding import OpenAIEmbeddingSpec
+from litserve.specs.openai import ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, OpenAISpec
+from litserve.specs.openai_embedding import EmbeddingRequest, EmbeddingResponse, OpenAIEmbeddingSpec
 
-__all__ = ["OpenAISpec", "OpenAIEmbeddingSpec"]
+__all__ = [
+    "OpenAISpec",
+    "OpenAIEmbeddingSpec",
+    "EmbeddingRequest",
+    "EmbeddingResponse",
+    "ChatCompletionRequest",
+    "ChatCompletionResponse",
+    "ChatCompletionChunk",
+]

--- a/src/litserve/specs/base.py
+++ b/src/litserve/specs/base.py
@@ -25,6 +25,7 @@ class LitSpec:
         self._endpoints = []
 
         self._server: LitServer = None
+        self._max_batch_size = 1
 
     @property
     def stream(self):

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -78,14 +78,15 @@ Please follow the example below for guidance on how to use the OpenAI Embedding 
 ```python
 import numpy as np
 from typing import List
+from litserve.specs import EmbeddingRequest
 from litserve import LitAPI, OpenAIEmbeddingSpec
 
 class TestAPI(LitAPI):
     def setup(self, device):
         self.model = None
 
-    def decode_request(self, request) -> List[str]:
-        return request.ensure_list()
+    def decode_request(self, request: EmbeddingRequest) -> List[str]:
+        return request.input
 
     def predict(self, x) -> List[List[float]]:
         return np.random.rand(len(x), 768).tolist()
@@ -136,7 +137,7 @@ class OpenAIEmbeddingSpec(LitSpec):
         print("OpenAI Embedding Spec is ready.")
 
     def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> List[str]:
-        return request.ensure_list()
+        return request.input
 
     def encode_response(self, output: List[List[float]], context_kwargs: Optional[dict] = None) -> dict:
         usage = {

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -211,7 +211,7 @@ class OpenAIEmbeddingSpec(LitSpec):
             embeddings = embeddings.tolist()
 
         # expand dims for list of floats
-        if isinstance(embeddings, list) and isinstance(embeddings[0], (int, float)):
+        if isinstance(embeddings, (list, tuple)) and isinstance(embeddings[0], (int, float)):
             embeddings = [embeddings]
 
         # check if we have total num_items number of embeddings vectors

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -233,12 +233,13 @@ class OpenAIEmbeddingSpec(LitSpec):
     async def embeddings_endpoint(self, request: EmbeddingRequest) -> EmbeddingResponse:
         response_queue_id = self.response_queue_id
         num_items = request.get_num_items()
-        if num_items > 1:
+        if num_items > 1 and self._max_batch_size > 1:
             raise HTTPException(
-                status_code=status_code.HTTP_400_BAD_REQUEST,
-                detail=f"OpenAIEmbedding specs doesn't support client side batching. "
-                "Please send a single input or enable batching in the LitAPI implementation.\n\n"
-                f"{EMBEDDING_API_EXAMPLE_BATCHING}",
+                status_code=400,
+                detail=(
+                    "The OpenAIEmbedding spec does not support dynamic batching when client-side batching is used. "
+                    "To resolve this, either set `max_batch_size=1` or send a single input from the client."
+                ),
             )
 
         logger.debug("Received embedding request: %s", request)

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -9,9 +9,6 @@ class TestEmbedAPI(LitAPI):
     def setup(self, device):
         self.model = None
 
-    def decode_request(self, request) -> List[str]:
-        return request.ensure_list()
-
     def predict(self, x) -> List[List[float]]:
         return np.random.rand(len(x), 768).tolist()
 

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -10,7 +10,7 @@ class TestEmbedAPI(LitAPI):
         self.model = None
 
     def predict(self, x) -> List[List[float]]:
-        return np.random.rand(len(x), 768).tolist()
+        return np.random.rand(768).tolist()
 
     def encode_response(self, output) -> dict:
         return {"embeddings": output}

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -10,7 +10,8 @@ class TestEmbedAPI(LitAPI):
         self.model = None
 
     def predict(self, x) -> List[List[float]]:
-        return np.random.rand(768).tolist()
+        n = len(x) if isinstance(x, list) else 1
+        return np.random.rand(n, 768).tolist()
 
     def encode_response(self, output) -> dict:
         return {"embeddings": output}

--- a/tests/e2e/openai_embedding_with_batching.py
+++ b/tests/e2e/openai_embedding_with_batching.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+import litserve as ls
+
+
+class EmbeddingsAPI(ls.LitAPI):
+    def setup(self, device):
+        def model(x):
+            return np.random.rand(len(x), 768)
+
+        self.model = model
+
+    def predict(self, inputs):
+        return self.model(inputs)
+
+
+if __name__ == "__main__":
+    api = EmbeddingsAPI(max_batch_size=10, batch_timeout=2)
+    server = ls.LitServer(api, spec=ls.OpenAIEmbeddingSpec())
+    server.run(port=8000)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -390,3 +390,20 @@ def test_e2e_default_async_streaming():
             outputs.append(json.loads(line.decode("utf-8"))["output"])
 
     assert outputs == list(range(10)), "server didn't return expected output"
+
+
+@e2e_from_file("tests/e2e/openai_embedding_with_batching.py")
+def test_e2e_openai_embedding_with_batching():
+    model = "text-embedding-3-large"
+    client = OpenAI(
+        base_url="http://127.0.0.1:8000/v1",
+        api_key="lit",  # required, but unused
+    )
+    response = client.embeddings.create(
+        model=model,
+        input=[
+            "How are you?",
+        ],
+    )
+    assert response.model == model, f"Expected model to be {model} but got {response.model}"
+    assert len(response.data[0].embedding) == 768, f"Expected 768 dimensions but got {len(response.data[0].embedding)}"

--- a/tests/test_openai_embedding.py
+++ b/tests/test_openai_embedding.py
@@ -1,0 +1,156 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import numpy as np
+import pytest
+from asgi_lifespan import LifespanManager
+from httpx import ASGITransport, AsyncClient
+
+import litserve as ls
+from litserve.specs.openai_embedding import OpenAIEmbeddingSpec
+from litserve.test_examples.openai_embedding_spec_example import (
+    TestEmbedAPI,
+    TestEmbedAPIWithMissingEmbeddings,
+    TestEmbedAPIWithNonDictOutput,
+    TestEmbedAPIWithUsage,
+    TestEmbedAPIWithYieldEncodeResponse,
+    TestEmbedAPIWithYieldPredict,
+)
+from litserve.utils import wrap_litserve_start
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_with_single_input(openai_embedding_request_data):
+    spec = OpenAIEmbeddingSpec()
+    server = ls.LitServer(TestEmbedAPI(), spec=spec)
+
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10)
+            assert resp.status_code == 200, "Status code should be 200"
+            assert resp.json()["object"] == "list", "Object should be list"
+            assert resp.json()["data"][0]["index"] == 0, "Index should be 0"
+            assert len(resp.json()["data"]) == 1, "Length of data should be 1"
+            assert len(resp.json()["data"][0]["embedding"]) == 768, "Embedding length should be 768"
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_with_multiple_inputs(openai_embedding_request_data_array):
+    spec = OpenAIEmbeddingSpec()
+    server = ls.LitServer(TestEmbedAPI(), spec=spec)
+
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/v1/embeddings", json=openai_embedding_request_data_array, timeout=10)
+            assert resp.status_code == 200, (
+                f"Status code should be 200 but got {resp.status_code}, response: {resp.content}"
+            )
+            assert resp.json()["object"] == "list", "Object should be list"
+            assert resp.json()["data"][0]["index"] == 0, "Index should be 0"
+            assert len(resp.json()["data"]) == 4, "Length of data should be 1"
+            assert len(resp.json()["data"][0]["embedding"]) == 768, "Embedding length should be 768"
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_with_usage(openai_embedding_request_data):
+    spec = OpenAIEmbeddingSpec()
+    server = ls.LitServer(TestEmbedAPIWithUsage(), spec=spec)
+
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10)
+            assert resp.status_code == 200, "Status code should be 200"
+            assert resp.json()["object"] == "list", "Object should be list"
+            assert resp.json()["data"][0]["index"] == 0, "Index should be 0"
+            assert len(resp.json()["data"]) == 1, "Length of data should be 1"
+            assert len(resp.json()["data"][0]["embedding"]) == 768, "Embedding length should be 768"
+            assert resp.json()["usage"]["prompt_tokens"] == 10, "Prompt tokens should be 10"
+            assert resp.json()["usage"]["total_tokens"] == 10, "Total tokens should be 10"
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_validation(openai_request_data):
+    server = ls.LitServer(TestEmbedAPIWithYieldPredict(), spec=OpenAIEmbeddingSpec())
+    with pytest.raises(ValueError, match="You are using yield in your predict method"), wrap_litserve_start(
+        server
+    ) as server:
+        async with LifespanManager(server.app):
+            pass
+
+    server = ls.LitServer(TestEmbedAPIWithYieldEncodeResponse(), spec=OpenAIEmbeddingSpec())
+    with pytest.raises(ValueError, match="You are using yield in your encode_response method"), wrap_litserve_start(
+        server
+    ) as server:
+        async with LifespanManager(server.app):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_with_non_dict_output(openai_embedding_request_data):
+    server = ls.LitServer(TestEmbedAPIWithNonDictOutput(), spec=ls.OpenAIEmbeddingSpec())
+
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            with pytest.raises(ValueError, match="Expected response to be a dictionary"):
+                await ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_with_missing_embeddings(openai_embedding_request_data):
+    server = ls.LitServer(TestEmbedAPIWithMissingEmbeddings(), spec=OpenAIEmbeddingSpec())
+
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            with pytest.raises(ValueError, match="The response does not contain the key 'embeddings'"):
+                await ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10)
+
+
+class TestOpenAIWithBatching(TestEmbedAPI):
+    def predict(self, batch):
+        assert len(batch) == 2, f"Batch size should be 2 but got {len(batch)}"
+        return [np.random.rand(len(x), 768).tolist() for x in batch]
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_with_batching(openai_embedding_request_data, openai_embedding_request_data_array):
+    server = ls.LitServer(TestOpenAIWithBatching(), spec=ls.OpenAIEmbeddingSpec(), max_batch_size=2, batch_timeout=10)
+
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            # send concurrent requests
+            resp1, resp2 = await asyncio.gather(
+                ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10),
+                ac.post("/v1/embeddings", json=openai_embedding_request_data_array, timeout=10),
+            )
+
+            assert resp1.status_code == 200, "Status code should be 200"
+            assert resp2.status_code == 200, "Status code should be 200"
+            assert len(resp1.json()["data"]) == 1, "Length of data should be 1"
+            assert len(resp2.json()["data"]) == 4, "Length of data should be 4"
+            assert len(resp1.json()["data"][0]["embedding"]) == 768, "Embedding length should be 768"
+            assert len(resp2.json()["data"][0]["embedding"]) == 768, "Embedding length should be 768"

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -338,7 +338,7 @@ async def test_fail_http(openai_request_data):
 
 
 @pytest.mark.asyncio
-async def test_openai_embedding_spec_with_single_input_doc(openai_embedding_request_data):
+async def test_openai_embedding_spec_with_single_input(openai_embedding_request_data):
     spec = OpenAIEmbeddingSpec()
     server = ls.LitServer(TestEmbedAPI(), spec=spec)
 
@@ -355,7 +355,7 @@ async def test_openai_embedding_spec_with_single_input_doc(openai_embedding_requ
 
 
 @pytest.mark.asyncio
-async def test_openai_embedding_spec_with_multiple_input_docs(openai_embedding_request_data_array):
+async def test_openai_embedding_spec_with_multiple_input(openai_embedding_request_data_array):
     spec = OpenAIEmbeddingSpec()
     server = ls.LitServer(TestEmbedAPI(), spec=spec)
 
@@ -364,7 +364,9 @@ async def test_openai_embedding_spec_with_multiple_input_docs(openai_embedding_r
             transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/v1/embeddings", json=openai_embedding_request_data_array, timeout=10)
-            assert resp.status_code == 200, "Status code should be 200"
+            assert resp.status_code == 200, (
+                f"Status code should be 200 but got {resp.status_code}, response: {resp.content}"
+            )
             assert resp.json()["object"] == "list", "Object should be list"
             assert resp.json()["data"][0]["index"] == 0, "Index should be 0"
             assert len(resp.json()["data"]) == 4, "Length of data should be 1"


### PR DESCRIPTION
## What does this PR do?

This PR addresses two key issues related to request decoding and response formatting when using the OpenAIEmbeddingSpec:

**1. Request Input Wrapping:**
The decode_request function always wraps request.input in a list, which breaks the downstream logic for certain input formats. This PR ensures inputs are handled more intelligently based on their structure.

**2. Output Shape Handling:**
When predict returns a 1D tensor or NumPy array (e.g., shape (128,)), the OpenAIEmbeddingSpec attempts to wrap each element individually into the Embedding class, leading to incorrect behavior. This PR corrects that by ensuring the output is treated as a single embedding vector when appropriate.

✅ Example Use Case
The following example previously failed due to the issues above but now works as expected after this fix:

```python
from sentence_transformers import SentenceTransformer
import litserve as ls

class EmbeddingsAPI(ls.LitAPI):
    def setup(self, device):
        self.model = SentenceTransformer("all-MiniLM-L6-v2", device=device)

    def predict(self, inputs):
        # Fix for nested list inputs
        if isinstance(inputs[0], list) and len(inputs[0]) == 1:
            inputs = inputs[0]
        return self.model.encode(inputs)

if __name__ == "__main__":
    api = EmbeddingsAPI(max_batch_size=2, batch_timeout=2)
    server = ls.LitServer(api, spec=ls.OpenAIEmbeddingSpec())
    server.run(port=8000)
```

After this PR, users will be able to run embedding models with LitServe and the OpenAIEmbeddingSpec seamlessly, even when the model outputs a 1D vector or the input structure is slightly irregular.


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
