### PR TITLE
chore: Add warnings for custom API paths in OpenAI Chat and Embed specs

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -365,6 +365,13 @@ class OpenAISpec(LitSpec):
         # Override the spec's api_path only if provided
         if lit_api._api_path and lit_api._api_path != _DEFAULT_LIT_API_PATH:
             self.api_path = lit_api._api_path
+            logger.warning(
+                f"You are using a custom API path: {self.api_path} with OpenAI Spec\n"
+                f"Note: The OpenAI SDK only works with the default path '/v1/chat/completions'.\n"
+                f"To use this custom path, please send HTTP requests directly to "
+                f"'http://your-server:port{self.api_path}' or use a client library that supports custom endpoints.\n"
+                f"If you want to use the OpenAI SDK, keep the default path '/v1/chat/completions'."
+            )
 
         # register the endpoint
         self.add_endpoint(self.api_path, self.chat_completion, ["POST"])

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -366,10 +366,10 @@ class OpenAISpec(LitSpec):
         if lit_api._api_path and lit_api._api_path != _DEFAULT_LIT_API_PATH:
             self.api_path = lit_api._api_path
             logger.warning(
-                f"You are using a custom API path: {self.api_path} with OpenAI Spec\n"
-                f"Note: The OpenAI SDK only works with the default path '/v1/chat/completions'.\n"
+                f"You are using a custom API path: '{self.api_path}' with OpenAI Spec. "
+                f"The OpenAI SDK only works with the default path '/v1/chat/completions'. "
                 f"To use this custom path, please send HTTP requests directly to "
-                f"'http://your-server:port{self.api_path}' or use a client library that supports custom endpoints.\n"
+                f"'http://your-server:port{self.api_path}' or use a client library that supports custom endpoints. "
                 f"If you want to use the OpenAI SDK, keep the default path '/v1/chat/completions'."
             )
 

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -367,12 +367,12 @@ class OpenAISpec(LitSpec):
         if lit_api._api_path and lit_api._api_path not in (_DEFAULT_LIT_API_PATH, self.api_path):
             self.api_path = lit_api._api_path
             warnings.warn(
-                f"You are using a custom API path: '{self.api_path}' with OpenAI Spec. "
-                f"The OpenAI SDK only works with the default path '/v1/chat/completions'. "
-                f"To use this custom path, please send HTTP requests directly to "
-                f"'http://your-server:port{self.api_path}' or use a client library that supports custom endpoints. "
-                f"If you want to use the OpenAI SDK, keep the default path '/v1/chat/completions'."
-            )
+                    f"Custom API path detected: '{self.api_path}'. "
+                    "The OpenAI SDK only supports the default path '/v1/chat/completions'. "
+                    f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints. "
+                    "For SDK compatibility, use the default path."
+                )
+
 
         # register the endpoint
         self.add_endpoint(self.api_path, self.chat_completion, ["POST"])

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -370,7 +370,7 @@ class OpenAISpec(LitSpec):
                 f"Custom API path detected: '{self.api_path}'. "
                 "The OpenAI SDK only supports the default path '/v1/chat/completions'. "
                 f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints."
-                "For SDK compatibility, use the default path."
+                " For SDK compatibility, use the default path."
             )
 
         # register the endpoint

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -367,12 +367,11 @@ class OpenAISpec(LitSpec):
         if lit_api._api_path and lit_api._api_path not in (_DEFAULT_LIT_API_PATH, self.api_path):
             self.api_path = lit_api._api_path
             warnings.warn(
-                    f"Custom API path detected: '{self.api_path}'. "
-                    "The OpenAI SDK only supports the default path '/v1/chat/completions'. "
-                    f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints. "
-                    "For SDK compatibility, use the default path."
-                )
-
+                f"Custom API path detected: '{self.api_path}'. "
+                "The OpenAI SDK only supports the default path '/v1/chat/completions'. "
+                f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints. "
+                "For SDK compatibility, use the default path."
+            )
 
         # register the endpoint
         self.add_endpoint(self.api_path, self.chat_completion, ["POST"])

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -18,6 +18,7 @@ import logging
 import time
 import typing
 import uuid
+import warnings
 from collections import deque
 from enum import Enum
 from typing import Annotated, AsyncGenerator, Dict, Iterator, List, Literal, Optional, Union
@@ -363,9 +364,9 @@ class OpenAISpec(LitSpec):
         from litserve import LitAPI
 
         # Override the spec's api_path only if provided
-        if lit_api._api_path and lit_api._api_path != _DEFAULT_LIT_API_PATH:
+        if lit_api._api_path and lit_api._api_path not in (_DEFAULT_LIT_API_PATH, self.api_path):
             self.api_path = lit_api._api_path
-            logger.warning(
+            warnings.warn(
                 f"You are using a custom API path: '{self.api_path}' with OpenAI Spec. "
                 f"The OpenAI SDK only works with the default path '/v1/chat/completions'. "
                 f"To use this custom path, please send HTTP requests directly to "

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -369,7 +369,7 @@ class OpenAISpec(LitSpec):
             warnings.warn(
                 f"Custom API path detected: '{self.api_path}'. "
                 "The OpenAI SDK only supports the default path '/v1/chat/completions'. "
-                f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints. "
+                f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints."
                 "For SDK compatibility, use the default path."
             )
 

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -17,6 +17,7 @@ import logging
 import sys
 import time
 import uuid
+import warnings
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 
 from fastapi import HTTPException, Request, Response, status
@@ -131,13 +132,13 @@ class OpenAIEmbeddingSpec(LitSpec):
         from litserve import LitAPI
 
         # Override the spec's api_path only if provided
-        if lit_api._api_path and lit_api._api_path != _DEFAULT_LIT_API_PATH:
+        if lit_api._api_path and lit_api._api_path not in (_DEFAULT_LIT_API_PATH, self.api_path):
             self.api_path = lit_api._api_path
-            logger.warning(
-                f"You are using a custom API path: {self.api_path} with OpenAI Embedding Spec\n"
-                f"Note: The OpenAI SDK only works with the default path '/v1/embeddings'.\n"
+            warnings.warn(
+                f"You are using a custom API path: '{self.api_path}' with OpenAI Embedding Spec. "
+                f"The OpenAI SDK only works with the default path '/v1/embeddings'. "
                 f"To use this custom path, please send HTTP requests directly to "
-                f"'http://your-server:port{self.api_path}' or use a client library that supports custom endpoints.\n"
+                f"'http://your-server:port{self.api_path}' or use a client library that supports custom endpoints. "
                 f"If you want to use the OpenAI SDK, keep the default path '/v1/embeddings'."
             )
 

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -137,7 +137,7 @@ class OpenAIEmbeddingSpec(LitSpec):
             warnings.warn(
                 f"Custom API path detected: '{self.api_path}'. "
                 "The OpenAI SDK only supports the default path '/v1/embeddings'. "
-                f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints. "
+                f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints."
                 "For SDK compatibility, use the default path."
             )
 

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -141,7 +141,6 @@ class OpenAIEmbeddingSpec(LitSpec):
                 "For SDK compatibility, use the default path."
             )
 
-
         # register the endpoint
         self.add_endpoint(self.api_path, self.embeddings_endpoint, ["POST"])
         self.add_endpoint(self.api_path, self.options_embeddings, ["GET"])

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -135,12 +135,12 @@ class OpenAIEmbeddingSpec(LitSpec):
         if lit_api._api_path and lit_api._api_path not in (_DEFAULT_LIT_API_PATH, self.api_path):
             self.api_path = lit_api._api_path
             warnings.warn(
-                f"You are using a custom API path: '{self.api_path}' with OpenAI Embedding Spec. "
-                f"The OpenAI SDK only works with the default path '/v1/embeddings'. "
-                f"To use this custom path, please send HTTP requests directly to "
-                f"'http://your-server:port{self.api_path}' or use a client library that supports custom endpoints. "
-                f"If you want to use the OpenAI SDK, keep the default path '/v1/embeddings'."
+                f"Custom API path detected: '{self.api_path}'. "
+                "The OpenAI SDK only supports the default path '/v1/embeddings'. "
+                f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints. "
+                "For SDK compatibility, use the default path."
             )
+
 
         # register the endpoint
         self.add_endpoint(self.api_path, self.embeddings_endpoint, ["POST"])

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -133,6 +133,13 @@ class OpenAIEmbeddingSpec(LitSpec):
         # Override the spec's api_path only if provided
         if lit_api._api_path and lit_api._api_path != _DEFAULT_LIT_API_PATH:
             self.api_path = lit_api._api_path
+            logger.warning(
+                f"You are using a custom API path: {self.api_path} with OpenAI Embedding Spec\n"
+                f"Note: The OpenAI SDK only works with the default path '/v1/embeddings'.\n"
+                f"To use this custom path, please send HTTP requests directly to "
+                f"'http://your-server:port{self.api_path}' or use a client library that supports custom endpoints.\n"
+                f"If you want to use the OpenAI SDK, keep the default path '/v1/embeddings'."
+            )
 
         # register the endpoint
         self.add_endpoint(self.api_path, self.embeddings_endpoint, ["POST"])

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -138,7 +138,7 @@ class OpenAIEmbeddingSpec(LitSpec):
                 f"Custom API path detected: '{self.api_path}'. "
                 "The OpenAI SDK only supports the default path '/v1/embeddings'. "
                 f"To use '{self.api_path}', send HTTP requests directly or use a client that supports custom endpoints."
-                "For SDK compatibility, use the default path."
+                " For SDK compatibility, use the default path."
             )
 
         # register the endpoint

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -71,7 +71,7 @@ async def test_openai_embedding_spec_with_custom_api_path(openai_embedding_reque
 
 @pytest.mark.asyncio
 async def test_openai_embedding_spec_custom_api_path_warning():
-    with pytest.warns(UserWarning, match="You are using a custom API path: "):
+    with pytest.warns(UserWarning, match="Custom API path detected"):
         ls.LitServer(TestEmbedAPI(spec=OpenAIEmbeddingSpec(), api_path="/v2/embeddings"))
 
 

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -70,6 +70,12 @@ async def test_openai_embedding_spec_with_custom_api_path(openai_embedding_reque
 
 
 @pytest.mark.asyncio
+async def test_openai_embedding_spec_custom_api_path_warning():
+    with pytest.warns(UserWarning, match="You are using a custom API path: "):
+        ls.LitServer(TestEmbedAPI(spec=OpenAIEmbeddingSpec(), api_path="/v2/embeddings"))
+
+
+@pytest.mark.asyncio
 async def test_openai_embedding_spec_with_multiple_inputs(openai_embedding_request_data_array):
     spec = OpenAIEmbeddingSpec()
     server = ls.LitServer(TestEmbedAPI(spec=spec))

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -486,6 +486,5 @@ async def test_openai_spec_with_custom_api_path(api_path, openai_request_data):
 
 @pytest.mark.asyncio
 async def test_openai_spec_custom_api_path_warning():
-    """Test that a warning is logged when using a custom API path with OpenAISpec."""
     with pytest.warns(UserWarning, match="You are using a custom API path: "):
         ls.LitServer(TestAPI(spec=OpenAISpec(), api_path="/v2/chat/completions"))

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -482,3 +482,10 @@ async def test_openai_spec_with_custom_api_path(api_path, openai_request_data):
             resp = await ac.post(api_path, json=openai_request_data, timeout=10)
             assert resp.status_code == 200, "Status code should be 200"
             assert resp.json()["choices"][0]["message"]["content"] == "This is a generated output"
+
+
+@pytest.mark.asyncio
+async def test_openai_spec_custom_api_path_warning():
+    """Test that a warning is logged when using a custom API path with OpenAISpec."""
+    with pytest.warns(UserWarning, match="You are using a custom API path: "):
+        ls.LitServer(TestAPI(spec=OpenAISpec(), api_path="/v2/chat/completions"))

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -486,5 +486,5 @@ async def test_openai_spec_with_custom_api_path(api_path, openai_request_data):
 
 @pytest.mark.asyncio
 async def test_openai_spec_custom_api_path_warning():
-    with pytest.warns(UserWarning, match="You are using a custom API path: "):
+    with pytest.warns(UserWarning, match="Custom API path detected"):
         ls.LitServer(TestAPI(spec=OpenAISpec(), api_path="/v2/chat/completions"))


### PR DESCRIPTION
## What does this PR do ?

Introduce warnings when using custom API paths with OpenAI specifications to inform users about the limitations and provide guidance on using the default paths. Include tests to verify the warning behavior.

Follow up to: #577