### PR TITLE
Support stream with non-stream LitAPIs

### DIFF
--- a/src/litserve/loops/base.py
+++ b/src/litserve/loops/base.py
@@ -142,7 +142,7 @@ class _BaseLoop(ABC):
             x = lit_api.decode_request(x_enc)
             response = lit_api.predict(x)
             response_enc = lit_api.encode_response(response)
-            response_queues[response_queue_id].put((uid, (response_enc, LitAPIStatus.OK)))
+            response_queues[response_queue_id].put((uid, (response_enc, LitAPIStatus.OK, LoopResponseType.REGULAR)))
     ```
 
     """

--- a/src/litserve/loops/base.py
+++ b/src/litserve/loops/base.py
@@ -29,7 +29,7 @@ from litserve import LitAPI
 from litserve.callbacks import CallbackRunner
 from litserve.specs.base import LitSpec
 from litserve.transport.base import MessageTransport
-from litserve.utils import LitAPIStatus
+from litserve.utils import LitAPIStatus, LoopResponseType
 
 logger = logging.getLogger(__name__)
 # FastAPI writes form files to disk over 1MB by default, which prevents serialization by multiprocessing
@@ -254,15 +254,26 @@ class LitLoop(_BaseLoop):
             lit_spec.populate_context(self._context, request)
 
     def put_response(
-        self, transport: MessageTransport, response_queue_id: int, uid: str, response_data: Any, status: LitAPIStatus
+        self,
+        transport: MessageTransport,
+        response_queue_id: int,
+        uid: str,
+        response_data: Any,
+        status: LitAPIStatus,
+        response_type: LoopResponseType,
     ) -> None:
-        transport.send((uid, (response_data, status)), consumer_id=response_queue_id)
+        transport.send((uid, (response_data, status, response_type)), consumer_id=response_queue_id)
 
     def put_error_response(
-        self, transport: MessageTransport, response_queue_id: int, uid: str, error: Exception
+        self,
+        transport: MessageTransport,
+        response_queue_id: int,
+        uid: str,
+        error: Exception,
+        response_type: LoopResponseType = LoopResponseType.REGULAR,
     ) -> None:
         error = pickle.dumps(error)
-        self.put_response(transport, response_queue_id, uid, error, LitAPIStatus.ERROR)
+        self.put_response(transport, response_queue_id, uid, error, LitAPIStatus.ERROR, response_type)
 
 
 class DefaultLoop(LitLoop):

--- a/src/litserve/loops/continuous_batching_loop.py
+++ b/src/litserve/loops/continuous_batching_loop.py
@@ -24,7 +24,7 @@ from litserve.callbacks import CallbackRunner
 from litserve.loops.base import LitLoop
 from litserve.specs.base import LitSpec
 from litserve.transport.base import MessageTransport
-from litserve.utils import LitAPIStatus
+from litserve.utils import LitAPIStatus, LoopResponseType
 
 logger = logging.getLogger(__name__)
 
@@ -210,19 +210,25 @@ requires the lit_api to have a has_finished method. Please implement the has_fin
 
                     response_data = lit_api.format_encoded_response(response_data)
                     if status == LitAPIStatus.ERROR:
-                        self.put_error_response(transport, response_queue_id, uid, response_data)
+                        self.put_error_response(
+                            transport, response_queue_id, uid, response_data, LoopResponseType.STREAMING
+                        )
                         self.mark_completed(uid)
                     elif status == LitAPIStatus.FINISH_STREAMING:
-                        self.put_response(transport, response_queue_id, uid, response_data, status)
+                        self.put_response(
+                            transport, response_queue_id, uid, response_data, status, LoopResponseType.STREAMING
+                        )
                         self.mark_completed(uid)
                     else:
-                        self.put_response(transport, response_queue_id, uid, response_data, status)
+                        self.put_response(
+                            transport, response_queue_id, uid, response_data, status, LoopResponseType.STREAMING
+                        )
 
         except Exception as e:
             logger.exception(f"Error in continuous batching loop: {e}")
             # Handle any errors by sending error responses for all tracked requests
             for uid, response_queue_id in self.response_queue_ids.items():
-                self.put_error_response(transport, response_queue_id, uid, e)
+                self.put_error_response(transport, response_queue_id, uid, e, LoopResponseType.STREAMING)
             self.response_queue_ids.clear()
             self.active_sequences.clear()
 

--- a/src/litserve/loops/continuous_batching_loop.py
+++ b/src/litserve/loops/continuous_batching_loop.py
@@ -35,7 +35,10 @@ def notify_timed_out_requests(
 ):
     for response_queue_id, uid in timed_out_uids:
         logger.error(f"Request {uid} was waiting in the queue for too long and has been timed out.")
-        response_queues[response_queue_id].put((uid, (HTTPException(504, "Request timed out"), LitAPIStatus.ERROR)))
+        response_queues[response_queue_id].put((
+            uid,
+            (HTTPException(504, "Request timed out"), LitAPIStatus.ERROR, LoopResponseType.STREAMING),
+        ))
 
 
 @dataclass

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -55,7 +55,12 @@ class StreamingLoop(DefaultLoop):
                     "You can adjust the timeout by providing the `timeout` argument to LitServe(..., timeout=30)."
                 )
                 self.put_response(
-                    transport, response_queue_id, uid, HTTPException(504, "Request timed out"), LitAPIStatus.ERROR
+                    transport,
+                    response_queue_id,
+                    uid,
+                    HTTPException(504, "Request timed out"),
+                    LitAPIStatus.ERROR,
+                    LoopResponseType.STREAMING,
                 )
                 continue
 
@@ -113,7 +118,7 @@ class StreamingLoop(DefaultLoop):
                     "Please check the error trace for more details.",
                     uid,
                 )
-                self.put_error_response(transport, response_queue_id, uid, e)
+                self.put_error_response(transport, response_queue_id, uid, e, LoopResponseType.STREAMING)
 
     async def _process_streaming_request(
         self,
@@ -186,7 +191,7 @@ class StreamingLoop(DefaultLoop):
                 "Please check the error trace for more details.",
                 uid,
             )
-            self.put_error_response(transport, response_queue_id, uid, e)
+            self.put_error_response(transport, response_queue_id, uid, e, LoopResponseType.STREAMING)
 
     def run_streaming_loop_async(
         self,
@@ -217,7 +222,12 @@ class StreamingLoop(DefaultLoop):
                         "You can adjust the timeout by providing the `timeout` argument to LitServe(..., timeout=30)."
                     )
                     self.put_response(
-                        transport, response_queue_id, uid, HTTPException(504, "Request timed out"), LitAPIStatus.ERROR
+                        transport,
+                        response_queue_id,
+                        uid,
+                        HTTPException(504, "Request timed out"),
+                        LitAPIStatus.ERROR,
+                        LoopResponseType.STREAMING,
                     )
                     continue
 
@@ -278,7 +288,12 @@ class BatchedStreamingLoop(DefaultLoop):
                     "You can adjust the timeout by providing the `timeout` argument to LitServe(..., timeout=30)."
                 )
                 self.put_response(
-                    transport, response_queue_id, uid, HTTPException(504, "Request timed out"), LitAPIStatus.ERROR
+                    transport,
+                    response_queue_id,
+                    uid,
+                    HTTPException(504, "Request timed out"),
+                    LitAPIStatus.ERROR,
+                    LoopResponseType.STREAMING,
                 )
 
             if not batches:
@@ -347,7 +362,7 @@ class BatchedStreamingLoop(DefaultLoop):
                     "Please check the error trace for more details."
                 )
                 for response_queue_id, uid in zip(response_queue_ids, uids):
-                    self.put_error_response(transport, response_queue_id, uid, e)
+                    self.put_error_response(transport, response_queue_id, uid, e, LoopResponseType.STREAMING)
 
     def __call__(
         self,

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -24,7 +24,7 @@ from litserve.callbacks import CallbackRunner, EventTypes
 from litserve.loops.base import DefaultLoop, _async_inject_context, _inject_context, collate_requests
 from litserve.specs.base import LitSpec
 from litserve.transport.base import MessageTransport
-from litserve.utils import LitAPIStatus, PickleableHTTPException
+from litserve.utils import LitAPIStatus, LoopResponseType, PickleableHTTPException
 
 logger = logging.getLogger(__name__)
 
@@ -85,8 +85,12 @@ class StreamingLoop(DefaultLoop):
                 )
                 for y_enc in y_enc_gen:
                     y_enc = lit_api.format_encoded_response(y_enc)
-                    self.put_response(transport, response_queue_id, uid, y_enc, LitAPIStatus.OK)
-                self.put_response(transport, response_queue_id, uid, "", LitAPIStatus.FINISH_STREAMING)
+                    self.put_response(
+                        transport, response_queue_id, uid, y_enc, LitAPIStatus.OK, LoopResponseType.STREAMING
+                    )
+                self.put_response(
+                    transport, response_queue_id, uid, "", LitAPIStatus.FINISH_STREAMING, LoopResponseType.STREAMING
+                )
 
                 callback_runner.trigger_event(EventTypes.AFTER_PREDICT.value, lit_api=lit_api)
                 callback_runner.trigger_event(EventTypes.AFTER_ENCODE_RESPONSE.value, lit_api=lit_api)
@@ -98,6 +102,7 @@ class StreamingLoop(DefaultLoop):
                     uid,
                     PickleableHTTPException.from_exception(e),
                     LitAPIStatus.ERROR,
+                    LoopResponseType.STREAMING,
                 )
             except KeyboardInterrupt:  # pragma: no cover
                 self.kill()
@@ -157,9 +162,13 @@ class StreamingLoop(DefaultLoop):
                 # encode_response should also return an async generator
                 async for y_enc in enc_result:
                     y_enc = lit_api.format_encoded_response(y_enc)
-                    self.put_response(transport, response_queue_id, uid, y_enc, LitAPIStatus.OK)
+                    self.put_response(
+                        transport, response_queue_id, uid, y_enc, LitAPIStatus.OK, LoopResponseType.STREAMING
+                    )
 
-            self.put_response(transport, response_queue_id, uid, "", LitAPIStatus.FINISH_STREAMING)
+            self.put_response(
+                transport, response_queue_id, uid, "", LitAPIStatus.FINISH_STREAMING, LoopResponseType.STREAMING
+            )
             callback_runner.trigger_event(EventTypes.AFTER_ENCODE_RESPONSE.value, lit_api=lit_api)
 
         except HTTPException as e:
@@ -169,6 +178,7 @@ class StreamingLoop(DefaultLoop):
                 uid=uid,
                 response_data=PickleableHTTPException.from_exception(e),
                 status=LitAPIStatus.ERROR,
+                response_type=LoopResponseType.STREAMING,
             )
         except Exception as e:
             logger.exception(
@@ -308,10 +318,14 @@ class BatchedStreamingLoop(DefaultLoop):
                 for y_batch in y_enc_iter:
                     for response_queue_id, y_enc, uid in zip(response_queue_ids, y_batch, uids):
                         y_enc = lit_api.format_encoded_response(y_enc)
-                        self.put_response(transport, response_queue_id, uid, y_enc, LitAPIStatus.OK)
+                        self.put_response(
+                            transport, response_queue_id, uid, y_enc, LitAPIStatus.OK, LoopResponseType.STREAMING
+                        )
 
                 for response_queue_id, uid in zip(response_queue_ids, uids):
-                    self.put_response(transport, response_queue_id, uid, "", LitAPIStatus.FINISH_STREAMING)
+                    self.put_response(
+                        transport, response_queue_id, uid, "", LitAPIStatus.FINISH_STREAMING, LoopResponseType.STREAMING
+                    )
             except KeyboardInterrupt:  # pragma: no cover
                 self.kill()
                 return
@@ -324,6 +338,7 @@ class BatchedStreamingLoop(DefaultLoop):
                         uid,
                         PickleableHTTPException.from_exception(e),
                         LitAPIStatus.ERROR,
+                        LoopResponseType.STREAMING,
                     )
 
             except Exception as e:

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -205,24 +205,8 @@ class _LitAPIConnector:
             if not self.lit_apis:  # Check if the iterable is empty
                 raise ValueError("lit_apis must not be an empty iterable")
             self._detect_path_collision()
-            # self._check_mixed_streaming_configuration()
         else:
             raise ValueError(f"lit_apis must be a LitAPI or an iterable of LitAPI, but got {type(lit_apis)}")
-
-    def _check_mixed_streaming_configuration(self):
-        """Ensure consistent streaming configuration across all endpoints.
-
-        Streaming must be either enabled for all endpoints or disabled for all. Mixing streaming and non-streaming
-        endpoints is currently not supported.
-
-        """
-        streams_enabled = [api.stream for api in self.lit_apis]
-        if any(streams_enabled) and not all(streams_enabled):
-            raise ValueError(
-                "Inconsistent streaming configuration: all endpoints must either "
-                "enable streaming or disable it. "
-                "Mixed configurations are not supported yet."
-            )
 
     def _detect_path_collision(self):
         paths = {"/health": "LitServe healthcheck", "/info": "LitServe info"}

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -92,7 +92,7 @@ async def _mixed_response_to_buffer(
             if result is None:
                 continue
 
-            uid, response, response_type = result
+            uid, (*response, response_type) = result
             if response_type == LoopResponseType.STREAMING:
                 stream_response_buffer, event = response_buffer[uid]
                 stream_response_buffer.append(response)
@@ -205,7 +205,7 @@ class _LitAPIConnector:
             if not self.lit_apis:  # Check if the iterable is empty
                 raise ValueError("lit_apis must not be an empty iterable")
             self._detect_path_collision()
-            self._check_mixed_streaming_configuration()
+            # self._check_mixed_streaming_configuration()
         else:
             raise ValueError(f"lit_apis must be a LitAPI or an iterable of LitAPI, but got {type(lit_apis)}")
 

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -20,6 +20,7 @@ import pickle
 import sys
 import uuid
 from contextlib import contextmanager
+from enum import Enum
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from fastapi import HTTPException
@@ -34,6 +35,11 @@ class LitAPIStatus:
     OK = "OK"
     ERROR = "ERROR"
     FINISH_STREAMING = "FINISH_STREAMING"
+
+
+class LoopResponseType(Enum):
+    STREAMING = "STREAMING"
+    REGULAR = "REGULAR"
 
 
 class PickleableHTTPException(HTTPException):

--- a/tests/test_multiple_endpoints.py
+++ b/tests/test_multiple_endpoints.py
@@ -57,14 +57,3 @@ def test_reserved_paths():
     api2 = InferencePipeline(name="api2", api_path="/info")
     with pytest.raises(ValueError, match="api_path /health is already in use by LitServe healthcheck"):
         ls.LitServer([api1, api2])
-
-
-def test_check_mixed_streaming_configuration():
-    api1 = InferencePipeline(name="api1", api_path="/api1", stream=True)
-    api2 = InferencePipeline(name="api2", api_path="/api2", stream=False)
-    with pytest.raises(
-        ValueError,
-        match="Inconsistent streaming configuration: all endpoints must either enable streaming or disable it. "
-        "Mixed configurations are not supported yet.",
-    ):
-        ls.LitServer([api1, api2])


### PR DESCRIPTION
## What does this PR do?

Users will be able to run heterogenous APIs which supports stream and non-stream. 

This example runs a text classification with an OpenAI chat completion (streaming) API. 

```python
from transformers import pipeline
import litserve as ls

ls.configure_logging(use_rich=True)

class SentimentAnalysisAPI(ls.LitAPI):
    def setup(self, device):
        self.model = pipeline("sentiment-analysis", model="stevhliu/my_awesome_model", device=device)

    def decode_request(self, request: dict):
        return request["text"]

    def predict(self, text):
        return self.model(text)[0]

class TextGenerationAPI(ls.LitAPI):
    def setup(self, device):
        self.generator = pipeline("text-generation", model="gpt2", device=device)

    def predict(self, prompt):
        yield from self.generator(prompt[0]["content"])[0]["generated_text"]

if __name__ == "__main__":
    sentiment_api = SentimentAnalysisAPI()
    chat_api = TextGenerationAPI(spec=ls.OpenAISpec())

    server = ls.LitServer([sentiment_api, chat_api])
    server.run(port=8000)

```


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
