### PR TITLE
feat(litserve): Add support for loading TLS certificates for the user

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -57,7 +57,7 @@ from litserve.utils import (
     call_after_stream,
     configure_logging,
     is_package_installed,
-    load_ssl_context_from_env,
+    add_ssl_context_from_env,
 )
 
 _MCP_AVAILABLE = is_package_installed("mcp")
@@ -1295,13 +1295,14 @@ class LitServer:
         if host not in ["0.0.0.0", "127.0.0.1", "::"]:
             raise ValueError(host_msg)
 
+        kwargs = add_ssl_context_from_env(kwargs)
+
         configure_logging(log_level, use_rich=pretty_logs)
         config = uvicorn.Config(
             app=self.app,
             host=host,
             port=port,
             log_level=log_level,
-            **load_ssl_context_from_env(),
             **kwargs,
         )
         sockets = [config.bind_socket()]

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -54,10 +54,10 @@ from litserve.utils import (
     LitAPIStatus,
     LoopResponseType,
     WorkerSetupStatus,
-    _load_ssl_context,
     call_after_stream,
     configure_logging,
     is_package_installed,
+    load_ssl_context_from_env,
 )
 
 _MCP_AVAILABLE = is_package_installed("mcp")
@@ -1301,7 +1301,7 @@ class LitServer:
             host=host,
             port=port,
             log_level=log_level,
-            **_load_ssl_context(),
+            **load_ssl_context_from_env(),
             **kwargs,
         )
         sockets = [config.bind_socket()]

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -54,10 +54,10 @@ from litserve.utils import (
     LitAPIStatus,
     LoopResponseType,
     WorkerSetupStatus,
+    add_ssl_context_from_env,
     call_after_stream,
     configure_logging,
     is_package_installed,
-    add_ssl_context_from_env,
 )
 
 _MCP_AVAILABLE = is_package_installed("mcp")

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -57,6 +57,7 @@ from litserve.utils import (
     call_after_stream,
     configure_logging,
     is_package_installed,
+    _load_ssl_context,
 )
 
 _MCP_AVAILABLE = is_package_installed("mcp")
@@ -1295,7 +1296,14 @@ class LitServer:
             raise ValueError(host_msg)
 
         configure_logging(log_level, use_rich=pretty_logs)
-        config = uvicorn.Config(app=self.app, host=host, port=port, log_level=log_level, **kwargs)
+        config = uvicorn.Config(
+            app=self.app, 
+            host=host, 
+            port=port, 
+            log_level=log_level, 
+            **_load_ssl_context(), 
+            **kwargs,
+        )
         sockets = [config.bind_socket()]
 
         if num_api_servers is None:

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -54,10 +54,10 @@ from litserve.utils import (
     LitAPIStatus,
     LoopResponseType,
     WorkerSetupStatus,
+    _load_ssl_context,
     call_after_stream,
     configure_logging,
     is_package_installed,
-    _load_ssl_context,
 )
 
 _MCP_AVAILABLE = is_package_installed("mcp")
@@ -1297,11 +1297,11 @@ class LitServer:
 
         configure_logging(log_level, use_rich=pretty_logs)
         config = uvicorn.Config(
-            app=self.app, 
-            host=host, 
-            port=port, 
-            log_level=log_level, 
-            **_load_ssl_context(), 
+            app=self.app,
+            host=host,
+            port=port,
+            log_level=log_level,
+            **_load_ssl_context(),
             **kwargs,
         )
         sockets = [config.bind_socket()]

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -284,7 +284,7 @@ class _TimedInitMeta(ABCMeta):
         return instance
 
 
-def load_ssl_context_from_env() -> Dict[str, Any]:
+def add_ssl_context_from_env(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """Loads SSL context from base64-encoded environment variables.
 
     This function checks for the presence of `LIGHTNING_CERT_PEM` and
@@ -311,6 +311,9 @@ def load_ssl_context_from_env() -> Dict[str, Any]:
 
     """
 
+    if "ssl_keyfile" in kwargs and "ssl_certfile" in kwargs:
+        return kwargs
+
     cert_pem_b64 = os.getenv("LIGHTNING_CERT_PEM", "")
     cert_key_b64 = os.getenv("LIGHTNING_KEY_FILE", "")
 
@@ -329,7 +332,7 @@ def load_ssl_context_from_env() -> Dict[str, Any]:
             key_file.flush()
 
             # Return a dictionary with Path objects to the created files
-            return {"ssl_keyfile": Path(key_file.name), "ssl_certfile": Path(cert_file.name)}
+            return {"ssl_keyfile": Path(key_file.name), "ssl_certfile": Path(cert_file.name), **kwargs}
 
     # Return an empty dictionary if env vars are not set
-    return {}
+    return kwargs

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -333,5 +333,7 @@ def add_ssl_context_from_env(kwargs: Dict[str, Any]) -> Dict[str, Any]:
         key_file.write(cert_key)
         key_file.flush()
 
+        logger.info("Loading TLS Certificates \n")
+
         # Return a dictionary with Path objects to the created files
         return {"ssl_keyfile": Path(key_file.name), "ssl_certfile": Path(cert_file.name), **kwargs}

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import base64
 import dataclasses
 import importlib.util
 import logging
@@ -19,16 +20,15 @@ import os
 import pdb
 import pickle
 import sys
+import tempfile
 import time
 import uuid
 import warnings
 from abc import ABCMeta
 from contextlib import contextmanager
 from enum import Enum
-from typing import TYPE_CHECKING, Any, AsyncIterator, TextIO, Union, Dict
-import tempfile
 from pathlib import Path
-import base64
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, TextIO, Union
 
 from fastapi import HTTPException
 
@@ -290,13 +290,13 @@ def _load_ssl_context() -> Dict[str, Any]:
 
     if cert_pem_b64 and cert_key_b64:
         # Decode the base64 strings to get the actual PEM content
-        cert_pem = base64.b64decode(cert_pem_b64).decode('utf-8')
-        cert_key = base64.b64decode(cert_key_b64).decode('utf-8')
+        cert_pem = base64.b64decode(cert_pem_b64).decode("utf-8")
+        cert_key = base64.b64decode(cert_key_b64).decode("utf-8")
 
         # Write to temporary files
-        with tempfile.NamedTemporaryFile(mode='w+', delete=False) as cert_file, \
-                tempfile.NamedTemporaryFile(mode='w+', delete=False) as key_file:
-
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as cert_file, tempfile.NamedTemporaryFile(
+            mode="w+", delete=False
+        ) as key_file:
             cert_file.write(cert_pem)
             cert_file.flush()
             key_file.write(cert_key)

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -317,22 +317,21 @@ def add_ssl_context_from_env(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     cert_pem_b64 = os.getenv("LIGHTNING_CERT_PEM", "")
     cert_key_b64 = os.getenv("LIGHTNING_KEY_FILE", "")
 
-    if cert_pem_b64 and cert_key_b64:
-        # Decode the base64 strings to get the actual PEM content
-        cert_pem = base64.b64decode(cert_pem_b64).decode("utf-8")
-        cert_key = base64.b64decode(cert_key_b64).decode("utf-8")
+    if cert_pem_b64 == "" or cert_key_b64 == "":
+        return kwargs
 
-        # Write to temporary files
-        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as cert_file, tempfile.NamedTemporaryFile(
-            mode="w+", delete=False
-        ) as key_file:
-            cert_file.write(cert_pem)
-            cert_file.flush()
-            key_file.write(cert_key)
-            key_file.flush()
+    # Decode the base64 strings to get the actual PEM content
+    cert_pem = base64.b64decode(cert_pem_b64).decode("utf-8")
+    cert_key = base64.b64decode(cert_key_b64).decode("utf-8")
 
-            # Return a dictionary with Path objects to the created files
-            return {"ssl_keyfile": Path(key_file.name), "ssl_certfile": Path(cert_file.name), **kwargs}
+    # Write to temporary files
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as cert_file, tempfile.NamedTemporaryFile(
+        mode="w+", delete=False
+    ) as key_file:
+        cert_file.write(cert_pem)
+        cert_file.flush()
+        key_file.write(cert_key)
+        key_file.flush()
 
-    # Return an empty dictionary if env vars are not set
-    return kwargs
+        # Return a dictionary with Path objects to the created files
+        return {"ssl_keyfile": Path(key_file.name), "ssl_certfile": Path(cert_file.name), **kwargs}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,12 +11,12 @@ import pytest
 from fastapi import HTTPException
 
 from litserve.utils import (
+    add_ssl_context_from_env,
     call_after_stream,
     configure_logging,
     dump_exception,
     generate_random_zmq_address,
     is_package_installed,
-    add_ssl_context_from_env,
     set_trace_if_debug,
 )
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,12 +11,12 @@ import pytest
 from fastapi import HTTPException
 
 from litserve.utils import (
-    _load_ssl_context,
     call_after_stream,
     configure_logging,
     dump_exception,
     generate_random_zmq_address,
     is_package_installed,
+    load_ssl_context_from_env,
     set_trace_if_debug,
 )
 
@@ -96,7 +96,7 @@ def test_is_package_installed():
     assert not is_package_installed("nonexistent_package")
 
 
-def test_load_ssl_context_with_env_vars():
+def testload_ssl_context_from_env_with_env_vars():
     """Tests that the SSL context is loaded correctly when environment variables are set."""
     dummy_cert = "dummy certificate"
     dummy_key = "dummy key"
@@ -105,7 +105,7 @@ def test_load_ssl_context_with_env_vars():
     b64_key = base64.b64encode(dummy_key.encode("utf-8")).decode("utf-8")
 
     with mock.patch.dict(os.environ, {"LIGHTNING_CERT_PEM": b64_cert, "LIGHTNING_KEY_FILE": b64_key}):
-        ssl_context = _load_ssl_context()
+        ssl_context = load_ssl_context_from_env()
 
         assert ssl_context
 
@@ -123,18 +123,18 @@ def test_load_ssl_context_with_env_vars():
         os.remove(ssl_context["ssl_keyfile"])
 
 
-def test_load_ssl_context_without_env_vars():
+def testload_ssl_context_from_env_without_env_vars():
     """Tests that an empty dictionary is returned when environment variables are not set."""
     with mock.patch.dict(os.environ, {}, clear=True):
-        ssl_context = _load_ssl_context()
+        ssl_context = load_ssl_context_from_env()
         assert ssl_context == {}
 
 
-def test_load_ssl_context_with_one_env_var_missing():
+def testload_ssl_context_from_env_with_one_env_var_missing():
     """Tests that an empty dictionary is returned when one of the environment variables is missing."""
     dummy_cert = "dummy certificate"
     b64_cert = base64.b64encode(dummy_cert.encode("utf-8")).decode("utf-8")
 
     with mock.patch.dict(os.environ, {"LIGHTNING_CERT_PEM": b64_cert}, clear=True):
-        ssl_context = _load_ssl_context()
+        ssl_context = load_ssl_context_from_env()
         assert ssl_context == {}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,23 +1,23 @@
+import base64
 import logging
 import os
 import pickle
 import sys
+from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
-import base64
-from pathlib import Path
 
 from litserve.utils import (
+    _load_ssl_context,
     call_after_stream,
     configure_logging,
     dump_exception,
     generate_random_zmq_address,
     is_package_installed,
     set_trace_if_debug,
-    _load_ssl_context,
 )
 
 
@@ -97,14 +97,12 @@ def test_is_package_installed():
 
 
 def test_load_ssl_context_with_env_vars():
-    """
-    Tests that the SSL context is loaded correctly when environment variables are set.
-    """
+    """Tests that the SSL context is loaded correctly when environment variables are set."""
     dummy_cert = "dummy certificate"
     dummy_key = "dummy key"
 
-    b64_cert = base64.b64encode(dummy_cert.encode('utf-8')).decode('utf-8')
-    b64_key = base64.b64encode(dummy_key.encode('utf-8')).decode('utf-8')
+    b64_cert = base64.b64encode(dummy_cert.encode("utf-8")).decode("utf-8")
+    b64_key = base64.b64encode(dummy_key.encode("utf-8")).decode("utf-8")
 
     with mock.patch.dict(os.environ, {"LIGHTNING_CERT_PEM": b64_cert, "LIGHTNING_KEY_FILE": b64_key}):
         ssl_context = _load_ssl_context()
@@ -124,20 +122,18 @@ def test_load_ssl_context_with_env_vars():
         os.remove(ssl_context["ssl_certfile"])
         os.remove(ssl_context["ssl_keyfile"])
 
+
 def test_load_ssl_context_without_env_vars():
-    """
-    Tests that an empty dictionary is returned when environment variables are not set.
-    """
+    """Tests that an empty dictionary is returned when environment variables are not set."""
     with mock.patch.dict(os.environ, {}, clear=True):
         ssl_context = _load_ssl_context()
         assert ssl_context == {}
 
+
 def test_load_ssl_context_with_one_env_var_missing():
-    """
-    Tests that an empty dictionary is returned when one of the environment variables is missing.
-    """
+    """Tests that an empty dictionary is returned when one of the environment variables is missing."""
     dummy_cert = "dummy certificate"
-    b64_cert = base64.b64encode(dummy_cert.encode('utf-8')).decode('utf-8')
+    b64_cert = base64.b64encode(dummy_cert.encode("utf-8")).decode("utf-8")
 
     with mock.patch.dict(os.environ, {"LIGHTNING_CERT_PEM": b64_cert}, clear=True):
         ssl_context = _load_ssl_context()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,7 +16,7 @@ from litserve.utils import (
     dump_exception,
     generate_random_zmq_address,
     is_package_installed,
-    load_ssl_context_from_env,
+    add_ssl_context_from_env,
     set_trace_if_debug,
 )
 
@@ -96,7 +96,7 @@ def test_is_package_installed():
     assert not is_package_installed("nonexistent_package")
 
 
-def testload_ssl_context_from_env_with_env_vars():
+def test_add_ssl_context_from_env_with_env_vars():
     """Tests that the SSL context is loaded correctly when environment variables are set."""
     dummy_cert = "dummy certificate"
     dummy_key = "dummy key"
@@ -105,7 +105,7 @@ def testload_ssl_context_from_env_with_env_vars():
     b64_key = base64.b64encode(dummy_key.encode("utf-8")).decode("utf-8")
 
     with mock.patch.dict(os.environ, {"LIGHTNING_CERT_PEM": b64_cert, "LIGHTNING_KEY_FILE": b64_key}):
-        ssl_context = load_ssl_context_from_env()
+        ssl_context = add_ssl_context_from_env()
 
         assert ssl_context
 
@@ -123,18 +123,18 @@ def testload_ssl_context_from_env_with_env_vars():
         os.remove(ssl_context["ssl_keyfile"])
 
 
-def testload_ssl_context_from_env_without_env_vars():
+def test_add_ssl_context_from_env_without_env_vars():
     """Tests that an empty dictionary is returned when environment variables are not set."""
     with mock.patch.dict(os.environ, {}, clear=True):
-        ssl_context = load_ssl_context_from_env()
+        ssl_context = add_ssl_context_from_env()
         assert ssl_context == {}
 
 
-def testload_ssl_context_from_env_with_one_env_var_missing():
+def test_add_ssl_context_from_env_with_one_env_var_missing():
     """Tests that an empty dictionary is returned when one of the environment variables is missing."""
     dummy_cert = "dummy certificate"
     b64_cert = base64.b64encode(dummy_cert.encode("utf-8")).decode("utf-8")
 
     with mock.patch.dict(os.environ, {"LIGHTNING_CERT_PEM": b64_cert}, clear=True):
-        ssl_context = load_ssl_context_from_env()
+        ssl_context = add_ssl_context_from_env()
         assert ssl_context == {}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -105,7 +105,7 @@ def test_add_ssl_context_from_env_with_env_vars():
     b64_key = base64.b64encode(dummy_key.encode("utf-8")).decode("utf-8")
 
     with mock.patch.dict(os.environ, {"LIGHTNING_CERT_PEM": b64_cert, "LIGHTNING_KEY_FILE": b64_key}):
-        ssl_context = add_ssl_context_from_env()
+        ssl_context = add_ssl_context_from_env({})
 
         assert ssl_context
 
@@ -126,7 +126,7 @@ def test_add_ssl_context_from_env_with_env_vars():
 def test_add_ssl_context_from_env_without_env_vars():
     """Tests that an empty dictionary is returned when environment variables are not set."""
     with mock.patch.dict(os.environ, {}, clear=True):
-        ssl_context = add_ssl_context_from_env()
+        ssl_context = add_ssl_context_from_env({})
         assert ssl_context == {}
 
 
@@ -136,5 +136,5 @@ def test_add_ssl_context_from_env_with_one_env_var_missing():
     b64_cert = base64.b64encode(dummy_cert.encode("utf-8")).decode("utf-8")
 
     with mock.patch.dict(os.environ, {"LIGHTNING_CERT_PEM": b64_cert}, clear=True):
-        ssl_context = add_ssl_context_from_env()
+        ssl_context = add_ssl_context_from_env({})
         assert ssl_context == {}


### PR DESCRIPTION
## What does this PR do?

This PR adds support for automatically loading TLS certificates within deployment if they are provided.

Demo:

<img width="997" height="602" alt="Screenshot 2025-07-28 at 17 44 43" src="https://github.com/user-attachments/assets/44af6030-6792-4e0d-97ba-1330343c452c" />

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
