### PR TITLE
fix: OpenAIEmbeddingSpec setup check for multi endpoint

### DIFF
--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 from fastapi import HTTPException, Request, Response, status
 from fastapi import status as status_code
 from pydantic import BaseModel
+
 from litserve.specs.base import LitSpec
 from litserve.utils import LitAPIStatus
 
@@ -130,20 +131,22 @@ class OpenAIEmbeddingSpec(LitSpec):
 
     def setup(self, server: "LitServer"):
         from litserve import LitAPI
+
         super().setup(server)
 
         lit_api = server.lit_api
 
         if isinstance(lit_api, LitAPI):
             self._check_lit_api(lit_api)
-        if isinstance(lit_api,list):
+        if isinstance(lit_api, list):
             for api in lit_api:
                 self._check_lit_api(api)
 
         print("OpenAI Embedding Spec is ready.")
 
-    def _check_lit_api(self,api: "LitAPI"):
+    def _check_lit_api(self, api: "LitAPI"):
         from litserve import LitAPI
+
         if inspect.isgeneratorfunction(api.predict):
             raise ValueError(
                 "You are using yield in your predict method, which is used for streaming.",
@@ -162,6 +165,7 @@ class OpenAIEmbeddingSpec(LitSpec):
                 "Please consider replacing yield with return in encode_response.\n",
                 EMBEDDING_API_EXAMPLE,
             )
+
     def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> List[str]:
         return request.input
 

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -144,7 +144,7 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         print("OpenAI Embedding Spec is ready.")
 
-    def _check_lit_api(self, api: "LitAPI"):
+    def _check_lit_api(self, api):
         from litserve import LitAPI
 
         if inspect.isgeneratorfunction(api.predict):

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -146,7 +146,8 @@ class OpenAIEmbeddingSpec(LitSpec):
 
     def _check_lit_api(self, api):
         from litserve import LitAPI
-        if isinstance(api.spec,OpenAIEmbeddingSpec):
+
+        if isinstance(api.spec, OpenAIEmbeddingSpec):
             if inspect.isgeneratorfunction(api.predict):
                 raise ValueError(
                     "You are using yield in your predict method, which is used for streaming.",

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -138,7 +138,7 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         if isinstance(lit_api, LitAPI):
             self._check_lit_api(lit_api)
-        if isinstance(lit_api, list):
+        elif isinstance(lit_api, list):
             for api in lit_api:
                 self._check_lit_api(api)
 

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -146,25 +146,25 @@ class OpenAIEmbeddingSpec(LitSpec):
 
     def _check_lit_api(self, api):
         from litserve import LitAPI
+        if isinstance(api.spec,OpenAIEmbeddingSpec):
+            if inspect.isgeneratorfunction(api.predict):
+                raise ValueError(
+                    "You are using yield in your predict method, which is used for streaming.",
+                    "OpenAIEmbeddingSpec doesn't support streaming because producing embeddings ",
+                    "is not a sequential operation.",
+                    "Please consider replacing yield with return in predict.\n",
+                    EMBEDDING_API_EXAMPLE,
+                )
 
-        if inspect.isgeneratorfunction(api.predict):
-            raise ValueError(
-                "You are using yield in your predict method, which is used for streaming.",
-                "OpenAIEmbeddingSpec doesn't support streaming because producing embeddings ",
-                "is not a sequential operation.",
-                "Please consider replacing yield with return in predict.\n",
-                EMBEDDING_API_EXAMPLE,
-            )
-
-        is_encode_response_original = api.encode_response.__code__ is LitAPI.encode_response.__code__
-        if not is_encode_response_original and inspect.isgeneratorfunction(api.encode_response):
-            raise ValueError(
-                "You are using yield in your encode_response method, which is used for streaming.",
-                "OpenAIEmbeddingSpec doesn't support streaming because producing embeddings ",
-                "is not a sequential operation.",
-                "Please consider replacing yield with return in encode_response.\n",
-                EMBEDDING_API_EXAMPLE,
-            )
+            is_encode_response_original = api.encode_response.__code__ is LitAPI.encode_response.__code__
+            if not is_encode_response_original and inspect.isgeneratorfunction(api.encode_response):
+                raise ValueError(
+                    "You are using yield in your encode_response method, which is used for streaming.",
+                    "OpenAIEmbeddingSpec doesn't support streaming because producing embeddings ",
+                    "is not a sequential operation.",
+                    "Please consider replacing yield with return in encode_response.\n",
+                    EMBEDDING_API_EXAMPLE,
+                )
 
     def decode_request(self, request: EmbeddingRequest, context_kwargs: Optional[dict] = None) -> List[str]:
         return request.input

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -17,18 +17,6 @@ class TestEmbedAPI(LitAPI):
         return {"embeddings": output}
 
 
-class TestOpenAPI(LitAPI):
-    def setup(self, device):
-        self.model = None
-
-    async def predict(self, x) -> List[List[float]]:
-        n = len(x) if isinstance(x, list) else 1
-        yield np.random.rand(n, 768).tolist()
-
-    async def encode_response(self, output) -> dict:
-        yield {"embeddings": output}
-
-
 class TestEmbedBatchedAPI(TestEmbedAPI):
     def predict(self, batch) -> List[List[List[float]]]:
         return [np.random.rand(len(x), 768).tolist() for x in batch]

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -16,6 +16,17 @@ class TestEmbedAPI(LitAPI):
     def encode_response(self, output) -> dict:
         return {"embeddings": output}
 
+class TestOpenAPI(LitAPI):
+    def setup(self, device):
+        self.model = None
+
+    async def predict(self, x) -> List[List[float]]:
+        n = len(x) if isinstance(x, list) else 1
+        yield np.random.rand(n, 768).tolist()
+
+    async  def encode_response(self, output) -> dict:
+        yield {"embeddings": output}
+
 
 class TestEmbedBatchedAPI(TestEmbedAPI):
     def predict(self, batch) -> List[List[List[float]]]:

--- a/src/litserve/test_examples/openai_embedding_spec_example.py
+++ b/src/litserve/test_examples/openai_embedding_spec_example.py
@@ -16,6 +16,7 @@ class TestEmbedAPI(LitAPI):
     def encode_response(self, output) -> dict:
         return {"embeddings": output}
 
+
 class TestOpenAPI(LitAPI):
     def setup(self, device):
         self.model = None
@@ -24,7 +25,7 @@ class TestOpenAPI(LitAPI):
         n = len(x) if isinstance(x, list) else 1
         yield np.random.rand(n, 768).tolist()
 
-    async  def encode_response(self, output) -> dict:
+    async def encode_response(self, output) -> dict:
         yield {"embeddings": output}
 
 

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -55,9 +55,7 @@ async def test_openai_embedding_spec_with_single_input(openai_embedding_request_
 
 @pytest.mark.asyncio
 async def test_openai_embedding_spec_with_multi_endpoint(openai_embedding_request_data):
-    spec_openai = OpenAISpec()
-    spec_embedding = OpenAIEmbeddingSpec()
-    server = ls.LitServer([TestOpenAPI(spec=spec_openai, enable_async=True), TestEmbedAPI(spec=spec_embedding)])
+    server = ls.LitServer([TestEmbedAPI(spec=OpenAIEmbeddingSpec(), api_path="/v2/embeddings"), TestEmbedAPI(spec=OpenAIEmbeddingSpec())])
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -26,6 +26,7 @@ from litserve.specs.openai import OpenAISpec
 from litserve.specs.openai_embedding import OpenAIEmbeddingSpec
 from litserve.test_examples.openai_embedding_spec_example import (
     TestEmbedAPI,
+    TestOpenAPI,
     TestEmbedAPIWithMissingEmbeddings,
     TestEmbedAPIWithNonDictOutput,
     TestEmbedAPIWithUsage,
@@ -55,7 +56,7 @@ async def test_openai_embedding_spec_with_single_input(openai_embedding_request_
 async def test_openai_embedding_spec_with_multi_endpoint(openai_embedding_request_data):
     spec_openai = OpenAISpec()
     spec_embedding = OpenAIEmbeddingSpec()
-    server = ls.LitServer([TestEmbedAPI(spec=spec_openai),TestEmbedAPI(spec=spec_embedding)])
+    server = ls.LitServer([TestOpenAPI(spec=spec_openai,enable_async=True),TestEmbedAPI(spec=spec_embedding)])
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -61,7 +61,7 @@ async def test_openai_embedding_spec_with_multi_endpoint(openai_embedding_reques
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
-            resp = await ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10)
+            resp = await ac.post("/v2/embeddings", json=openai_embedding_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
             assert resp.json()["object"] == "list", "Object should be list"
             assert resp.json()["data"][0]["index"] == 0, "Index should be 0"

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -54,7 +54,6 @@ async def test_openai_embedding_spec_with_single_input(openai_embedding_request_
 @pytest.mark.asyncio
 async def test_openai_embedding_spec_with_multi_endpoint(openai_embedding_request_data):
     server = ls.LitServer([
-        TestEmbedAPI(spec=OpenAIEmbeddingSpec(), api_path="/v2/embeddings"),
         TestEmbedAPI(spec=OpenAIEmbeddingSpec()),
     ])
     with wrap_litserve_start(server) as server:

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -26,12 +26,12 @@ from litserve.specs.openai import OpenAISpec
 from litserve.specs.openai_embedding import OpenAIEmbeddingSpec
 from litserve.test_examples.openai_embedding_spec_example import (
     TestEmbedAPI,
-    TestOpenAPI,
     TestEmbedAPIWithMissingEmbeddings,
     TestEmbedAPIWithNonDictOutput,
     TestEmbedAPIWithUsage,
     TestEmbedAPIWithYieldEncodeResponse,
     TestEmbedAPIWithYieldPredict,
+    TestOpenAPI,
 )
 from litserve.utils import wrap_litserve_start
 
@@ -52,11 +52,12 @@ async def test_openai_embedding_spec_with_single_input(openai_embedding_request_
             assert len(resp.json()["data"]) == 1, "Length of data should be 1"
             assert len(resp.json()["data"][0]["embedding"]) == 768, "Embedding length should be 768"
 
+
 @pytest.mark.asyncio
 async def test_openai_embedding_spec_with_multi_endpoint(openai_embedding_request_data):
     spec_openai = OpenAISpec()
     spec_embedding = OpenAIEmbeddingSpec()
-    server = ls.LitServer([TestOpenAPI(spec=spec_openai,enable_async=True),TestEmbedAPI(spec=spec_embedding)])
+    server = ls.LitServer([TestOpenAPI(spec=spec_openai, enable_async=True), TestEmbedAPI(spec=spec_embedding)])
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -31,7 +31,6 @@ from litserve.test_examples.openai_embedding_spec_example import (
     TestEmbedAPIWithUsage,
     TestEmbedAPIWithYieldEncodeResponse,
     TestEmbedAPIWithYieldPredict,
-    TestOpenAPI,
 )
 from litserve.utils import wrap_litserve_start
 

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -22,7 +22,6 @@ from asgi_lifespan import LifespanManager
 from httpx import ASGITransport, AsyncClient
 
 import litserve as ls
-from litserve.specs.openai import OpenAISpec
 from litserve.specs.openai_embedding import OpenAIEmbeddingSpec
 from litserve.test_examples.openai_embedding_spec_example import (
     TestEmbedAPI,
@@ -54,7 +53,10 @@ async def test_openai_embedding_spec_with_single_input(openai_embedding_request_
 
 @pytest.mark.asyncio
 async def test_openai_embedding_spec_with_multi_endpoint(openai_embedding_request_data):
-    server = ls.LitServer([TestEmbedAPI(spec=OpenAIEmbeddingSpec(), api_path="/v2/embeddings"), TestEmbedAPI(spec=OpenAIEmbeddingSpec())])
+    server = ls.LitServer([
+        TestEmbedAPI(spec=OpenAIEmbeddingSpec(), api_path="/v2/embeddings"),
+        TestEmbedAPI(spec=OpenAIEmbeddingSpec()),
+    ])
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -22,6 +22,7 @@ from asgi_lifespan import LifespanManager
 from httpx import ASGITransport, AsyncClient
 
 import litserve as ls
+from litserve.specs.openai import OpenAISpec
 from litserve.specs.openai_embedding import OpenAIEmbeddingSpec
 from litserve.test_examples.openai_embedding_spec_example import (
     TestEmbedAPI,
@@ -39,6 +40,22 @@ async def test_openai_embedding_spec_with_single_input(openai_embedding_request_
     spec = OpenAIEmbeddingSpec()
     server = ls.LitServer(TestEmbedAPI(spec=spec))
 
+    with wrap_litserve_start(server) as server:
+        async with LifespanManager(server.app) as manager, AsyncClient(
+            transport=ASGITransport(app=manager.app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10)
+            assert resp.status_code == 200, "Status code should be 200"
+            assert resp.json()["object"] == "list", "Object should be list"
+            assert resp.json()["data"][0]["index"] == 0, "Index should be 0"
+            assert len(resp.json()["data"]) == 1, "Length of data should be 1"
+            assert len(resp.json()["data"][0]["embedding"]) == 768, "Embedding length should be 768"
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_with_multi_endpoint(openai_embedding_request_data):
+    spec_openai = OpenAISpec()
+    spec_embedding = OpenAIEmbeddingSpec()
+    server = ls.LitServer([TestEmbedAPI(spec=spec_openai),TestEmbedAPI(spec=spec_embedding)])
     with wrap_litserve_start(server) as server:
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -60,7 +60,7 @@ async def test_openai_embedding_spec_with_multi_endpoint(openai_embedding_reques
         async with LifespanManager(server.app) as manager, AsyncClient(
             transport=ASGITransport(app=manager.app), base_url="http://test"
         ) as ac:
-            resp = await ac.post("/v2/embeddings", json=openai_embedding_request_data, timeout=10)
+            resp = await ac.post("/v1/embeddings", json=openai_embedding_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
             assert resp.json()["object"] == "list", "Object should be list"
             assert resp.json()["data"][0]["index"] == 0, "Index should be 0"


### PR DESCRIPTION
## What does this PR do?

Fixes # (issue).

The OpenAIEmbeddingSpec currently only checks if server.lit_api is set to one. However, LitServe now supports multiple Endpoint , so this PR adds the necessary checks for multiple Endpoint.

