### PR TITLE
support `mcp` package  less than v1.10.0

### DIFF
--- a/src/litserve/mcp.py
+++ b/src/litserve/mcp.py
@@ -33,6 +33,7 @@ _is_mcp_installed = is_package_installed("fastmcp")
 
 if _is_mcp_installed:
     from fastapi import FastAPI
+
     try:
         from mcp.server.fastmcp.server import _convert_to_content
     except ImportError:


### PR DESCRIPTION
## What does this PR do?

Fixes # (issue).

From https://github.com/modelcontextprotocol/python-sdk/pull/993, this PR removes _convert_to_content from utilities.func_metadata to support older versions of the MCP package (less than v1.10.0). Some checks will be included.
