### PR TITLE
make dependency installation check as utility function

### DIFF
--- a/src/litserve/cli.py
+++ b/src/litserve/cli.py
@@ -1,10 +1,11 @@
-import importlib.util
 import subprocess
 import sys
 
+from litserve.utils import is_package_installed
+
 
 def _ensure_lightning_installed():
-    if not importlib.util.find_spec("lightning_sdk"):
+    if not is_package_installed("lightning_sdk"):
         print("Lightning CLI not found. Installing...")
         subprocess.check_call([sys.executable, "-m", "pip", "install", "-U", "lightning-sdk"])
 

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 import dataclasses
+import importlib.util
 import logging
 import os
 import pdb
@@ -215,3 +216,8 @@ def set_trace_if_debug(debug_env_var="LITSERVE_DEBUG", debug_env_var_value="1"):
     """Set a tracepoint in the code if the environment variable LITSERVE_DEBUG is set."""
     if os.environ.get(debug_env_var) == debug_env_var_value:
         set_trace()
+
+
+def is_package_installed(package_name: str) -> bool:
+    spec = importlib.util.find_spec(package_name)
+    return spec is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,10 +33,10 @@ def test_dockerize_command(monkeypatch, capsys):
     assert os.path.exists("Dockerfile"), "CLI did not create Dockerfile"
 
 
-@patch("importlib.util.find_spec")
+@patch("litserve.cli.is_package_installed")
 @patch("subprocess.check_call")
-def test_ensure_lightning_installed(mock_check_call, mock_find_spec):
-    mock_find_spec.return_value = False
+def test_ensure_lightning_installed(mock_check_call, mock_is_package_installed):
+    mock_is_package_installed.return_value = False
     _ensure_lightning_installed()
     mock_check_call.assert_called_once_with([sys.executable, "-m", "pip", "install", "-U", "lightning-sdk"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,10 +43,10 @@ def test_ensure_lightning_installed(mock_check_call, mock_is_package_installed):
 
 # TODO: Remove this once we have a fix for Python 3.9 and 3.10
 @pytest.mark.skipif(sys.version_info[:2] in [(3, 9), (3, 10)], reason="Test fails on Python 3.9 and 3.10")
-@patch("importlib.util.find_spec")
+@patch("litserve.cli.is_package_installed")
 @patch("subprocess.check_call")
 @patch("builtins.__import__")
-def test_cli_main_lightning_not_installed(mock_import, mock_check_call, mock_find_spec):
+def test_cli_main_lightning_not_installed(mock_import, mock_check_call, mock_is_package_installed):
     # Create a mock for the lightning_sdk module and its components
     mock_lightning_sdk = MagicMock()
     mock_lightning_sdk.cli.entrypoint.main_cli = MagicMock()
@@ -60,7 +60,7 @@ def test_cli_main_lightning_not_installed(mock_import, mock_check_call, mock_fin
     mock_import.side_effect = side_effect
 
     # Test when lightning_sdk is not installed but gets installed dynamically
-    mock_find_spec.side_effect = [False, True]  # First call returns False, second call returns True
+    mock_is_package_installed.side_effect = [False, True]  # First call returns False, second call returns True
     test_args = ["lightning", "run", "app", "app.py"]
 
     with patch.object(sys, "argv", test_args):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from litserve.utils import (
     configure_logging,
     dump_exception,
     generate_random_zmq_address,
+    is_package_installed,
     set_trace_if_debug,
 )
 
@@ -85,3 +86,8 @@ def test_set_trace_if_debug_not_set(mock_forked_pdb):
     with mock.patch("litserve.utils.os.environ", {"LITSERVE_DEBUG": "0"}):
         set_trace_if_debug()
     mock_forked_pdb.assert_not_called()
+
+
+def test_is_package_installed():
+    assert is_package_installed("pytest")
+    assert not is_package_installed("nonexistent_package")


### PR DESCRIPTION
## What does this PR do?

We will be able to reuse the dependency installation check function (`is_package_installed`) at other places such as in #534 

- Updated the `_ensure_lightning_installed` function to use `is_package_installed` from `litserve.utils` instead of `importlib.util.find_spec`.
- Added `is_package_installed` function to `utils.py` for better package checking abstraction.
- Adjusted tests to mock the new utility function.

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
