### PR TITLE
Add support for custom client file paths in `generate_client_file` with improved logging and tests

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -987,11 +987,19 @@ class LitServer:
                 self.app.add_middleware(middleware)
 
     @staticmethod
-    def generate_client_file(port: Union[str, int] = 8000):
-        dest_path = os.path.join(os.getcwd(), "client.py")
+    def generate_client_file(port: Union[str, int] = 8000, dest_path: Optional[str] = None):
+        """Generate a small Python client for interacting with the server.
+
+        Args:
+            port: The port the server is running on.
+            dest_path: Path to write the client file to. Defaults to ``client.py`` in the
+                current working directory.
+
+        """
+        dest_path = dest_path or os.path.join(os.getcwd(), "client.py")
 
         if os.path.exists(dest_path):
-            logger.debug("client.py already exists in the current directory. Skipping generation.")
+            logger.debug(f"{dest_path} already exists. Skipping generation.")
             return
 
         try:
@@ -1169,7 +1177,7 @@ class LitServer:
             generate_client_file:
                 Auto-generate a Python client file for easy API interaction. Defaults to True.
 
-                - Creates `client.py` in current directory with typed methods
+                - Creates a client file (default `client.py` in current directory)
                 - Useful for testing and integration
                 - Safe to disable in production environments
 

--- a/tests/test_lit_server.py
+++ b/tests/test_lit_server.py
@@ -529,6 +529,14 @@ print(f"Status: {response.status_code}\\nResponse:\\n {response.text}")"""
         assert expected in fr.read(), "Shouldn't replace existing client.py"
 
 
+def test_generate_client_file_custom_path(tmp_path):
+    dest = tmp_path / "my_client.py"
+    LitServer.generate_client_file(8123, dest_path=dest)
+    with open(dest) as fr:
+        content = fr.read()
+    assert "http://127.0.0.1:8123/predict" in content
+
+
 class FailFastAPI(ls.test_examples.SimpleLitAPI):
     def setup(self, device):
         raise ValueError("setup failed")


### PR DESCRIPTION
### PR Description:

This PR enhances the generate_client_file static method in LiteServe by adding support for a user-defined destination path (dest_path). If not specified, the method defaults to generating client.py in the current working directory, preserving backward compatibility.

**Key Improvements:**

    Custom Output Path Support: Users can now specify a custom filename and path for the generated client file.

    Improved Logging: Log messages now reflect the actual path where the client file is (or would be) written, improving clarity in debugging and automation workflows.

    Documentation Update: The inline docstring and YAML-based config description have been updated to reflect the new behavior.

    New Unit Test: Adds test_generate_client_file_custom_path to validate that the generated file correctly reflects the server URL when a custom path is used.

**Test Coverage:**

    Verified that both default (client.py) and custom output paths generate a valid client with expected contents.

    Ensured backward compatibility with existing usage.

Fix:#549