### PR TITLE
feat: openapi url

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -476,11 +476,11 @@ class LitServer:
             - Shows model metadata, device info, server config
             - Useful for debugging and monitoring
 
-        openapi_url:
-            OpenAPI specification endpoint provided by FastAPI. Defaults to "/openapi.json".
+        disable_openapi_url:
+            If True, disables the OpenAPI schema endpoint ("/openapi.json").
 
-            - Provides a machine-readable description of the API
-            - To disable it, set this value to an empty string: ""
+            - Useful for production environments where exposing API schemas is not desired.
+            - Defaults to False (the OpenAPI schema is enabled).
 
         shutdown_path:
             Graceful shutdown endpoint. Defaults to "/shutdown".
@@ -645,7 +645,7 @@ class LitServer:
         middlewares: Optional[list[Union[Callable, tuple[Callable, dict]]]] = None,
         loggers: Optional[Union[Logger, List[Logger]]] = None,
         fast_queue: bool = False,
-        openapi_url: str = "/openapi.json",
+        disable_openapi_url: bool = False,
         # All the following arguments are deprecated and will be removed in v0.3.0
         max_batch_size: Optional[int] = None,
         batch_timeout: float = 0.0,
@@ -716,12 +716,6 @@ class LitServer:
                 "info_path must start with '/'. Please provide a valid api path like '/info', '/details', or '/v1/info'"
             )
 
-        if openapi_url != "" and not openapi_url.startswith("/"):
-            raise ValueError(
-                "openapi_url must start with '/'. Please provide a valid api path like '/openapi.json' or '' if you "
-                "want to deactivate it"
-            )
-
         if enable_shutdown_api and not shutdown_path.startswith("/"):
             raise ValueError("shutdown_path must start with '/'. Please provide a valid api path like '/shutdown'")
 
@@ -755,7 +749,7 @@ class LitServer:
         self.track_requests = track_requests
         self.timeout = timeout
         self.litapi_connector.set_request_timeout(timeout)
-        self.app = FastAPI(lifespan=self.lifespan, openapi_url=openapi_url)
+        self.app = FastAPI(lifespan=self.lifespan, openapi_url="" if disable_openapi_url else "/openapi.json")
         self.app.response_queue_id = None
         self.response_buffer = {}
         # gzip does not play nicely with streaming, see https://github.com/tiangolo/fastapi/discussions/8448

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -476,6 +476,12 @@ class LitServer:
             - Shows model metadata, device info, server config
             - Useful for debugging and monitoring
 
+        openapi_url:
+            OpenAPI specification endpoint provided by FastAPI. Defaults to "/openapi.json".
+
+            - Provides a machine-readable description of the API
+            - To disable it, set this value to an empty string: ""
+
         shutdown_path:
             Graceful shutdown endpoint. Defaults to "/shutdown".
 
@@ -639,6 +645,7 @@ class LitServer:
         middlewares: Optional[list[Union[Callable, tuple[Callable, dict]]]] = None,
         loggers: Optional[Union[Logger, List[Logger]]] = None,
         fast_queue: bool = False,
+        openapi_url: str = "/openapi.json",
         # All the following arguments are deprecated and will be removed in v0.3.0
         max_batch_size: Optional[int] = None,
         batch_timeout: float = 0.0,
@@ -709,6 +716,12 @@ class LitServer:
                 "info_path must start with '/'. Please provide a valid api path like '/info', '/details', or '/v1/info'"
             )
 
+        if openapi_url != "" and not openapi_url.startswith("/"):
+            raise ValueError(
+                "openapi_url must start with '/'. Please provide a valid api path like '/openapi.json' or '' if you "
+                "want to deactivate it"
+            )
+
         if enable_shutdown_api and not shutdown_path.startswith("/"):
             raise ValueError("shutdown_path must start with '/'. Please provide a valid api path like '/shutdown'")
 
@@ -742,7 +755,7 @@ class LitServer:
         self.track_requests = track_requests
         self.timeout = timeout
         self.litapi_connector.set_request_timeout(timeout)
-        self.app = FastAPI(lifespan=self.lifespan)
+        self.app = FastAPI(lifespan=self.lifespan, openapi_url=openapi_url)
         self.app.response_queue_id = None
         self.response_buffer = {}
         # gzip does not play nicely with streaming, see https://github.com/tiangolo/fastapi/discussions/8448


### PR DESCRIPTION
## What does this PR do?

*Allow setting `openapi_url` in `LitAPI` constructor*.

This PR adds support for customizing the `openapi_url` when initializing `LitAPI`, by exposing it as an optional argument. This allows users to disable or relocate the OpenAPI schema endpoint (e.g., `/openapi.json`) for better control in production environments.

* [x] Was this discussed/agreed via a Github issue?
* [x] Did you read the [[contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md)](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
* [ ] Did you make sure to update the docs? *(Not needed unless public API docs are affected.)*
* [ ] Did you write any new necessary tests? *(N/A if change is small and non-breaking.)*

---

### ⚠️ How does this PR impact the user?

As a user deploying `LitServe` in production, I want to avoid exposing internal metadata like the OpenAPI schema at the default path. This PR allows me to move or disable `/openapi.json` by simply passing `openapi_url=""` or a custom path to the `LitAPI` constructor — no monkey-patching or router rewrites required.

This makes `LitServe` safer and more flexible for production deployments, especially in security-conscious environments.

---

## PR review

Anyone in the community is welcome to review this PR. The change is small, backward-compatible, and tied to a concrete production use case.

## Did you have fun?

Yes 🙃 — it's always a pleasure contributing to this project!