### PR TITLE
chore: asyncify default decode_request method if not overridden by user

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -54,6 +54,14 @@ class LitAPI(ABC):
 
         # Asyncify default decode_request if not implemented by user when enable_async is True
         if self.enable_async and not asyncio.iscoroutinefunction(self.decode_request):
+            warnings.warn(
+                "'decode_request' is not implemented as an async coroutine. "
+                "Since 'enable_async=True', the default implementation will be wrapped to run asynchronously. "
+                "To avoid this warning and ensure proper async support, "
+                "please override 'decode_request' as 'async def decode_request(...)'.",
+                UserWarning,
+                stacklevel=2,
+            )
             self.decode_request = self._asyncify(self.decode_request)
 
         self._validate_async_methods()

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -52,14 +52,14 @@ class LitAPI(ABC):
         self.batch_timeout = batch_timeout
         self.enable_async = enable_async
 
-        # asyncify default decode_request if not implemented by user when enable_async is True
+        # Asyncify default decode_request if not implemented by user when enable_async is True
         if self.enable_async and not asyncio.iscoroutinefunction(self.decode_request):
             self.decode_request = self._asyncify(self.decode_request)
 
         self._validate_async_methods()
 
     def _asyncify(self, func):
-        """Wrap a function to be async if enable_async is True."""
+        """Wrap a synchronous function to be async using asyncio.to_thread."""
 
         @wraps(func)
         async def async_wrapper(*args, **kwargs):

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -522,8 +522,8 @@ class DecodeNotImplementedAsyncOpenAILitAPI(ls.LitAPI):
 
 
 @pytest.mark.asyncio
-def test_openai_asyncapi_decode_not_implemented():
-    with pytest.raises(ValueError, match=r"LitAPI\(enable_async=True\) requires all methods to be coroutines\."):
+def test_openai_asyncapi_decode_not_implemented_warning():
+    with pytest.warns(UserWarning, match="'decode_request' is not implemented as an async coroutine."):
         ls.LitServer(DecodeNotImplementedAsyncOpenAILitAPI(enable_async=True), spec=OpenAISpec())
 
 


### PR DESCRIPTION
## What does this PR do?

This PR is a follow-up to #499.
It ensures that the default `decode_request` method is converted to an asynchronous function if the user has not overridden it.
This allows consistent async behavior across implementations and improves compatibility with async-based request handling.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
