### PR TITLE
add shutdown endpoint w/ test

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -221,12 +221,9 @@ class LitServer:
             raise ValueError(
                 "info_path must start with '/'. Please provide a valid api path like '/info', '/details', or '/v1/info'"
             )
-        
+
         if not shutdown_path.startswith("/"):
-            raise ValueError(
-                "shutdown_path must start with '/'. "
-                "Please provide a valid api path like '/shutdown'"
-            )
+            raise ValueError("shutdown_path must start with '/'. Please provide a valid api path like '/shutdown'")
 
         try:
             json.dumps(model_metadata)
@@ -455,7 +452,7 @@ class LitServer:
                     },
                 }
             )
-        
+
         @self.app.post(self.shutdown_path, dependencies=[Depends(self.setup_auth())])
         async def shutdown(request: Request):
             server = self.app.state.server

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -457,6 +457,8 @@ class LitServer:
         async def shutdown(request: Request):
             server = self.app.state.server
             print("Initiating shutdown...")
+            if server.should_exit:
+                return Response(content="Shutdown already in progress", status_code=400)
             server.should_exit = True
 
             return Response(content="Server has been shutdown")
@@ -631,12 +633,14 @@ class LitServer:
                     print(f"Uvicorn worker {i} : [{uw.pid}]")
                 uw.join()
         finally:
-            print("Shutting down LitServe")
             self._transport.close()
+            print("Transport closed")
             for iw in inference_workers:
                 iw: Process
+                print(f"Terminating worker [PID {iw.pid}]")
                 iw.terminate()
                 iw.join()
+            print("Shutting down LitServe")
             manager.shutdown()
 
     def _prepare_app_run(self, app: FastAPI):

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -27,9 +27,6 @@ from litserve import LitAPI, LitServer
 from litserve.utils import wrap_litserve_start
 
 from types import SimpleNamespace
-
-
-
 class SimpleLitAPI(LitAPI):
     def setup(self, device):
         self.model = lambda x: x**2

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -160,7 +160,6 @@ def test_shutdown_endpoint():
     server.app.state.server = SimpleNamespace(should_exit=False)
 
     with wrap_litserve_start(server) as server, TestClient(server.app) as client:
-        # Send a shutdown request
         response = client.post("/shutdown")
         assert response.status_code == 200
         assert "shutdown" in response.text.lower()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -15,6 +15,7 @@ import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -26,7 +27,7 @@ from httpx import ASGITransport, AsyncClient
 from litserve import LitAPI, LitServer
 from litserve.utils import wrap_litserve_start
 
-from types import SimpleNamespace
+
 class SimpleLitAPI(LitAPI):
     def setup(self, device):
         self.model = lambda x: x**2
@@ -145,7 +146,8 @@ def test_workers_health_with_custom_health_method(use_zmq):
         response = client.get("/health")
         assert response.status_code == 200
         assert response.text == "ok"
-   
+
+
 def test_shutdown_endpoint():
     server = LitServer(
         SlowSetupLitAPI(),
@@ -156,7 +158,7 @@ def test_shutdown_endpoint():
     )
 
     server.app.state.server = SimpleNamespace(should_exit=False)
-    
+
     with wrap_litserve_start(server) as server, TestClient(server.app) as client:
         # Send a shutdown request
         response = client.post("/shutdown")

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -166,7 +166,11 @@ def test_shutdown_endpoint():
         assert "shutdown" in response.text.lower()
         time.sleep(0.5)
         assert server.app.state.server.should_exit is True, "Server should be marked for shutdown"
-
+        
+        time.sleep(1)
+        response = client.post("/shutdown")
+        assert response.status_code == 400
+        assert "shutdown already" in response.text.lower()
 
 def make_load_request(server, outputs):
     with TestClient(server.app) as client:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -165,11 +165,12 @@ def test_shutdown_endpoint():
         assert "shutdown" in response.text.lower()
         time.sleep(0.5)
         assert server.app.state.server.should_exit is True, "Server should be marked for shutdown"
-        
+
         time.sleep(1)
         response = client.post("/shutdown")
         assert response.status_code == 400
         assert "shutdown already" in response.text.lower()
+
 
 def make_load_request(server, outputs):
     with TestClient(server.app) as client:


### PR DESCRIPTION
## What does this PR do?
As a user, I want the ability to shutdown a LitServe server programmatically instead of force quitting. This pull request adds a POST endpoint to the Uvicorn server (labeled /shutdown) which terminates the server using FastAPI's built-in `.should_exit()` function. A unit test has also been added, which has passed.  

<img width="644" alt="Screenshot 2025-05-22 at 4 49 39 PM" src="https://github.com/user-attachments/assets/610e5144-a5a1-456d-b666-a8f3acf6dd36" />


Fixes Issue #505.


<details>
  <summary><b>Before submitting</b></summary>

- [✅] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [✅] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [✅] Did you make sure to update the docs?
- [✅] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

This was a good challenge for me! I initially had some issues since exceptions were still arising when stopping the server, but I was able to find a way so there were no exceptions. 