### PR TITLE
Fix health and info endpoints when multiple LitAPIs are specified

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -662,8 +662,7 @@ class LitServer:
             if not workers_ready:
                 workers_ready = all(v == WorkerSetupStatus.READY for v in self.workers_setup_status.values())
 
-            api_list = self.lit_api if isinstance(self.lit_api, list) else [self.lit_api]
-            lit_api_health_status = all(lit_api.health() for lit_api in api_list)
+            lit_api_health_status = all(lit_api.health() for lit_api in self.litapi_connector)
             if workers_ready and lit_api_health_status:
                 return Response(content="ok", status_code=200)
 
@@ -671,7 +670,6 @@ class LitServer:
 
         @self.app.get(self.info_path, dependencies=[Depends(self.setup_auth())])
         async def info(request: Request) -> Response:
-            api_list = self.lit_api if isinstance(self.lit_api, list) else [self.lit_api]
             return JSONResponse(
                 content={
                     "model": self.model_metadata,
@@ -679,7 +677,7 @@ class LitServer:
                         "devices": self.devices,
                         "workers_per_device": self.workers_per_device,
                         "timeout": self.timeout,
-                        "stream": {lit_api.api_path: lit_api.stream for lit_api in api_list},
+                        "stream": {lit_api.api_path: lit_api.stream for lit_api in self.litapi_connector},
                         "max_payload_size": self.max_payload_size,
                         "track_requests": self.track_requests,
                     },

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -58,7 +58,8 @@ def test_device_identifiers(lifespan_mock, simple_litapi):
 @pytest.mark.parametrize("devices", ["cpu", ["cpu", "cuda:0"], ["cuda:a", "cuda:1"]])
 def test_device_identifiers_error(simple_litapi, devices):
     with pytest.raises(
-        ValueError, match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got .*"
+            ValueError,
+            match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got .*"
     ):
         LitServer(simple_litapi, accelerator="cuda", devices=devices, timeout=10)
 
@@ -72,7 +73,7 @@ async def test_stream(simple_stream_api, use_zmq):
 
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             # TODO: remove this sleep when we have a better way to check if the server is ready
             # TODO: main process can only consume when response_queue_to_buffer is ready
@@ -101,7 +102,7 @@ async def test_batched_stream_server(simple_batched_stream_api, use_zmq):
 
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp1 = ac.post("/predict", json={"prompt": "Hello"}, timeout=10)
             resp2 = ac.post("/predict", json={"prompt": "World"}, timeout=10)
@@ -118,8 +119,8 @@ async def test_batched_stream_server(simple_batched_stream_api, use_zmq):
 
 def test_litapi_with_stream(simple_litapi):
     with pytest.raises(
-        ValueError,
-        match="""When `stream=True` both `lit_api.predict` and
+            ValueError,
+            match="""When `stream=True` both `lit_api.predict` and
              `lit_api.encode_response` must generate values using `yield""",
     ):
         LitServer(simple_litapi, stream=True)
@@ -253,7 +254,7 @@ def test_server_run_with_api_server_worker_type(mock_uvicorn, server_for_api_wor
 @pytest.mark.parametrize(("api_server_worker_type", "num_api_workers"), [(None, 1), ("process", 1)])
 @patch("litserve.server.uvicorn")
 def test_server_run_with_process_api_worker(
-    mock_uvicorn, api_server_worker_type, num_api_workers, server_for_api_worker_test
+        mock_uvicorn, api_server_worker_type, num_api_workers, server_for_api_worker_test
 ):
     server = server_for_api_worker_test
 
@@ -368,7 +369,7 @@ async def test_inject_context():
     server = LitServer(api)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
     assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
@@ -377,7 +378,7 @@ async def test_inject_context():
     server = LitServer(IdentityBatchedAPI(), max_batch_size=2, batch_timeout=0.01)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
     assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
@@ -386,7 +387,7 @@ async def test_inject_context():
     server = LitServer(IdentityBatchedStreamingAPI(), max_batch_size=2, batch_timeout=0.01, stream=True)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
     assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
@@ -434,7 +435,7 @@ def test_custom_info_path():
             "devices": ["cpu"],
             "workers_per_device": 1,
             "timeout": 30,
-            "stream": False,
+            "stream": {'/predict': False},
             "max_payload_size": None,
             "track_requests": False,
         },
@@ -460,7 +461,7 @@ def test_info_route():
             "devices": ["cpu"],
             "workers_per_device": 1,
             "timeout": 30,
-            "stream": False,
+            "stream": {'/predict': False},
             "max_payload_size": None,
             "track_requests": False,
         },
@@ -532,8 +533,8 @@ def test_workers_setup_status(use_zmq):
 
 def test_max_batch_size_warning(simple_litapi):
     with pytest.warns(
-        DeprecationWarning,
-        match="'max_batch_size' and 'batch_timeout' are being deprecated in `LitServer`",
+            DeprecationWarning,
+            match="'max_batch_size' and 'batch_timeout' are being deprecated in `LitServer`",
     ):
         ls.LitServer(simple_litapi, max_batch_size=4)
     assert simple_litapi.max_batch_size == 4, "LitServer should have max_batch_size set to 4"
@@ -547,7 +548,7 @@ class TestAsyncLitAPI(ls.LitAPI):
         return request["input"]
 
     async def predict(self, x):
-        return x**2
+        return x ** 2
 
     async def encode_response(self, output):
         return {"output": output}
@@ -559,7 +560,7 @@ async def test_async_litapi():
     server = LitServer(api)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
             assert resp.status_code == 200, "Server response should be 200 (OK)"
@@ -570,7 +571,7 @@ class TestSleepAsyncLitAPI(TestAsyncLitAPI):
     async def predict(self, x):
         # simulate a long-running task
         await asyncio.sleep(4)
-        return x**2
+        return x ** 2
 
 
 @pytest.mark.asyncio
@@ -581,7 +582,7 @@ async def test_concurrent_async_inference(num_requests):
     server = LitServer(api)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             sleep(2)  # Sleep a bit to ensure the server is ready
 
@@ -608,7 +609,7 @@ async def test_error_propagation_in_async_litapi():
     server = LitServer(TestHTTPExceptionAsyncLitAPI(enable_async=True))
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
             assert resp.status_code == 501, "Server raises 501 error"
@@ -637,7 +638,7 @@ async def test_async_stream_litapi():
     server = LitServer(api, stream=True)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 4.0}, timeout=10)
             assert resp.status_code == 200, "Server response should be 200 (OK)"
@@ -663,7 +664,7 @@ async def test_concurrent_async_streaming_inference(num_requests):
     server = LitServer(api, stream=True)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-            transport=ASGITransport(app=manager.app), base_url="http://test"
+                transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             sleep(2)  # Sleep a bit to ensure the server is ready
 

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -58,8 +58,7 @@ def test_device_identifiers(lifespan_mock, simple_litapi):
 @pytest.mark.parametrize("devices", ["cpu", ["cpu", "cuda:0"], ["cuda:a", "cuda:1"]])
 def test_device_identifiers_error(simple_litapi, devices):
     with pytest.raises(
-            ValueError,
-            match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got .*"
+        ValueError, match="devices must be an integer or a list of integers when using 'cuda' or 'mps', instead got .*"
     ):
         LitServer(simple_litapi, accelerator="cuda", devices=devices, timeout=10)
 
@@ -73,7 +72,7 @@ async def test_stream(simple_stream_api, use_zmq):
 
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             # TODO: remove this sleep when we have a better way to check if the server is ready
             # TODO: main process can only consume when response_queue_to_buffer is ready
@@ -102,7 +101,7 @@ async def test_batched_stream_server(simple_batched_stream_api, use_zmq):
 
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp1 = ac.post("/predict", json={"prompt": "Hello"}, timeout=10)
             resp2 = ac.post("/predict", json={"prompt": "World"}, timeout=10)
@@ -119,8 +118,8 @@ async def test_batched_stream_server(simple_batched_stream_api, use_zmq):
 
 def test_litapi_with_stream(simple_litapi):
     with pytest.raises(
-            ValueError,
-            match="""When `stream=True` both `lit_api.predict` and
+        ValueError,
+        match="""When `stream=True` both `lit_api.predict` and
              `lit_api.encode_response` must generate values using `yield""",
     ):
         LitServer(simple_litapi, stream=True)
@@ -254,7 +253,7 @@ def test_server_run_with_api_server_worker_type(mock_uvicorn, server_for_api_wor
 @pytest.mark.parametrize(("api_server_worker_type", "num_api_workers"), [(None, 1), ("process", 1)])
 @patch("litserve.server.uvicorn")
 def test_server_run_with_process_api_worker(
-        mock_uvicorn, api_server_worker_type, num_api_workers, server_for_api_worker_test
+    mock_uvicorn, api_server_worker_type, num_api_workers, server_for_api_worker_test
 ):
     server = server_for_api_worker_test
 
@@ -369,7 +368,7 @@ async def test_inject_context():
     server = LitServer(api)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
     assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
@@ -378,7 +377,7 @@ async def test_inject_context():
     server = LitServer(IdentityBatchedAPI(), max_batch_size=2, batch_timeout=0.01)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
     assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
@@ -387,7 +386,7 @@ async def test_inject_context():
     server = LitServer(IdentityBatchedStreamingAPI(), max_batch_size=2, batch_timeout=0.01, stream=True)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
     assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
@@ -435,7 +434,7 @@ def test_custom_info_path():
             "devices": ["cpu"],
             "workers_per_device": 1,
             "timeout": 30,
-            "stream": {'/predict': False},
+            "stream": {"/predict": False},
             "max_payload_size": None,
             "track_requests": False,
         },
@@ -461,7 +460,7 @@ def test_info_route():
             "devices": ["cpu"],
             "workers_per_device": 1,
             "timeout": 30,
-            "stream": {'/predict': False},
+            "stream": {"/predict": False},
             "max_payload_size": None,
             "track_requests": False,
         },
@@ -533,8 +532,8 @@ def test_workers_setup_status(use_zmq):
 
 def test_max_batch_size_warning(simple_litapi):
     with pytest.warns(
-            DeprecationWarning,
-            match="'max_batch_size' and 'batch_timeout' are being deprecated in `LitServer`",
+        DeprecationWarning,
+        match="'max_batch_size' and 'batch_timeout' are being deprecated in `LitServer`",
     ):
         ls.LitServer(simple_litapi, max_batch_size=4)
     assert simple_litapi.max_batch_size == 4, "LitServer should have max_batch_size set to 4"
@@ -548,7 +547,7 @@ class TestAsyncLitAPI(ls.LitAPI):
         return request["input"]
 
     async def predict(self, x):
-        return x ** 2
+        return x**2
 
     async def encode_response(self, output):
         return {"output": output}
@@ -560,7 +559,7 @@ async def test_async_litapi():
     server = LitServer(api)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
             assert resp.status_code == 200, "Server response should be 200 (OK)"
@@ -571,7 +570,7 @@ class TestSleepAsyncLitAPI(TestAsyncLitAPI):
     async def predict(self, x):
         # simulate a long-running task
         await asyncio.sleep(4)
-        return x ** 2
+        return x**2
 
 
 @pytest.mark.asyncio
@@ -582,7 +581,7 @@ async def test_concurrent_async_inference(num_requests):
     server = LitServer(api)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             sleep(2)  # Sleep a bit to ensure the server is ready
 
@@ -609,7 +608,7 @@ async def test_error_propagation_in_async_litapi():
     server = LitServer(TestHTTPExceptionAsyncLitAPI(enable_async=True))
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
             assert resp.status_code == 501, "Server raises 501 error"
@@ -638,7 +637,7 @@ async def test_async_stream_litapi():
     server = LitServer(api, stream=True)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/predict", json={"input": 4.0}, timeout=10)
             assert resp.status_code == 200, "Server response should be 200 (OK)"
@@ -664,7 +663,7 @@ async def test_concurrent_async_streaming_inference(num_requests):
     server = LitServer(api, stream=True)
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
-                transport=ASGITransport(app=manager.app), base_url="http://test"
+            transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             sleep(2)  # Sleep a bit to ensure the server is ready
 


### PR DESCRIPTION
## What does this PR do?

Fixes # (issue).


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

Currently when multiple LitAPIs are specified under the same server, the health and info checkpoints fail. This PR iterates over a list of LitAPIs when applicable.



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

cc @aniketmaurya @bhimrazy 

