### PR TITLE
Update LitServer initialization parameters for type safety

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -611,8 +611,8 @@ class LitServer:
     def __init__(
         self,
         lit_api: Union[LitAPI, List[LitAPI]],
-        accelerator: str = "auto",
-        devices: Union[str, int] = "auto",
+        accelerator: Literal["cpu", "cuda", "mps", "auto"] = "auto",
+        devices: Union[int, Literal["auto"]] = "auto",
         workers_per_device: int = 1,
         timeout: Union[float, bool] = 30,
         healthcheck_path: str = "/health",
@@ -627,6 +627,7 @@ class LitServer:
         middlewares: Optional[list[Union[Callable, tuple[Callable, dict]]]] = None,
         loggers: Optional[Union[Logger, List[Logger]]] = None,
         fast_queue: bool = False,
+        # All the following arguments are deprecated and will be removed in v0.3.0
         max_batch_size: Optional[int] = None,
         batch_timeout: float = 0.0,
         stream: bool = False,


### PR DESCRIPTION
## What does this PR do?

Good devex

- Updated the `accelerator` parameter to use a more specific Literal type, allowing only "cpu", "cuda", "mps", or "auto".
- Changed the `devices` parameter to accept either an integer or the Literal "auto", enhancing clarity and type checking.
- Added a comment indicating that several arguments are deprecated and will be removed in version 0.3.0.



<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
