### PR TITLE
add JAX support for accelerator

### DIFF
--- a/src/litserve/connector.py
+++ b/src/litserve/connector.py
@@ -63,7 +63,7 @@ class _Connector:
     def _sanitize_accelerator(accelerator: Optional[str]):
         if isinstance(accelerator, str):
             accelerator = accelerator.lower()
-            
+
         if accelerator not in ["auto", "cpu", "mps", "cuda", "gpu", None]:
             raise ValueError(f"accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'. Found: {accelerator}")
 

--- a/src/litserve/connector.py
+++ b/src/litserve/connector.py
@@ -17,12 +17,14 @@ import subprocess
 import sys
 from functools import lru_cache
 from typing import List, Optional, Union
+import logging
 
+logger = logging.getLogger(__name__)
 
 class _Connector:
     def __init__(self, accelerator: str = "auto", devices: Union[List[int], int, str] = "auto"):
         accelerator = self._sanitize_accelerator(accelerator)
-        if accelerator in ("cpu", "cuda", "mps"):
+        if accelerator in ("cpu", "cuda", "mps", "jax"):
             self._accelerator = accelerator
         elif accelerator == "auto":
             self._accelerator = self._choose_auto_accelerator()
@@ -38,16 +40,17 @@ class _Connector:
 
     def check_devices_and_accelerators(self):
         """Check if the devices are in a valid fomra and raise an error if they are not."""
-        if self._accelerator in ("cuda", "mps"):
+        if self._accelerator in ("cuda", "mps", "jax"):
             if not isinstance(self._devices, int) and not (
                 isinstance(self._devices, list) and all(isinstance(device, int) for device in self._devices)
             ):
                 raise ValueError(
-                    "devices must be an integer or a list of integers when using 'cuda' or 'mps', "
+                    "devices must be an integer or a list of integers when using 'cuda', 'mps', or 'jax', "
                     f"instead got {self._devices}"
                 )
         elif self._accelerator != "cpu":
-            raise ValueError(f"accelerator must be one of (cuda, mps, cpu), instead got {self._accelerator}")
+            # Updated error message to include 'jax'
+            raise ValueError(f"accelerator must be one of (cuda, mps, cpu, jax), instead got {self._accelerator}")
 
     @property
     def accelerator(self):
@@ -62,37 +65,104 @@ class _Connector:
         if isinstance(accelerator, str):
             accelerator = accelerator.lower()
 
-        if accelerator not in ["auto", "cpu", "mps", "cuda", "gpu", None]:
-            raise ValueError(f"accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'. Found: {accelerator}")
+        if accelerator not in ["auto", "cpu", "mps", "cuda", "gpu", "jax", None]:
+            raise ValueError(f"accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', 'gpu', or 'jax'. Found: {accelerator}")
 
         if accelerator is None:
             return "auto"
         return accelerator
 
     def _choose_auto_accelerator(self):
-        gpu_backend = self._choose_gpu_accelerator_backend()
-        if "torch" in sys.modules and gpu_backend:
-            return gpu_backend
+        """
+        Determines the appropriate accelerator for 'auto' mode, with PyTorch preference then JAX.
+        """
+        torch_backend = self._choose_gpu_accelerator_torch()
+        if torch_backend:
+            logger.info(f"Auto-selected PyTorch GPU accelerator: {torch_backend}")
+            return torch_backend
+        
+        jax_backend = self._choose_gpu_accelerator_jax()
+        if jax_backend:
+            logger.info(f"Auto-selected JAX GPU accelerator: {jax_backend}")
+            return jax_backend
+
+        logger.info("No GPU accelerator detected for 'auto' mode. Defaulting to 'cpu'.")
         return "cpu"
 
     def _accelerator_device_count(self) -> int:
         if self._accelerator == "cuda":
             return check_cuda_with_nvidia_smi()
+        elif self._accelerator == "mps":
+            return 1 # MPS typically only has 1 GPU
+        elif self._accelerator == "jax":
+            try:
+                import jax
+                return jax.device_count()
+            except ImportError:
+                logger.warning("JAX not installed, cannot determine JAX device count. Defaulting to 1.")
+                return 1
         return 1
 
     @staticmethod
-    def _choose_gpu_accelerator_backend():
+    def _choose_gpu_accelerator_torch():
+        """
+        Checks for PyTorch GPU accelerator backend (CUDA or MPS).
+        """
         if check_cuda_with_nvidia_smi() > 0:
             return "cuda"
 
         try:
             import torch
-
             if torch.backends.mps.is_available() and platform.processor() in ("arm", "arm64"):
                 return "mps"
         except ImportError:
-            return None
+            logger.debug("PyTorch not installed, skipping PyTorch GPU accelerator check.")
+        return None
+    
+    @staticmethod
+    def _choose_gpu_accelerator_jax():
+        """
+        Checks for JAX GPU accelerator backend (CUDA or MPS).
+        """
+        try:
+            import jax
+            from jax.extend import backend as jax_backend
+            
+            # JAX with CUDA
+            if jax_backend.get_backend().platform == "gpu" or jax_backend.get_backend().platform == "cuda":
+                if check_cuda_with_nvidia_smi() > 0:
+                    return "cuda"
+                
+            #JAX with MPS
+            if platform.processor() in ("arm", "arm64"):
+                if jax_backend.get_backend().platform == "mps":
+                    return "mps"
+                
+        except ImportError:
+            logger.debug("JAX not installed, skipping JAX GPU accelerator check.")
+        except Exception as e:
+            logger.debug(f"Error during JAX GPU accelerator check: {e}")
+            
+        return None
+                    
 
+    @staticmethod
+    def _choose_gpu_accelerator_backend():
+        """
+        Determines the appropriate GPU accelerator backend when `accelerator='gpu'` is explicitly set.
+        Prioritizes PyTorch then JAX.
+        """
+        torch_backend = _Connector._choose_gpu_accelerator_torch()
+        if torch_backend:
+            logger.info(f"Explicit 'gpu' accelerator selected PyTorch backend: {torch_backend}")
+            return torch_backend
+        
+        jax_backend = _Connector._choose_gpu_accelerator_jax()
+        if jax_backend:
+            logger.info(f"Explicit 'gpu' accelerator selected JAX backend: {jax_backend}")
+            return jax_backend
+        
+        logger.info("No specific GPU accelerator detected for explicit 'gpu' selection.")
         return None
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -239,11 +239,6 @@ def test_connector_mock_jax_mps_check(mock_cuda_smi, mock_jax_backend, mock_jax)
         assert connector.devices == 1
 
         check_cuda_with_nvidia_smi.cache_clear()
-        connector = _Connector(accelerator="jax")
-        assert connector.accelerator == "jax"
-        assert connector.devices == 1
-
-        check_cuda_with_nvidia_smi.cache_clear()
         connector = _Connector(accelerator="gpu")
         assert connector.accelerator == "mps"
         assert connector.devices == 1
@@ -262,11 +257,6 @@ def test_connector_mock_jax_cuda(mock_cuda_smi, mock_jax_backend, mock_jax):
     check_cuda_with_nvidia_smi.cache_clear()
     connector = _Connector(accelerator="auto")
     assert connector.accelerator == "cuda"
-    assert connector.devices == 1
-
-    check_cuda_with_nvidia_smi.cache_clear()
-    connector = _Connector(accelerator="jax")
-    assert connector.accelerator == "jax"
     assert connector.devices == 1
 
     check_cuda_with_nvidia_smi.cache_clear()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import os
 import platform
-import subprocess # Keep subprocess for check_cuda_with_nvidia_smi, although not used in tests
-import sys # Keep sys for _choose_auto_accelerator
+import subprocess
+import sys
 from functools import lru_cache
 from typing import List, Optional, Union
 from unittest.mock import patch, MagicMock

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -11,20 +11,51 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import patch
-
-import pytest
-import torch
-
+import os
+import platform
+import subprocess # Keep subprocess for check_cuda_with_nvidia_smi, although not used in tests
+import sys # Keep sys for _choose_auto_accelerator
+from functools import lru_cache
+from typing import List, Optional, Union
+from unittest.mock import patch, MagicMock
 from litserve.connector import _Connector, check_cuda_with_nvidia_smi
 
 
-@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU")
+import pytest
+
+try:
+    import torch
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+
+try:
+    import jax
+    import jax.extend.backend as jax_backend 
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+
+
+def jax_mps_check():
+    if not JAX_AVAILABLE:
+        return False
+    # Check if JAX is configured for MPS
+    return any(d.device_kind == 'mps' for d in jax.devices()) and \
+           (jax_backend.get_backend().platform == 'mps') and \
+           platform.processor() in ("arm", "arm64")
+
+def torch_mps_check():
+    if not TORCH_AVAILABLE:
+        return False
+    return torch.backends.mps.is_available() and platform.processor() in ("arm", "arm64")
+
+
+@pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch")
 def test_check_cuda_with_nvidia_smi():
     assert check_cuda_with_nvidia_smi() == torch.cuda.device_count()
 
-
-@pytest.mark.skipif(torch.cuda.device_count() > 0, reason="Non Nvidia GPU only")
+@pytest.mark.skipif(TORCH_AVAILABLE and torch.cuda.device_count() > 0, reason="Non-Nvidia GPU only")
 @patch(
     "litserve.connector.subprocess.check_output",
     return_value=b"GPU 0: NVIDIA GeForce RTX 4090 (UUID: GPU-rb438fre-0ar-9702-de35-ref4rjn34omk3 )",
@@ -39,58 +70,140 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
     ("input_accelerator", "expected_accelerator", "expected_devices"),
     [
         ("cpu", "cpu", 1),
+        # --- PyTorch CUDA Tests ---
         pytest.param(
             "cuda",
             "cuda",
-            torch.cuda.device_count(),
-            marks=pytest.mark.skipif(torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU"),
+            lambda: torch.cuda.device_count() if TORCH_AVAILABLE else 0,
+            marks=pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"),
+            id="torch_cuda_explicit",
         ),
         pytest.param(
             "gpu",
             "cuda",
-            torch.cuda.device_count(),
-            marks=pytest.mark.skipif(torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU"),
-        ),
-        pytest.param(
-            None,
-            "cuda",
-            torch.cuda.device_count(),
-            marks=pytest.mark.skipif(torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU"),
+            lambda: torch.cuda.device_count() if TORCH_AVAILABLE else 0,
+            marks=pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"),
+            id="torch_gpu_auto_cuda",
         ),
         pytest.param(
             "auto",
             "cuda",
-            torch.cuda.device_count(),
-            marks=pytest.mark.skipif(torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU"),
+            lambda: torch.cuda.device_count() if TORCH_AVAILABLE else 0,
+            marks=pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"),
+            id="torch_auto_cuda",
+        ),
+
+        # --- PyTorch MPS Tests ---
+        pytest.param(
+            "mps",
+            "mps",
+            1,
+            marks=pytest.mark.skipif(not torch_mps_check(), reason="Only tested on Apple MPS with PyTorch"),
+            id="torch_mps_check_explicit",
         ),
         pytest.param(
             "auto",
             "mps",
             1,
-            marks=pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Only tested on Apple MPS"),
+            marks=pytest.mark.skipif(not torch_mps_check(), reason="Only tested on Apple MPS with PyTorch"),
+            id="torch_auto_mps",
         ),
         pytest.param(
             "gpu",
             "mps",
             1,
-            marks=pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Only tested on Apple MPS"),
+            marks=pytest.mark.skipif(not torch_mps_check(), reason="Only tested on Apple MPS with PyTorch"),
+            id="torch_gpu_auto_mps",
+        ),
+
+        # --- JAX CUDA Tests  ---
+        pytest.param(
+            "jax",
+            "jax",
+            lambda: jax.device_count() if JAX_AVAILABLE else 0,
+            marks=pytest.mark.skipif(
+                not JAX_AVAILABLE or not any(d.device_kind == 'gpu' for d in jax.devices()) or check_cuda_with_nvidia_smi() == 0,
+                reason="Only tested on Nvidia GPU with JAX"
+            ),
+            id="jax_cuda_explicit",
         ),
         pytest.param(
+            "auto",
+            "cuda",
+            lambda: jax.device_count() if JAX_AVAILABLE else 0,
+            marks=pytest.mark.skipif(
+                not JAX_AVAILABLE or not any(d.device_kind == 'gpu' for d in jax.devices()) or check_cuda_with_nvidia_smi() == 0,
+                reason="Only tested on Nvidia GPU with JAX"
+            ),
+            id="jax_auto_cuda",
+        ),
+        pytest.param(
+            "gpu",
+            "cuda",
+            lambda: jax.device_count() if JAX_AVAILABLE else 0,
+            marks=pytest.mark.skipif(
+                not JAX_AVAILABLE or not any(d.device_kind == 'gpu' for d in jax.devices()) or check_cuda_with_nvidia_smi() == 0,
+                reason="Only tested on Nvidia GPU with JAX"
+            ),
+            id="jax_gpu_auto_cuda",
+        ),
+
+        # --- JAX MPS Tests ---
+        pytest.param(
+            "jax",
+            "jax",
+            lambda: jax.device_count() if JAX_AVAILABLE else 0,
+            marks=pytest.mark.skipif(not jax_mps_check(), reason="Only tested on Apple MPS with JAX"),
+            id="jax_mps_check_explicit",
+        ),
+        pytest.param(
+            "auto",
             "mps",
+            lambda: jax.device_count() if JAX_AVAILABLE else 0,
+            marks=pytest.mark.skipif(not jax_mps_check(), reason="Only tested on Apple MPS with JAX"),
+            id="jax_auto_mps",
+        ),
+        pytest.param(
+            "gpu",
             "mps",
-            1,
-            marks=pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Only tested on Apple MPS"),
+            lambda: jax.device_count() if JAX_AVAILABLE else 0,
+            marks=pytest.mark.skipif(not jax_mps_check(), reason="Only tested on Apple MPS with JAX"),
+            id="jax_gpu_auto_mps",
+        ),
+
+        # --- None (auto) tests, consider both Torch and JAX scenarios ---
+        pytest.param(
+            None,
+            "cuda",
+            lambda: torch.cuda.device_count() if TORCH_AVAILABLE else 0,
+            marks=pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"),
+            id="none_auto_cuda_torch",
         ),
         pytest.param(
             None,
             "mps",
             1,
-            marks=pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Only tested on Apple MPS"),
+            marks=pytest.mark.skipif(not torch_mps_check(), reason="Only tested on Apple MPS with PyTorch"),
+            id="none_auto_mps_torch",
         ),
+        pytest.param(
+            None,
+            "mps",
+            lambda: jax.device_count() if JAX_AVAILABLE else 0,
+            marks=pytest.mark.skipif(
+                TORCH_AVAILABLE and torch_mps_check(),
+                reason="PyTorch MPS takes precedence for 'auto' if available. Test JAX auto-mps only if PyTorch MPS is absent."
+            ),
+            id="none_auto_mps_jax_fallback"
+        )
     ],
 )
 def test_connector(input_accelerator, expected_accelerator, expected_devices):
     check_cuda_with_nvidia_smi.cache_clear()
+    
+    if callable(expected_devices):
+        expected_devices = expected_devices()
+
     connector = _Connector(accelerator=input_accelerator)
     assert connector.accelerator == expected_accelerator, (
         f"accelerator mismatch - expected: {expected_accelerator}, actual: {connector.accelerator}"
@@ -100,12 +213,86 @@ def test_connector(input_accelerator, expected_accelerator, expected_devices):
         f"devices mismatch - expected {expected_devices}, actual: {connector.devices}"
     )
 
-    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'"):
+    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', 'gpu', or 'jax'"):
         _Connector(accelerator="SUPER_CHIP")
-
 
 def test__sanitize_accelerator():
     assert _Connector._sanitize_accelerator(None) == "auto"
     assert _Connector._sanitize_accelerator("CPU") == "cpu"
-    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'"):
+    assert _Connector._sanitize_accelerator("JAX") == "jax"
+    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', 'gpu', or 'jax'"):
         _Connector._sanitize_accelerator("SUPER_CHIP")
+
+
+# --- Mocking tests for JAX scenarios ---
+
+@pytest.mark.skipif(JAX_AVAILABLE, reason="Only run mocking tests if JAX is not actually installed")
+@patch('litserve.connector.jax')
+@patch('litserve.connector.jax_backend')
+@patch('litserve.connector.check_cuda_with_nvidia_smi', return_value=0) # No CUDA
+def test_connector_mock_jax_mps_check(mock_cuda_smi, mock_jax_backend, mock_jax):
+    # Mock JAX to report MPS platform and an MPS device
+    mock_jax_backend.get_backend.return_value.platform = "mps"
+    mock_jax.devices.return_value = [MagicMock(device_kind='mps')]
+    mock_jax.device_count.return_value = 1
+    
+    # Mock platform.processor for Apple Silicon
+    with patch('platform.processor', return_value='arm64'):
+        check_cuda_with_nvidia_smi.cache_clear()
+        connector = _Connector(accelerator="auto")
+        assert connector.accelerator == "mps"
+        assert connector.devices == 1
+
+        check_cuda_with_nvidia_smi.cache_clear()
+        connector = _Connector(accelerator="jax")
+        assert connector.accelerator == "jax"
+        assert connector.devices == 1
+
+        check_cuda_with_nvidia_smi.cache_clear()
+        connector = _Connector(accelerator="gpu")
+        assert connector.accelerator == "mps"
+        assert connector.devices == 1
+
+@pytest.mark.skipif(JAX_AVAILABLE, reason="Only run mocking tests if JAX is not actually installed")
+@patch('litserve.connector.jax')
+@patch('litserve.connector.jax_backend')
+@patch('litserve.connector.check_cuda_with_nvidia_smi', return_value=1) 
+def test_connector_mock_jax_cuda(mock_cuda_smi, mock_jax_backend, mock_jax):
+    # Mock JAX to report CUDA platform and a GPU device
+    mock_jax_backend.get_backend.return_value.platform = "cuda" # or "gpu"
+    mock_jax.devices.return_value = [MagicMock(device_kind='gpu')]
+    mock_jax.device_count.return_value = 1
+    
+    check_cuda_with_nvidia_smi.cache_clear()
+    connector = _Connector(accelerator="auto")
+    assert connector.accelerator == "cuda"
+    assert connector.devices == 1
+
+    check_cuda_with_nvidia_smi.cache_clear()
+    connector = _Connector(accelerator="jax")
+    assert connector.accelerator == "jax"
+    assert connector.devices == 1
+
+    check_cuda_with_nvidia_smi.cache_clear()
+    connector = _Connector(accelerator="gpu")
+    assert connector.accelerator == "cuda"
+    assert connector.devices == 1
+
+@pytest.mark.skipif(JAX_AVAILABLE, reason="Only run mocking tests if JAX is not actually installed")
+@patch('litserve.connector.jax', None) # Simulate JAX not installed
+@patch('litserve.connector.jax_backend', None) # Simulate JAX backend extension not available
+@patch('litserve.connector.torch', None) # Simulate Torch not installed
+@patch('litserve.connector.check_cuda_with_nvidia_smi', return_value=0) # No CUDA
+def test_connector_no_frameworks(mock_cuda_smi):
+    check_cuda_with_nvidia_smi.cache_clear()
+    connector = _Connector(accelerator="auto")
+    assert connector.accelerator == "cpu"
+    assert connector.devices == 1
+
+    connector = _Connector(accelerator="gpu")
+    assert connector.accelerator is None
+    assert connector.devices == 1
+
+    connector = _Connector(accelerator="jax")
+    assert connector.accelerator == "jax"
+    assert connector.devices == 1

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -125,18 +125,6 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
         ),
         # --- JAX CUDA Tests  ---
         pytest.param(
-            "jax",
-            "jax",
-            lambda: jax.device_count() if JAX_AVAILABLE else 0,
-            marks=pytest.mark.skipif(
-                not JAX_AVAILABLE
-                or not any(d.device_kind == "gpu" for d in jax.devices())
-                or check_cuda_with_nvidia_smi() == 0,
-                reason="Only tested on Nvidia GPU with JAX",
-            ),
-            id="jax_cuda_explicit",
-        ),
-        pytest.param(
             "auto",
             "cuda",
             lambda: jax.device_count() if JAX_AVAILABLE else 0,
@@ -161,13 +149,6 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
             id="jax_gpu_auto_cuda",
         ),
         # --- JAX MPS Tests ---
-        pytest.param(
-            "jax",
-            "jax",
-            lambda: jax.device_count() if JAX_AVAILABLE else 0,
-            marks=pytest.mark.skipif(not jax_mps_check(), reason="Only tested on Apple MPS with JAX"),
-            id="jax_mps_check_explicit",
-        ),
         pytest.param(
             "auto",
             "mps",
@@ -226,15 +207,14 @@ def test_connector(input_accelerator, expected_accelerator, expected_devices):
         f"devices mismatch - expected {expected_devices}, actual: {connector.devices}"
     )
 
-    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', 'gpu', or 'jax'"):
+    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'"):
         _Connector(accelerator="SUPER_CHIP")
 
 
 def test__sanitize_accelerator():
     assert _Connector._sanitize_accelerator(None) == "auto"
     assert _Connector._sanitize_accelerator("CPU") == "cpu"
-    assert _Connector._sanitize_accelerator("JAX") == "jax"
-    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', 'gpu', or 'jax'"):
+    with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', or 'gpu'"):
         _Connector._sanitize_accelerator("SUPER_CHIP")
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -11,27 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import platform
-import subprocess
-import sys
-from functools import lru_cache
-from typing import List, Optional, Union
-from unittest.mock import patch, MagicMock
-from litserve.connector import _Connector, check_cuda_with_nvidia_smi
-
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from litserve.connector import _Connector, check_cuda_with_nvidia_smi
+
 try:
     import torch
+
     TORCH_AVAILABLE = True
 except ImportError:
     TORCH_AVAILABLE = False
 
 try:
     import jax
-    import jax.extend.backend as jax_backend 
+    import jax.extend.backend as jax_backend
+
     JAX_AVAILABLE = True
 except ImportError:
     JAX_AVAILABLE = False
@@ -41,9 +38,12 @@ def jax_mps_check():
     if not JAX_AVAILABLE:
         return False
     # Check if JAX is configured for MPS
-    return any(d.device_kind == 'mps' for d in jax.devices()) and \
-           (jax_backend.get_backend().platform == 'mps') and \
-           platform.processor() in ("arm", "arm64")
+    return (
+        any(d.device_kind == "mps" for d in jax.devices())
+        and (jax_backend.get_backend().platform == "mps")
+        and platform.processor() in ("arm", "arm64")
+    )
+
 
 def torch_mps_check():
     if not TORCH_AVAILABLE:
@@ -51,9 +51,12 @@ def torch_mps_check():
     return torch.backends.mps.is_available() and platform.processor() in ("arm", "arm64")
 
 
-@pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch")
+@pytest.mark.skipif(
+    not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"
+)
 def test_check_cuda_with_nvidia_smi():
     assert check_cuda_with_nvidia_smi() == torch.cuda.device_count()
+
 
 @pytest.mark.skipif(TORCH_AVAILABLE and torch.cuda.device_count() > 0, reason="Non-Nvidia GPU only")
 @patch(
@@ -75,24 +78,29 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
             "cuda",
             "cuda",
             lambda: torch.cuda.device_count() if TORCH_AVAILABLE else 0,
-            marks=pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"),
+            marks=pytest.mark.skipif(
+                not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"
+            ),
             id="torch_cuda_explicit",
         ),
         pytest.param(
             "gpu",
             "cuda",
             lambda: torch.cuda.device_count() if TORCH_AVAILABLE else 0,
-            marks=pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"),
+            marks=pytest.mark.skipif(
+                not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"
+            ),
             id="torch_gpu_auto_cuda",
         ),
         pytest.param(
             "auto",
             "cuda",
             lambda: torch.cuda.device_count() if TORCH_AVAILABLE else 0,
-            marks=pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"),
+            marks=pytest.mark.skipif(
+                not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"
+            ),
             id="torch_auto_cuda",
         ),
-
         # --- PyTorch MPS Tests ---
         pytest.param(
             "mps",
@@ -115,15 +123,16 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
             marks=pytest.mark.skipif(not torch_mps_check(), reason="Only tested on Apple MPS with PyTorch"),
             id="torch_gpu_auto_mps",
         ),
-
         # --- JAX CUDA Tests  ---
         pytest.param(
             "jax",
             "jax",
             lambda: jax.device_count() if JAX_AVAILABLE else 0,
             marks=pytest.mark.skipif(
-                not JAX_AVAILABLE or not any(d.device_kind == 'gpu' for d in jax.devices()) or check_cuda_with_nvidia_smi() == 0,
-                reason="Only tested on Nvidia GPU with JAX"
+                not JAX_AVAILABLE
+                or not any(d.device_kind == "gpu" for d in jax.devices())
+                or check_cuda_with_nvidia_smi() == 0,
+                reason="Only tested on Nvidia GPU with JAX",
             ),
             id="jax_cuda_explicit",
         ),
@@ -132,8 +141,10 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
             "cuda",
             lambda: jax.device_count() if JAX_AVAILABLE else 0,
             marks=pytest.mark.skipif(
-                not JAX_AVAILABLE or not any(d.device_kind == 'gpu' for d in jax.devices()) or check_cuda_with_nvidia_smi() == 0,
-                reason="Only tested on Nvidia GPU with JAX"
+                not JAX_AVAILABLE
+                or not any(d.device_kind == "gpu" for d in jax.devices())
+                or check_cuda_with_nvidia_smi() == 0,
+                reason="Only tested on Nvidia GPU with JAX",
             ),
             id="jax_auto_cuda",
         ),
@@ -142,12 +153,13 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
             "cuda",
             lambda: jax.device_count() if JAX_AVAILABLE else 0,
             marks=pytest.mark.skipif(
-                not JAX_AVAILABLE or not any(d.device_kind == 'gpu' for d in jax.devices()) or check_cuda_with_nvidia_smi() == 0,
-                reason="Only tested on Nvidia GPU with JAX"
+                not JAX_AVAILABLE
+                or not any(d.device_kind == "gpu" for d in jax.devices())
+                or check_cuda_with_nvidia_smi() == 0,
+                reason="Only tested on Nvidia GPU with JAX",
             ),
             id="jax_gpu_auto_cuda",
         ),
-
         # --- JAX MPS Tests ---
         pytest.param(
             "jax",
@@ -170,13 +182,14 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
             marks=pytest.mark.skipif(not jax_mps_check(), reason="Only tested on Apple MPS with JAX"),
             id="jax_gpu_auto_mps",
         ),
-
         # --- None (auto) tests, consider both Torch and JAX scenarios ---
         pytest.param(
             None,
             "cuda",
             lambda: torch.cuda.device_count() if TORCH_AVAILABLE else 0,
-            marks=pytest.mark.skipif(not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"),
+            marks=pytest.mark.skipif(
+                not TORCH_AVAILABLE or torch.cuda.device_count() == 0, reason="Only tested on Nvidia GPU with PyTorch"
+            ),
             id="none_auto_cuda_torch",
         ),
         pytest.param(
@@ -192,15 +205,15 @@ def test_check_cuda_with_nvidia_smi_mock_gpu(mock_subprocess):
             lambda: jax.device_count() if JAX_AVAILABLE else 0,
             marks=pytest.mark.skipif(
                 TORCH_AVAILABLE and torch_mps_check(),
-                reason="PyTorch MPS takes precedence for 'auto' if available. Test JAX auto-mps only if PyTorch MPS is absent."
+                reason="PyTorch MPS takes precedence for 'auto' if available. Test JAX auto-mps only if PyTorch MPS is absent.",
             ),
-            id="none_auto_mps_jax_fallback"
-        )
+            id="none_auto_mps_jax_fallback",
+        ),
     ],
 )
 def test_connector(input_accelerator, expected_accelerator, expected_devices):
     check_cuda_with_nvidia_smi.cache_clear()
-    
+
     if callable(expected_devices):
         expected_devices = expected_devices()
 
@@ -216,6 +229,7 @@ def test_connector(input_accelerator, expected_accelerator, expected_devices):
     with pytest.raises(ValueError, match="accelerator must be one of 'auto', 'cpu', 'mps', 'cuda', 'gpu', or 'jax'"):
         _Connector(accelerator="SUPER_CHIP")
 
+
 def test__sanitize_accelerator():
     assert _Connector._sanitize_accelerator(None) == "auto"
     assert _Connector._sanitize_accelerator("CPU") == "cpu"
@@ -226,18 +240,19 @@ def test__sanitize_accelerator():
 
 # --- Mocking tests for JAX scenarios ---
 
+
 @pytest.mark.skipif(JAX_AVAILABLE, reason="Only run mocking tests if JAX is not actually installed")
-@patch('litserve.connector.jax')
-@patch('litserve.connector.jax_backend')
-@patch('litserve.connector.check_cuda_with_nvidia_smi', return_value=0) # No CUDA
+@patch("litserve.connector.jax")
+@patch("litserve.connector.jax_backend")
+@patch("litserve.connector.check_cuda_with_nvidia_smi", return_value=0)  # No CUDA
 def test_connector_mock_jax_mps_check(mock_cuda_smi, mock_jax_backend, mock_jax):
     # Mock JAX to report MPS platform and an MPS device
     mock_jax_backend.get_backend.return_value.platform = "mps"
-    mock_jax.devices.return_value = [MagicMock(device_kind='mps')]
+    mock_jax.devices.return_value = [MagicMock(device_kind="mps")]
     mock_jax.device_count.return_value = 1
-    
+
     # Mock platform.processor for Apple Silicon
-    with patch('platform.processor', return_value='arm64'):
+    with patch("platform.processor", return_value="arm64"):
         check_cuda_with_nvidia_smi.cache_clear()
         connector = _Connector(accelerator="auto")
         assert connector.accelerator == "mps"
@@ -253,16 +268,17 @@ def test_connector_mock_jax_mps_check(mock_cuda_smi, mock_jax_backend, mock_jax)
         assert connector.accelerator == "mps"
         assert connector.devices == 1
 
+
 @pytest.mark.skipif(JAX_AVAILABLE, reason="Only run mocking tests if JAX is not actually installed")
-@patch('litserve.connector.jax')
-@patch('litserve.connector.jax_backend')
-@patch('litserve.connector.check_cuda_with_nvidia_smi', return_value=1) 
+@patch("litserve.connector.jax")
+@patch("litserve.connector.jax_backend")
+@patch("litserve.connector.check_cuda_with_nvidia_smi", return_value=1)
 def test_connector_mock_jax_cuda(mock_cuda_smi, mock_jax_backend, mock_jax):
     # Mock JAX to report CUDA platform and a GPU device
-    mock_jax_backend.get_backend.return_value.platform = "cuda" # or "gpu"
-    mock_jax.devices.return_value = [MagicMock(device_kind='gpu')]
+    mock_jax_backend.get_backend.return_value.platform = "cuda"  # or "gpu"
+    mock_jax.devices.return_value = [MagicMock(device_kind="gpu")]
     mock_jax.device_count.return_value = 1
-    
+
     check_cuda_with_nvidia_smi.cache_clear()
     connector = _Connector(accelerator="auto")
     assert connector.accelerator == "cuda"
@@ -278,11 +294,12 @@ def test_connector_mock_jax_cuda(mock_cuda_smi, mock_jax_backend, mock_jax):
     assert connector.accelerator == "cuda"
     assert connector.devices == 1
 
+
 @pytest.mark.skipif(JAX_AVAILABLE, reason="Only run mocking tests if JAX is not actually installed")
-@patch('litserve.connector.jax', None) # Simulate JAX not installed
-@patch('litserve.connector.jax_backend', None) # Simulate JAX backend extension not available
-@patch('litserve.connector.torch', None) # Simulate Torch not installed
-@patch('litserve.connector.check_cuda_with_nvidia_smi', return_value=0) # No CUDA
+@patch("litserve.connector.jax", None)  # Simulate JAX not installed
+@patch("litserve.connector.jax_backend", None)  # Simulate JAX backend extension not available
+@patch("litserve.connector.torch", None)  # Simulate Torch not installed
+@patch("litserve.connector.check_cuda_with_nvidia_smi", return_value=0)  # No CUDA
 def test_connector_no_frameworks(mock_cuda_smi):
     check_cuda_with_nvidia_smi.cache_clear()
     connector = _Connector(accelerator="auto")


### PR DESCRIPTION
## What does this PR do?

Fixes #54 (issue).

### Problem
Currently, there is no JAX support within the accelerator for LitServe. LitServe would like to accomodate for JAX users as well as segregate `_choose_gpu_accelerator_backend ` into framework-specific functions.

### Solution
This PR provides a comprehensive solution by implementing the following:

1. Added separate functions to determine PyTorch devices and JAX devices. For each function, we check for CUDA and MPS. Preference has been made for PyTorch devices over JAX devices if not specified to use JAX.
2. Added JAX functionality to the `_choose_auto_accelerator` function.
3. Added logging to display what device is being used. 
4. Reformated the test_connector file to test both CUDA and MPS for PyTorch and JAX. 

This is a draft PR, there can be some refactoring done with using the `_choose_gpu_accelerator_backend` in the `_choose_auto_accelerator` function which I'll work on.

<details>
  <summary><b>Before submitting</b></summary>

- [✅] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [✅] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [] Did you make sure to update the docs?
- [✅] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
