### PR TITLE
Add secure shutdown endpoint with API key authentication

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -526,16 +526,18 @@ class LitServer:
         # Generate shutdown API key if shutdown endpoint is enabled
         if self.enable_shutdown_api:
             import os
+
             # Try to get key from environment, generate if not provided
             self.shutdown_api_key = os.getenv("LITSERVE_SHUTDOWN_KEY")
             if not self.shutdown_api_key:
                 import secrets
+
                 self.shutdown_api_key = secrets.token_urlsafe(32)
-                print(f"⚠️  No LITSERVE_SHUTDOWN_KEY environment variable set.")
+                print("⚠️  No LITSERVE_SHUTDOWN_KEY environment variable set.")
                 print(f"🔑 Generated temporary API key: {self.shutdown_api_key}")
-                print(f"💡 For production, set: export LITSERVE_SHUTDOWN_KEY=your_secure_key")
+                print("💡 For production, set: export LITSERVE_SHUTDOWN_KEY=your_secure_key")
             else:
-                print(f"🔑 Using LITSERVE_SHUTDOWN_KEY from environment")
+                print("🔑 Using LITSERVE_SHUTDOWN_KEY from environment")
             print(f"🛑 Shutdown endpoint: POST {self.shutdown_path}")
             print("   Use: curl -X POST http://localhost:8000/shutdown -H 'Authorization: Bearer YOUR_API_KEY'")
         else:

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -525,10 +525,17 @@ class LitServer:
 
         # Generate shutdown API key if shutdown endpoint is enabled
         if self.enable_shutdown_api:
-            import secrets
-
-            self.shutdown_api_key = secrets.token_urlsafe(32)
-            print(f"🔑 Shutdown API Key: {self.shutdown_api_key}")
+            import os
+            # Try to get key from environment, generate if not provided
+            self.shutdown_api_key = os.getenv("LITSERVE_SHUTDOWN_KEY")
+            if not self.shutdown_api_key:
+                import secrets
+                self.shutdown_api_key = secrets.token_urlsafe(32)
+                print(f"⚠️  No LITSERVE_SHUTDOWN_KEY environment variable set.")
+                print(f"🔑 Generated temporary API key: {self.shutdown_api_key}")
+                print(f"💡 For production, set: export LITSERVE_SHUTDOWN_KEY=your_secure_key")
+            else:
+                print(f"🔑 Using LITSERVE_SHUTDOWN_KEY from environment")
             print(f"🛑 Shutdown endpoint: POST {self.shutdown_path}")
             print("   Use: curl -X POST http://localhost:8000/shutdown -H 'Authorization: Bearer YOUR_API_KEY'")
         else:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -315,10 +315,11 @@ def test_exception():
 def test_shutdown_endpoint():
     """Test the shutdown endpoint with API key authentication."""
     import os
+
     # Set a test API key in environment
     test_key = "test_shutdown_key_12345"
     os.environ["LITSERVE_SHUTDOWN_KEY"] = test_key
-    
+
     try:
         # Create server with shutdown endpoint enabled
         server = LitServer(
@@ -329,27 +330,27 @@ def test_shutdown_endpoint():
             enable_shutdown_api=True,
             shutdown_path="/shutdown",
         )
-        
+
         # Mock the server state to avoid actually shutting down during tests
         server.app.state.server = SimpleNamespace(should_exit=False)
-        
+
         with wrap_litserve_start(server) as server, TestClient(server.app) as client:
             # Test without API key - should fail
             response = client.post("/shutdown")
             assert response.status_code == 401
             assert "Unauthorized" in response.text
-            
+
             # Test with wrong API key - should fail
             response = client.post("/shutdown", headers={"Authorization": "Bearer wrong_key"})
             assert response.status_code == 401
             assert "Invalid API key" in response.text
-            
+
             # Test with correct API key - should succeed
             response = client.post("/shutdown", headers={"Authorization": f"Bearer {test_key}"})
             assert response.status_code == 200
             assert "shutdown initiated" in response.text.lower()
             assert server.app.state.server.should_exit is True
-            
+
             # Test shutdown already in progress - should return 400
             response = client.post("/shutdown", headers={"Authorization": f"Bearer {test_key}"})
             assert response.status_code == 400
@@ -369,7 +370,7 @@ def test_shutdown_endpoint_disabled():
         workers_per_device=1,
         enable_shutdown_api=False,  # Disabled by default
     )
-    
+
     with wrap_litserve_start(server) as server, TestClient(server.app) as client:
         # Should get 404 since endpoint doesn't exist
         response = client.post("/shutdown")
@@ -379,10 +380,11 @@ def test_shutdown_endpoint_disabled():
 def test_shutdown_endpoint_multiple_workers():
     """Test shutdown endpoint with multiple workers."""
     import os
+
     # Set a test API key in environment
     test_key = "test_shutdown_key_workers_12345"
     os.environ["LITSERVE_SHUTDOWN_KEY"] = test_key
-    
+
     try:
         server = LitServer(
             SimpleLitAPI(),
@@ -392,10 +394,10 @@ def test_shutdown_endpoint_multiple_workers():
             enable_shutdown_api=True,
             shutdown_path="/shutdown",
         )
-        
+
         # Mock the server state
         server.app.state.server = SimpleNamespace(should_exit=False)
-        
+
         with wrap_litserve_start(server) as server, TestClient(server.app) as client:
             # Test with correct API key - should work
             response = client.post("/shutdown", headers={"Authorization": f"Bearer {test_key}"})

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -309,3 +309,58 @@ def test_exception():
         response = client.post("/predict", json={"input": 4.0})
         assert response.status_code == 500
         assert response.json() == {"detail": "Internal server error"}
+
+def test_shutdown_endpoint():
+    """Test the shutdown endpoint with API key authentication."""
+    # Create server with shutdown endpoint enabled
+    server = LitServer(
+        SimpleLitAPI(),
+        accelerator="cpu",
+        devices=1,
+        workers_per_device=1,
+        enable_shutdown_api=True,
+        shutdown_path="/shutdown",
+    )
+    
+    # Mock the server state to avoid actually shutting down during tests
+    from types import SimpleNamespace
+    server.app.state.server = SimpleNamespace(should_exit=False)
+    
+    with wrap_litserve_start(server) as server, TestClient(server.app) as client:
+        # Test without API key - should fail
+        response = client.post("/shutdown")
+        assert response.status_code == 401
+        assert "Unauthorized" in response.text
+        
+        # Test with wrong API key - should fail
+        response = client.post("/shutdown", headers={"Authorization": "Bearer wrong_key"})
+        assert response.status_code == 401
+        assert "Invalid API key" in response.text
+        
+        # Test with correct API key - should succeed
+        correct_key = server.shutdown_api_key
+        response = client.post("/shutdown", headers={"Authorization": f"Bearer {correct_key}"})
+        assert response.status_code == 200
+        assert "shutdown initiated" in response.text.lower()
+        assert server.app.state.server.should_exit is True
+        
+        # Test shutdown already in progress - should return 400
+        response = client.post("/shutdown", headers={"Authorization": f"Bearer {correct_key}"})
+        assert response.status_code == 400
+        assert "already in progress" in response.text.lower()
+
+
+def test_shutdown_endpoint_disabled():
+    """Test that shutdown endpoint is not available when disabled."""
+    server = LitServer(
+        SimpleLitAPI(),
+        accelerator="cpu",
+        devices=1,
+        workers_per_device=1,
+        enable_shutdown_api=False,  # Disabled by default
+    )
+    
+    with wrap_litserve_start(server) as server, TestClient(server.app) as client:
+        # Should get 404 since endpoint doesn't exist
+        response = client.post("/shutdown")
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
Addresses #505 by implementing a secure shutdown endpoint with API key authentication as requested by maintainers.

## Changes Made
- ✅ **Added `enable_shutdown_api` parameter** (defaults to `False` for security)
- ✅ **Added `shutdown_path` parameter** for customizable endpoint path
- ✅ **Implemented secure API key generation** using `secrets.token_urlsafe()`
- ✅ **Created POST `/shutdown` endpoint** with Bearer token authentication
- ✅ **Added comprehensive validation** for all new parameters
- ✅ **User-friendly output** - prints API key and usage instructions
- ✅ **Complete test coverage** for both enabled and disabled scenarios

## Security Features
- **Authorization required**: Endpoint requires `Authorization: Bearer <token>` header
- **API key validation**: Validates provided key against generated key
- **Unauthorized protection**: Returns 401 for invalid/missing keys
- **Duplicate prevention**: Returns 400 if shutdown already in progress
- **Disabled by default**: Only enabled when explicitly requested

## Usage Example
```python
server = LitServer(
    MyAPI(),
    enable_shutdown_api=True,  # Enable the endpoint
    shutdown_path="/shutdown"  # Optional: customize path
)
server.run()
# Prints: 🔑 Shutdown API Key: <generated-key>
# Prints: 🛑 Shutdown endpoint: POST /shutdown