### PR TITLE
Fix duplicate/multiple middleware initialization

### DIFF
--- a/tests/unit/test_middlewares.py
+++ b/tests/unit/test_middlewares.py
@@ -75,3 +75,13 @@ def test_middlewares_inputs():
 
     with pytest.raises(ValueError, match="middlewares must be a list of tuples"):
         ls.LitServer(ls.test_examples.SimpleLitAPI(), middlewares=(RequestIdMiddleware, {"length": 5}))
+
+
+def test_middleware_multiple_initialization():
+    api1 = ls.test_examples.SimpleLitAPI(api_path="/api1")
+    api2 = ls.test_examples.SimpleLitAPI(api_path="/api2")
+    api3 = ls.test_examples.SimpleLitAPI(api_path="/api3")
+    api4 = ls.test_examples.SimpleLitAPI(api_path="/api4")
+
+    server = ls.LitServer([api1, api2, api3, api4])
+    assert len(server.app.user_middleware) == 1, "Default/User middleware should be initialized only once"


### PR DESCRIPTION
## What does this PR do?

Fixes #599



<details>
  <summary><b>Fix middlewares duplicate/multiple initialization in LitServe initialization when multiple `LitAPI` instances were provided</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

As a user, I want to ensure that middleware initialization in `LitServe` is done only once for any number of `LitAPI`. This PR fix the bug where default middleware were added multiple times when initializing `LitServe`

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
