### PR TITLE
Shutdown server when workers crash

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -564,6 +564,7 @@ class LitServer:
         self.litapi_request_queues = {}
         self._shutdown_event: Optional[mp.Event] = None
         self.uvicorn_graceful_timeout = 30
+        self.restart_workers = False
 
         accelerator = self._connector.accelerator
         devices = self._connector.devices
@@ -835,7 +836,6 @@ class LitServer:
         self,
         manager: mp.Manager,
         uvicorn_workers: List[Union[mp.Process, threading.Thread]],
-        inference_workers: List[mp.Process],
         shutdown_reason: str = "normal",
     ):
         """Encapsulates the graceful shutdown logic."""
@@ -869,8 +869,8 @@ class LitServer:
                     logger.error(f"Error during termination of {log_prefix}: {e}")
 
         # terminate and join inference worker processes
-        logger.debug(f"Terminating {len(inference_workers)} inference workers...")
-        for i, iw in enumerate(inference_workers):
+        logger.debug(f"Terminating {len(self.inference_workers)} inference workers...")
+        for i, iw in enumerate(self.inference_workers):
             worker_pid = iw.pid
             worker_name = iw.name
             try:
@@ -980,10 +980,10 @@ class LitServer:
 
         manager = self._init_manager(num_api_servers)
         self._logger_connector.run(self)
-        inference_workers = []
+        self.inference_workers = []
         for lit_api in self.litapi_connector:
             _inference_workers = self.launch_inference_worker(lit_api)
-            inference_workers.extend(_inference_workers)
+            self.inference_workers.extend(_inference_workers)
 
         self.verify_worker_status()
 
@@ -995,13 +995,15 @@ class LitServer:
             )
             print(f"Swagger UI is available at http://0.0.0.0:{port}/docs")
 
+            self._start_worker_monitoring(manager, uvicorn_workers)
+
             self._shutdown_event.wait()
 
         except KeyboardInterrupt:
             logger.info("KeyboardInterrupt received. Initiating graceful shutdown.")
             shutdown_reason = "keyboard_interrupt"
         finally:
-            self._perform_graceful_shutdown(manager, uvicorn_workers, inference_workers, shutdown_reason)
+            self._perform_graceful_shutdown(manager, uvicorn_workers, shutdown_reason)
 
     def _prepare_app_run(self, app: FastAPI):
         # Add middleware to count active requests
@@ -1064,3 +1066,25 @@ class LitServer:
                 detail="Invalid Bearer token for Shutdown API."
                 " Check that you are passing a correct 'Authorization: Bearer <SHUTDOWN_API_KEY>' in your header.",
             )
+
+    def _start_worker_monitoring(
+        self,
+        manager: mp.Manager,
+        uvicorn_workers: List[Union[mp.Process, threading.Thread]],
+    ):
+        def monitor():
+            while not self._shutdown_event.is_set():
+                for proc in self.inference_workers:
+                    if proc.is_alive():
+                        continue
+
+                    if not self.restart_workers:
+                        logging.error(f"⚠️ Worker {proc.name} died; shutting down")
+                        self._perform_graceful_shutdown(manager, uvicorn_workers, f"⚠️ Worker {proc.name} died)")
+                        return
+
+                    # TODO: Handle restarting failed workers
+                time.sleep(1)
+
+        t = threading.Thread(target=monitor, daemon=True, name="litserve-monitoring")
+        t.start()

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -1079,7 +1079,7 @@ class LitServer:
                         continue
 
                     if not self.restart_workers:
-                        logging.error(f"⚠️ Worker {proc.name} died; shutting down")
+                        logger.error(f"⚠️ Worker {proc.name} died; shutting down")
                         self._perform_graceful_shutdown(manager, uvicorn_workers, f"⚠️ Worker {proc.name} died)")
                         return
 

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -1084,7 +1084,7 @@ class LitServer:
                         return
 
                     # TODO: Handle restarting failed workers
-                time.sleep(1)
+                time.sleep(5)
 
         t = threading.Thread(target=monitor, daemon=True, name="litserve-monitoring")
         t.start()

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -76,10 +76,10 @@ def wrap_litserve_start(server: "LitServer"):
         if lit_api.spec:
             lit_api.spec.response_queue_id = 0
 
-    manager = server._init_manager(1)
-    processes = []
+    server.manager = server._init_manager(1)
+    server.inference_workers = []
     for lit_api in server.litapi_connector:
-        processes.extend(server.launch_inference_worker(lit_api))
+        server.inference_workers.extend(server.launch_inference_worker(lit_api))
     server._prepare_app_run(server.app)
     try:
         yield server
@@ -87,10 +87,10 @@ def wrap_litserve_start(server: "LitServer"):
         server._shutdown_event.set()
         # First close the transport to signal to the response_queue_to_buffer task that it should stop
         server._transport.close()
-        for p in processes:
+        for p in server.inference_workers:
             p.terminate()
             p.join()
-        manager.shutdown()
+        server.manager.shutdown()
 
 
 async def call_after_stream(streamer: AsyncIterator, callback, *args, **kwargs):

--- a/tests/test_failed_workers.py
+++ b/tests/test_failed_workers.py
@@ -1,0 +1,61 @@
+import multiprocessing as mp
+import time
+
+from fastapi import Request, Response
+
+from litserve import LitAPI, LitServer
+
+
+class CrashingLitAPI(LitAPI):
+    """API that crashes after 2 predictions to simulate worker failure."""
+
+    def setup(self, device):
+        self.model = lambda x: x**2
+        self.count = 0
+
+    def decode_request(self, request: Request):
+        return request["input"]
+
+    def predict(self, x):
+        return self.model(x)
+
+    def encode_response(self, output) -> Response:
+        return {"output": output}
+
+
+def test_worker_monitoring_triggers_shutdown_on_worker_death():
+    """Test that server shuts down when a worker dies."""
+    server = LitServer(CrashingLitAPI(), accelerator="cpu", devices=1, workers_per_device=1)
+
+    # Track if shutdown was called
+    shutdown_called = {"value": False}
+
+    def mock_shutdown(manager, uvicorn_workers, shutdown_reason="normal"):
+        shutdown_called["value"] = True
+
+    manager = mp.Manager()
+    server._shutdown_event = manager.Event()
+    server._perform_graceful_shutdown = mock_shutdown
+    ctx = mp.get_context("spawn")
+    proc = ctx.Process(
+        target=SystemExit,
+        args=("Crash",),
+        name="crashed process",
+    )
+
+    server.inference_workers = [proc]
+
+    server._start_worker_monitoring(manager, [])
+
+    server._start_worker_monitoring(manager, [])
+
+    for i in range(20):
+        if shutdown_called["value"]:
+            break
+        assert i != 19, "Server should shutdown when worker dies"
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    test_worker_monitoring_triggers_shutdown_on_worker_death()
+    print("Test passed!")


### PR DESCRIPTION
## What does this PR do?

Right now, if a worker crashes, the Litserve server stays up and reports it is healthy even though it is very unhealthy and can't serve requests.

Demo of the problem: https://www.loom.com/share/30443d7da3b84741b67006f6f7fbcb35

There are multiple ways this could be handled, either the service could shut down, or the workers could be restarted. Ideally, this is configured by the user.  This PR implements the first method, which I believe should be the default.  It adds a monitoring thread that polls each worker process after it is launched to see if it is still alive.   If it detects a worker has crashed, it will exit the entire server gracefully.

Demo of the solution: https://www.loom.com/share/1724eba9234a444ea9fb0adfad922c19

I will follow-up with the second method of restarting failed workers in a subsequent PR.
