### PR TITLE
Increase CI test timeout to 20 minutes

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -48,7 +48,7 @@ jobs:
           pip list
 
       - name: Tests
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: |
           python -m pytest --cov=litserve src/ tests/ -v -s
 


### PR DESCRIPTION
## What does this PR do?
As new tests are being added, we've reached the 10-minute timeout limit.
This PR increases the CI test timeout to support longer-running tests.

>At this stage, we cannot enable parallel test execution because some tests start servers on the same port, leading to conflicts.
However, we plan to explore assigning unique dynamic ports to make parallel execution possible in the future.