### PR TITLE
Add reasoning effort parameter to OpenAI Spec ChatCompletionRequest 

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -176,6 +176,7 @@ class ChatCompletionRequest(BaseModel):
     tools: Optional[List[Tool]] = None
     tool_choice: Optional[ToolChoice] = ToolChoice.auto
     response_format: Optional[ResponseFormat] = None
+    reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
     metadata: Optional[Dict[str, str]] = None
 
 

--- a/src/litserve/test_examples/openai_spec_example.py
+++ b/src/litserve/test_examples/openai_spec_example.py
@@ -53,6 +53,14 @@ class TestAPIWithStructuredOutput(TestAPI):
         )
 
 
+class TestAPIWithReasoningEffort(TestAPI):
+    def encode_response(self, output, context):
+        yield ChatMessage(
+            role="assistant",
+            content=f"This is a generated output with reasoning effort: {context.get('reasoning_effort', None)}",
+        )
+
+
 class OpenAIBatchContext(LitAPI):
     def setup(self, device: str) -> None:
         self.model = None

--- a/src/litserve/test_examples/openai_spec_example.py
+++ b/src/litserve/test_examples/openai_spec_example.py
@@ -53,14 +53,6 @@ class TestAPIWithStructuredOutput(TestAPI):
         )
 
 
-class TestAPIWithReasoningEffort(TestAPI):
-    def encode_response(self, output, context):
-        yield ChatMessage(
-            role="assistant",
-            content=f"This is a generated output with reasoning effort: {context.get('reasoning_effort', None)}",
-        )
-
-
 class OpenAIBatchContext(LitAPI):
     def setup(self, device: str) -> None:
         self.model = None

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -263,11 +263,14 @@ async def test_openai_spec_reasoning_effort(reasoning_effort, openai_request_dat
             transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
             resp = await ac.post("/v1/chat/completions", json=openai_request_data)
-            assert resp.status_code == 200 if reasoning_effort != "random" else 422
-            assert (
-                resp.json()["choices"][0]["message"]["content"]
-                == f"This is a generated output with reasoning effort: {reasoning_effort}"
-            )
+            if reasoning_effort == "random":
+                assert resp.status_code == 422
+            else:
+                assert resp.status_code == 200
+                assert (
+                    resp.json()["choices"][0]["message"]["content"]
+                    == f"This is a generated output with reasoning effort: {reasoning_effort}"
+                )
 
 
 class IncorrectAPI1(ls.LitAPI):

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -24,7 +24,6 @@ from litserve.test_examples.openai_spec_example import (
     OpenAIWithUsageEncodeResponse,
     TestAPI,
     TestAPIWithCustomEncode,
-    TestAPIWithReasoningEffort,
     TestAPIWithStructuredOutput,
     TestAPIWithToolCalls,
 )
@@ -251,6 +250,14 @@ async def test_openai_spec_metadata_required_fail(openai_request_data):
             resp = await ac.post("/v1/chat/completions", json=openai_request_data)
             assert resp.status_code == 500
             assert "Missing required metadata" in resp.text
+
+
+class TestAPIWithReasoningEffort(TestAPI):
+    def encode_response(self, output, context):
+        yield ChatMessage(
+            role="assistant",
+            content=f"This is a generated output with reasoning effort: {context.get('reasoning_effort', None)}",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -264,7 +264,7 @@ async def test_openai_spec_reasoning_effort(reasoning_effort, openai_request_dat
         ) as ac:
             resp = await ac.post("/v1/chat/completions", json=openai_request_data)
             if reasoning_effort == "random":
-                assert resp.status_code == 422
+                assert resp.status_code == 422  # as random is not a valid reasoning effort
             else:
                 assert resp.status_code == 200
                 assert (


### PR DESCRIPTION
## What does this PR do ?

Fixes #547

Introduce a new `reasoning_effort` field to the `ChatCompletionRequest` model and implement corresponding tests to validate its functionality in the API responses.