### PR TITLE
Send blocking CPU operations to thread for async conversion. 

### DIFF
--- a/tests/unit/test_loops.py
+++ b/tests/unit/test_loops.py
@@ -33,7 +33,7 @@ import litserve as ls
 from litserve import LitAPI
 from litserve.callbacks import CallbackRunner
 from litserve.loops import BatchedStreamingLoop, LitLoop, Output, StreamingLoop, inference_worker
-from litserve.loops.base import DefaultLoop, _async_inject_context, _handle_async_function
+from litserve.loops.base import DefaultLoop, _async_inject_context, _handle_async_function, _sync_fn_to_async_fn
 from litserve.loops.continuous_batching_loop import (
     ContinuousBatchingLoop,
     notify_timed_out_requests,
@@ -945,3 +945,17 @@ async def test_async_inject_context():
 
     context = {"a": 1}
     assert await _async_inject_context(context, async_func, 2) == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_fn_to_async_fn():
+    def sync_func():
+        return "sync-to-async"
+
+    def sync_gen():
+        for i in range(3):
+            yield f"sync-to-async-{i}"
+
+    assert await _sync_fn_to_async_fn(sync_func) == "sync-to-async"
+    async_gen = await _sync_fn_to_async_fn(sync_gen)
+    assert isinstance(async_gen, AsyncGenerator)


### PR DESCRIPTION
## What does this PR do?

Send blocking CPU operations to thread for async conversion. 

- If there is a blocking CPU operation then it will block the whole asyncio loop. 
- This PR sends the CPU blocking operations to a background thread. 

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
