### PR TITLE
add fpdb for multiprocess debugging using pdb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
+fpdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
-fpdb >=0.0.0.dev2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi >=0.100
 uvicorn[standard] >=0.29.0
 pyzmq >=22.0.0
-fpdb
+fpdb >=0.0.0.dev2

--- a/src/litserve/__init__.py
+++ b/src/litserve/__init__.py
@@ -18,7 +18,7 @@ from litserve.callbacks import Callback
 from litserve.loggers import Logger
 from litserve.server import LitServer, Request, Response
 from litserve.specs import OpenAIEmbeddingSpec, OpenAISpec
-from litserve.utils import configure_logging
+from litserve.utils import configure_logging, set_trace, set_trace_if_debug
 
 configure_logging()
 
@@ -32,4 +32,6 @@ __all__ = [
     "test_examples",
     "Callback",
     "Logger",
+    "set_trace",
+    "set_trace_if_debug",
 ]

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -155,7 +155,7 @@ def generate_random_zmq_address(temp_dir="/tmp"):
 
 
 class ForkedPdb(pdb.Pdb):
-    # Borrowed from https://github.com/Lightning-AI/forked-pdb
+    # Borrowed from - https://github.com/Lightning-AI/forked-pdb
     """
     PDB Subclass for debugging multi-processed code
     Suggested in: https://stackoverflow.com/questions/4716533/how-to-attach-debugger-to-a-python-subproccess

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -22,6 +22,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, AsyncIterator
 
 from fastapi import HTTPException
+from fpdb import ForkedPdb
 
 if TYPE_CHECKING:
     from litserve.server import LitServer
@@ -151,3 +152,14 @@ def generate_random_zmq_address(temp_dir="/tmp"):
     unique_name = f"zmq-{uuid.uuid4().hex}.ipc"
     ipc_path = os.path.join(temp_dir, unique_name)
     return f"ipc://{ipc_path}"
+
+
+def set_trace():
+    """Set a tracepoint in the code."""
+    ForkedPdb().set_trace()
+
+
+def set_trace_if_debug(debug_env_var="LITSERVE_DEBUG", debug_env_var_value="1"):
+    """Set a tracepoint in the code if the environment variable LITSERVE_DEBUG is set."""
+    if os.environ.get(debug_env_var) == debug_env_var_value:
+        set_trace()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,13 @@
 import os
 import pickle
 import sys
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
 
-from litserve.utils import call_after_stream, dump_exception, generate_random_zmq_address
+from litserve.utils import call_after_stream, dump_exception, generate_random_zmq_address, set_trace_if_debug
 
 
 def test_dump_exception():
@@ -50,3 +51,18 @@ def test_generate_random_zmq_address_non_windows(tmpdir):
     # Verify the path exists within the specified temp_dir
     assert os.path.commonpath([temp_dir, address1[6:]]) == temp_dir
     assert os.path.commonpath([temp_dir, address2[6:]]) == temp_dir
+
+
+@mock.patch("litserve.utils.set_trace")
+def test_set_trace_if_debug(mock_set_trace):
+    # mock environ
+    with mock.patch("litserve.utils.os.environ", {"LITSERVE_DEBUG": "1"}):
+        set_trace_if_debug()
+    mock_set_trace.assert_called_once()
+
+
+@mock.patch("litserve.utils.ForkedPdb")
+def test_set_trace_if_debug_not_set(mock_forked_pdb):
+    with mock.patch("litserve.utils.os.environ", {"LITSERVE_DEBUG": "0"}):
+        set_trace_if_debug()
+    mock_forked_pdb.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Users will be able to set_trace for debugging. 

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/ddad896d-ed7d-4872-b06c-d470f6a33e11" />

### Example

```
import litserve as ls

class SimpleLitAPI(ls.LitAPI):
    def setup(self, device):
        self.model1 = lambda x: x**2
        self.model2 = lambda x: x**3

    def decode_request(self, request):
        # get inputs to /predict
        return request["input"]

    def predict(self, x):
        # perform calculations using both models
        a = self.model1(x)
        ls.set_trace()
        b = self.model2(x)
        c = a + b
        return {"output": c}

    def encode_response(self, output):
        # package outputs from /predict
        return {"output": output}

if __name__ == "__main__":
    server = ls.LitServer(SimpleLitAPI(max_batch_size=1), accelerator="auto")
    server.run(port=8000)

```

- Added `set_trace` and `set_trace_if_debug` functions to `litserve/utils.py` for debugging support.
- Updated `litserve/__init__.py` to import new debugging utilities.
- Added unit tests for `set_trace_if_debug` to ensure correct behavior based on the `LITSERVE_DEBUG` environment variable.


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
