### PR TITLE
pytest surface thread exceptions as error [wip]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ addopts = [
 ]
 filterwarnings = [
     "error::FutureWarning",
+    "error::pytest.PytestUnhandledThreadExceptionWarning",
 ]
 xfail_strict = true
 junit_duration_report = "call"

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,6 @@ markers =
 addopts = --strict-markers --color=yes --disable-pytest-warnings
 filterwarnings =
     error::FutureWarning
+    error::pytest.PytestUnhandledThreadExceptionWarning
 xfail_strict = true
 junit_duration_report = call

--- a/src/litserve/loops/simple_loops.py
+++ b/src/litserve/loops/simple_loops.py
@@ -48,6 +48,10 @@ class SingleLoop(DefaultLoop):
                 response_queue_id, uid, timestamp, x_enc = request_data
             except (Empty, ValueError):
                 continue
+            except EOFError:
+                # Manager/connection closed: treat as shutdown
+                logger.debug("Request queue closed (EOF). Exiting worker loop.")
+                break
             except KeyboardInterrupt:  # pragma: no cover
                 self.kill()
                 return

--- a/src/litserve/transport/zmq_queue.py
+++ b/src/litserve/transport/zmq_queue.py
@@ -58,6 +58,7 @@ class Broker:
     def _run(self):
         """Main broker loop."""
         context = zmq.Context()
+        frontend, backend = None, None
         try:
             frontend = context.socket(zmq.XPUB)
             frontend.bind(self.frontend_address)
@@ -69,8 +70,10 @@ class Broker:
         except zmq.ZMQError as e:
             logger.error(f"Broker error: {e}")
         finally:
-            frontend.close(linger=0)
-            backend.close(linger=0)
+            if frontend:
+                frontend.close(linger=0)
+            if backend:
+                backend.close(linger=0)
             context.term()
 
     def stop(self):

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import atexit
 import json
 import sys
 import time
@@ -31,6 +32,27 @@ from litserve import LitAPI
 from litserve.connector import _Connector
 from litserve.server import LitServer
 from litserve.utils import wrap_litserve_start
+
+# Add cleanup tracking
+_active_processes = []
+
+
+def cleanup_processes():
+    """Cleanup function to terminate any remaining processes."""
+    for process in _active_processes:
+        try:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=2)
+                if process.is_alive():
+                    process.kill()
+        except Exception:
+            pass
+    _active_processes.clear()
+
+
+# Register cleanup on exit
+atexit.register(cleanup_processes)
 
 
 def test_index(sync_testclient):

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -16,6 +16,7 @@ import atexit
 import json
 import sys
 import time
+from contextlib import suppress
 from time import sleep
 from unittest.mock import MagicMock, patch
 
@@ -40,14 +41,13 @@ _active_processes = []
 def cleanup_processes():
     """Cleanup function to terminate any remaining processes."""
     for process in _active_processes:
-        try:
+        with suppress(Exception):
+            if not process.is_alive():
+                continue
+            process.terminate()
+            process.join(timeout=2)
             if process.is_alive():
-                process.terminate()
-                process.join(timeout=2)
-                if process.is_alive():
-                    process.kill()
-        except Exception:
-            pass
+                process.kill()
     _active_processes.clear()
 
 


### PR DESCRIPTION
## What does this PR do?

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

Some tests pass, but the logs suggest it shall not, since there are some exceptions...
So, trying to fix the test to correctly fail in these cases :)
```
  /home/runner/work/LitServe/LitServe/.venv/lib/python3.11/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-67 (run_single_loop)
  
  Traceback (most recent call last):
    File "/home/runner/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
      self.run()
    File "/home/runner/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/threading.py", line 982, in run
      self._target(*self._args, **self._kwargs)
    File "/home/runner/work/LitServe/LitServe/src/litserve/loops/simple_loops.py", line 54, in run_single_loop
      time.monotonic() - timestamp > lit_api.request_timeout
      ~~~~~~~~~~~~~~~~~^~~~~~~~~~~
  TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
  
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
