### PR TITLE
Improve error handling for streaming

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -19,6 +19,7 @@ import json
 import logging
 import multiprocessing as mp
 import os
+import pickle
 import secrets
 import sys
 import threading
@@ -325,16 +326,22 @@ class RegularRequestHandler(BaseRequestHandler):
             return response
 
         except HTTPException as e:
-            raise e
+            return e
 
         except Exception as e:
-            logger.exception(f"Error handling request: {e}")
-            raise HTTPException(status_code=500, detail="Internal server error")
+            logger.error(f"Unhandled exception: {e}", exc_info=True)
+            return HTTPException(status_code=500, detail="Internal server error")
 
     async def _handle_error_response(self, response):
-        logger.error("Error in request: %s", response)
+        """Raise HTTPException as is and rest as 500 after logging the error."""
+        if isinstance(response, bytes):
+            response = pickle.loads(response)
+
         if isinstance(response, HTTPException):
             raise response
+
+        if isinstance(response, Exception):
+            logger.exception(f"Error while handling request: {response}")
 
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -800,7 +807,7 @@ class LitServer:
                     self.workers_setup_status,
                     self._callback_runner,
                 ),
-                name=f"lit-inference-{endpoint}_{worker_id}",
+                name="inference-worker",
             )
             process.start()
             process_list.append(process)
@@ -1363,9 +1370,9 @@ class LitServer:
             server = uvicorn.Server(config=uvicorn_config)
             if uvicorn_worker_type == "process":
                 ctx = mp.get_context("fork")
-                w = ctx.Process(target=server.run, args=(sockets,), name=f"lit-uvicorn-{response_queue_id}")
+                w = ctx.Process(target=server.run, args=(sockets,), name=f"LitServer-{response_queue_id}")
             elif uvicorn_worker_type == "thread":
-                w = threading.Thread(target=server.run, args=(sockets,), name=f"lit-uvicorn-{response_queue_id}")
+                w = threading.Thread(target=server.run, args=(sockets,), name=f"LitServer-{response_queue_id}")
             else:
                 raise ValueError("Invalid value for api_server_worker_type. Must be 'process' or 'thread'")
             w.start()

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -326,11 +326,11 @@ class RegularRequestHandler(BaseRequestHandler):
             return response
 
         except HTTPException as e:
-            return e
+            raise e from None
 
         except Exception as e:
             logger.error(f"Unhandled exception: {e}", exc_info=True)
-            return HTTPException(status_code=500, detail="Internal server error")
+            raise HTTPException(status_code=500, detail="Internal server error") from e
 
     async def _handle_error_response(self, response):
         """Raise HTTPException as is and rest as 500 after logging the error."""
@@ -341,7 +341,7 @@ class RegularRequestHandler(BaseRequestHandler):
             raise response
 
         if isinstance(response, Exception):
-            logger.exception(f"Error while handling request: {response}")
+            logger.error(f"Error while handling request: {response}")
 
         raise HTTPException(status_code=500, detail="Internal server error")
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -327,6 +327,26 @@ class ExampleAPI(ls.LitAPI):
 """  # noqa: E501
 
 
+def _openai_format_error(error: Exception):
+    if isinstance(error, HTTPException):
+        return "data: " + json.dumps({
+            "error": {
+                "message": error.detail,
+                "type": "internal",
+                "param": None,
+                "code": "internal_error",
+            }
+        })
+    return "data: " + json.dumps({
+        "error": {
+            "message": "Internal server error",
+            "type": "internal",
+            "param": None,
+            "code": "internal_error",
+        }
+    })
+
+
 class OpenAISpec(LitSpec):
     def __init__(
         self,
@@ -486,82 +506,91 @@ class OpenAISpec(LitSpec):
         return await response_task
 
     async def streaming_completion(self, request: ChatCompletionRequest, pipe_responses: List):
-        model = request.model
-        usage_info = None
-        async for streaming_response in azip(*pipe_responses):
-            choices = []
-            usage_infos = []
-            # iterate over n choices
-            for i, (response, status) in enumerate(streaming_response):
-                if status == LitAPIStatus.ERROR and isinstance(response, HTTPException):
-                    raise response
-                elif status == LitAPIStatus.ERROR:
-                    logger.error("Error in streaming response: %s", response)
-                    raise HTTPException(status_code=500)
-                encoded_response = json.loads(response)
-                logger.debug(encoded_response)
-                chat_msg = ChoiceDelta(**encoded_response)
-                usage_infos.append(UsageInfo(**encoded_response))
-                choice = ChatCompletionStreamingChoice(
-                    index=i, delta=chat_msg, system_fingerprint="", finish_reason=None
+        try:
+            model = request.model
+            usage_info = None
+            async for streaming_response in azip(*pipe_responses):
+                choices = []
+                usage_infos = []
+                # iterate over n choices
+                for i, (response, status) in enumerate(streaming_response):
+                    if status == LitAPIStatus.ERROR and isinstance(response, HTTPException):
+                        raise response
+                    elif status == LitAPIStatus.ERROR:
+                        logger.error("Error in streaming response: %s", response)
+                        raise HTTPException(status_code=500)
+                    encoded_response = json.loads(response)
+                    logger.debug(encoded_response)
+                    chat_msg = ChoiceDelta(**encoded_response)
+                    usage_infos.append(UsageInfo(**encoded_response))
+                    choice = ChatCompletionStreamingChoice(
+                        index=i, delta=chat_msg, system_fingerprint="", finish_reason=None
+                    )
+
+                    choices.append(choice)
+
+                # Only use the last item from encode_response
+                usage_info = sum(usage_infos)
+                chunk = ChatCompletionChunk(model=model, choices=choices, usage=None)
+                logger.debug(chunk)
+                yield f"data: {chunk.model_dump_json(by_alias=True)}\n\n"
+
+            choices = [
+                ChatCompletionStreamingChoice(
+                    index=i,
+                    delta=ChoiceDelta(),
+                    finish_reason="stop",
                 )
-
-                choices.append(choice)
-
-            # Only use the last item from encode_response
-            usage_info = sum(usage_infos)
-            chunk = ChatCompletionChunk(model=model, choices=choices, usage=None)
-            logger.debug(chunk)
-            yield f"data: {chunk.model_dump_json(by_alias=True)}\n\n"
-
-        choices = [
-            ChatCompletionStreamingChoice(
-                index=i,
-                delta=ChoiceDelta(),
-                finish_reason="stop",
+                for i in range(request.n)
+            ]
+            last_chunk = ChatCompletionChunk(
+                model=model,
+                choices=choices,
+                usage=usage_info,
             )
-            for i in range(request.n)
-        ]
-        last_chunk = ChatCompletionChunk(
-            model=model,
-            choices=choices,
-            usage=usage_info,
-        )
-        yield f"data: {last_chunk.model_dump_json(by_alias=True)}\n\n"
-        yield "data: [DONE]\n\n"
+            yield f"data: {last_chunk.model_dump_json(by_alias=True)}\n\n"
+            yield "data: [DONE]\n\n"
+        except Exception as e:
+            logger.error("Error in streaming response: %s", e, exc_info=True)
+            yield _openai_format_error(e)
+            return
 
     async def non_streaming_completion(self, request: ChatCompletionRequest, generator_list: List[AsyncGenerator]):
-        model = request.model
-        usage_infos = []
-        choices = []
-        # iterate over n choices
-        for i, streaming_response in enumerate(generator_list):
-            msgs = []
-            tool_calls = None
-            usage = None
-            async for response, status in streaming_response:
-                if status == LitAPIStatus.ERROR and isinstance(response, HTTPException):
-                    raise response
-                if status == LitAPIStatus.ERROR:
-                    logger.error("Error in OpenAI non-streaming response: %s", response)
-                    raise HTTPException(status_code=500)
+        try:
+            model = request.model
+            usage_infos = []
+            choices = []
+            # iterate over n choices
+            for i, streaming_response in enumerate(generator_list):
+                msgs = []
+                tool_calls = None
+                usage = None
+                async for response, status in streaming_response:
+                    if status == LitAPIStatus.ERROR and isinstance(response, HTTPException):
+                        raise response
+                    if status == LitAPIStatus.ERROR:
+                        logger.error("Error in OpenAI non-streaming response: %s", response)
+                        raise HTTPException(status_code=500)
 
-                # data from LitAPI.encode_response
-                encoded_response = json.loads(response)
-                logger.debug(encoded_response)
-                chat_msg = ChatMessage(**encoded_response)
-                usage = UsageInfo(**encoded_response)
-                usage_infos.append(usage)  # Aggregate usage info across all choices
-                msgs.append(chat_msg.content)
-                if chat_msg.tool_calls:
-                    tool_calls = chat_msg.tool_calls
+                    # data from LitAPI.encode_response
+                    encoded_response = json.loads(response)
+                    logger.debug(encoded_response)
+                    chat_msg = ChatMessage(**encoded_response)
+                    usage = UsageInfo(**encoded_response)
+                    usage_infos.append(usage)  # Aggregate usage info across all choices
+                    msgs.append(chat_msg.content)
+                    if chat_msg.tool_calls:
+                        tool_calls = chat_msg.tool_calls
 
-            content = "".join(msg for msg in msgs if msg is not None)
-            msg = {"role": "assistant", "content": content, "tool_calls": tool_calls}
-            choice = ChatCompletionResponseChoice(index=i, message=msg, finish_reason="stop")
-            choices.append(choice)
+                content = "".join(msg for msg in msgs if msg is not None)
+                msg = {"role": "assistant", "content": content, "tool_calls": tool_calls}
+                choice = ChatCompletionResponseChoice(index=i, message=msg, finish_reason="stop")
+                choices.append(choice)
 
-        return ChatCompletionResponse(model=model, choices=choices, usage=sum(usage_infos))
+            return ChatCompletionResponse(model=model, choices=choices, usage=sum(usage_infos))
+        except Exception as e:
+            logger.error("Error in non-streaming response: %s", e, exc_info=True)
+            raise HTTPException(status_code=500)
 
 
 class _AsyncOpenAISpecWrapper(_AsyncSpecWrapper):

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -64,6 +64,15 @@ def dump_exception(exception):
     return pickle.dumps(exception)
 
 
+def unpickle_exception(error):
+    try:
+        if isinstance(error, bytes):
+            parsed_error = pickle.loads(error)
+        return parsed_error
+    except Exception as _:
+        return error
+
+
 async def azip(*async_iterables):
     iterators = [ait.__aiter__() for ait in async_iterables]
     while True:

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -31,6 +31,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_LOG_FORMAT = (
+    "%(asctime)s - %(processName)s[%(process)d] - %(name)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s"
+)
+
 
 class LitAPIStatus:
     OK = "OK"
@@ -128,7 +132,7 @@ def _get_default_handler(stream, format):
 
 def configure_logging(
     level: Union[str, int] = logging.INFO,
-    format: str = "%(processName)s[%(process)d] - %(name)s - %(levelname)s - %(message)s",
+    format: str = _DEFAULT_LOG_FORMAT,
     stream: TextIO = sys.stdout,
     use_rich: bool = False,
 ):


### PR DESCRIPTION
## What does this PR do?

### Before

<details>
<summary>insane error trace:  </summary>

```
(LitServe) ➜  LitServe git:(improve-error) ✗ python main.py
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
OpenAI spec setup complete
Swagger UI is available at http://0.0.0.0:8000/docs
INFO:     Started server process [95899]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     127.0.0.1:53752 - "POST /v1/chat/completions HTTP/1.1" 200 OK
lit-inference-completions_0[95878] - litserve.loops.streaming_loops - ERROR - LitAPI ran into an error while processing the streaming request uid=dbb351f1-ec62-47ce-9b5c-cb4957436bf0.
Please check the error trace for more details.
Traceback (most recent call last):
  File "/Users/aniket/Projects/github/LitServe/src/litserve/loops/streaming_loops.py", line 91, in run_streaming_loop
    for y_enc in y_enc_gen:
                 ^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/src/litserve/specs/openai.py", line 446, in encode_response
    for output in output_generator:
                  ^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/main.py", line 21, in predict
    raise ApiException(status_code=500, detail="test")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ApiException.__init__() got an unexpected keyword argument 'status_code'
lit-uvicorn-0[95899] - litserve.server - ERROR - Error occurred while streaming outputs from the inference worker. Please check the above traceback.
lit-uvicorn-0[95899] - litserve.specs.openai - ERROR - Error in streaming response: b"\x80\x04\x95i\x00\x00\x00\x00\x00\x00\x00\x8c\x08builtins\x94\x8c\tTypeError\x94\x93\x94\x8cHApiException.__init__() got an unexpected keyword argument 'status_code'\x94\x85\x94R\x94."
ERROR:    Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 76, in collapse_excgroups
  |     yield
  |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/responses.py", line 263, in __call__
  |     async with anyio.create_task_group() as task_group:
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/routing.py", line 74, in app
    |     await response(scope, receive, send)
    |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/responses.py", line 262, in __call__
    |     with collapse_excgroups():
    |          ^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/aniket/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/contextlib.py", line 158, in __exit__
    |     self.gen.throw(value)
    |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    |     raise exc
    |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/responses.py", line 266, in wrap
    |     await func()
    |   File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/responses.py", line 246, in stream_response
    |     async for chunk in self.body_iterator:
    |   File "/Users/aniket/Projects/github/LitServe/src/litserve/specs/openai.py", line 500, in streaming_completion
    |     raise HTTPException(status_code=500)
    | fastapi.exceptions.HTTPException: 500: Internal Server Error
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/routing.py", line 74, in app
    await response(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/responses.py", line 262, in __call__
    with collapse_excgroups():
         ^^^^^^^^^^^^^^^^^^^^
  File "/Users/aniket/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/responses.py", line 266, in wrap
    await func()
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/responses.py", line 246, in stream_response
    async for chunk in self.body_iterator:
  File "/Users/aniket/Projects/github/LitServe/src/litserve/specs/openai.py", line 500, in streaming_completion
    raise HTTPException(status_code=500)
fastapi.exceptions.HTTPException: 500: Internal Server Error

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/Users/aniket/Projects/github/LitServe/src/litserve/middlewares.py", line 69, in __call__
    await self.app(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/routing.py", line 714, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/routing.py", line 734, in app
    await route.handle(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/aniket/Projects/github/LitServe/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 56, in wrapped_app
    raise RuntimeError("Caught handled exception, but response already started.") from exc
RuntimeError: Caught handled exception, but response already started.

```
</details>

### After

Cleaner error handling

```
^[[AINFO:     127.0.0.1:53912 - "POST /v1/chat/completions HTTP/1.1" 200 OK
2025-07-01 23:26:30,409 - inference-worker[98235] - litserve.loops.streaming_loops - ERROR - streaming_loops.py:116 - LitAPI ran into an error while processing the streaming request uid=fc0dd2a1-0409-477c-a395-8cbed8843b4a.
Please check the error trace for more details.
Traceback (most recent call last):
  File "/Users/aniket/Projects/github/LitServe/src/litserve/loops/streaming_loops.py", line 91, in run_streaming_loop
    for y_enc in y_enc_gen:
                 ^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/src/litserve/specs/openai.py", line 466, in encode_response
    for output in output_generator:
                  ^^^^^^^^^^^^^^^^
  File "/Users/aniket/Projects/github/LitServe/main.py", line 21, in predict
    raise ApiException(status_code=500, detail="test")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ApiException.__init__() got an unexpected keyword argument 'status_code'
2025-07-01 23:26:30,414 - LitServer-0[98269] - litserve.server - ERROR - server.py:869 - Error occurred while streaming outputs from the inference worker. Please check the above traceback.
2025-07-01 23:26:30,415 - LitServer-0[98269] - litserve.specs.openai - ERROR - openai.py:520 - Error in streaming response: b"\x80\x04\x95i\x00\x00\x00\x00\x00\x00\x00\x8c\x08builtins\x94\x8c\tTypeError\x94\x93\x94\x8cHApiException.__init__() got an unexpected keyword argument 'status_code'\x94\x85\x94R\x94."
2025-07-01 23:26:30,416 - LitServer-0[98269] - litserve.specs.openai - ERROR - openai.py:554 - Error in streaming response: 500: Internal Server Error
Traceback (most recent call last):
  File "/Users/aniket/Projects/github/LitServe/src/litserve/specs/openai.py", line 521, in streaming_completion
    raise HTTPException(status_code=500)
fastapi.exceptions.HTTPException: 500: Internal Server Error
```

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
