### PR TITLE
fix: MCP tools/call fails with missing 'request' positional argument

### DIFF
--- a/src/litserve/mcp.py
+++ b/src/litserve/mcp.py
@@ -247,9 +247,47 @@ def _param_name_to_title(param_name: str) -> str:
 
 async def _call_handler(handler, **kwargs):
     sig = inspect.signature(handler)
+    params = list(sig.parameters.values())
+
+    # FastAPI endpoint handlers typically have a single parameter (the request model).
+    # MCP arguments may either:
+    #   1. Match the parameter name (e.g. {"request": {...}}) – pass-through after
+    #      constructing the BaseModel if needed.
+    #   2. Represent the *fields* of the request model directly (e.g. {"name": "…",
+    #      "age": 30}) – we must wrap them into the model before calling the handler.
+    if len(params) == 1:
+        param = params[0]
+        annotation = param.annotation
+        is_model = (
+            annotation is not inspect.Parameter.empty
+            and isinstance(annotation, type)
+            and issubclass(annotation, BaseModel)
+        )
+
+        if param.name in kwargs:
+            # Case 1: arguments already keyed by the parameter name
+            value = kwargs[param.name]
+            if is_model and isinstance(value, dict):
+                value = annotation(**value)
+            return _convert_to_content(await handler(value))
+
+        if is_model:
+            # Case 2: arguments are the model fields themselves
+            return _convert_to_content(await handler(annotation(**kwargs)))
+
+    # Fallback: multiple parameters – bind each kwarg to matching params,
+    # constructing BaseModel instances from dicts where appropriate.
     bound = sig.bind_partial(
         **{
-            k: (v if not issubclass(p.annotation, BaseModel) else p.annotation(**v))
+            k: (
+                v
+                if not (
+                    p.annotation is not inspect.Parameter.empty
+                    and isinstance(p.annotation, type)
+                    and issubclass(p.annotation, BaseModel)
+                )
+                else p.annotation(**v)
+            )
             for k, v in kwargs.items()
             for name, p in sig.parameters.items()
             if k == name

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 from typing import Optional
 from unittest.mock import patch
@@ -11,6 +12,7 @@ import litserve as ls
 from litserve.mcp import (
     MCP,
     _LitMCPServerConnector,
+    _call_handler,
     _param_name_to_title,
     _python_type_to_json_schema,
     extract_input_schema,
@@ -271,3 +273,28 @@ def test_mcp_litserve_connector():
     connector.connect_mcp_server([tool], app)
     mcp_mount = list(filter(lambda route: route.name == "mcp", app.routes))[0]
     assert isinstance(mcp_mount.app, Starlette)
+
+
+def test_call_handler_with_flat_mcp_arguments():
+    """Test that _call_handler correctly wraps flat MCP arguments into the request model.
+
+    Reproduces the bug from issue #560 where MCP tools/call fails with
+    'endpoint_handler() missing 1 required positional argument: request'
+    because MCP arguments (the model fields) don't match the handler's
+    parameter name.
+    """
+
+    async def endpoint_handler(request: MCPTestModel):
+        return {"name": request.name, "age": request.age}
+
+    # MCP sends model fields directly (flat arguments), not wrapped under "request"
+    result = asyncio.get_event_loop().run_until_complete(
+        _call_handler(endpoint_handler, name="Alice", age=30)
+    )
+    assert any("Alice" in c.text for c in result)
+
+    # Also verify it works when arguments ARE keyed by the parameter name
+    result = asyncio.get_event_loop().run_until_complete(
+        _call_handler(endpoint_handler, request={"name": "Bob", "age": 25})
+    )
+    assert any("Bob" in c.text for c in result)

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -11,8 +11,8 @@ from starlette.applications import Starlette
 import litserve as ls
 from litserve.mcp import (
     MCP,
-    _LitMCPServerConnector,
     _call_handler,
+    _LitMCPServerConnector,
     _param_name_to_title,
     _python_type_to_json_schema,
     extract_input_schema,
@@ -278,19 +278,16 @@ def test_mcp_litserve_connector():
 def test_call_handler_with_flat_mcp_arguments():
     """Test that _call_handler correctly wraps flat MCP arguments into the request model.
 
-    Reproduces the bug from issue #560 where MCP tools/call fails with
-    'endpoint_handler() missing 1 required positional argument: request'
-    because MCP arguments (the model fields) don't match the handler's
-    parameter name.
+    Reproduces the bug from issue #560 where MCP tools/call fails with 'endpoint_handler() missing 1 required positional
+    argument: request' because MCP arguments (the model fields) don't match the handler's parameter name.
+
     """
 
     async def endpoint_handler(request: MCPTestModel):
         return {"name": request.name, "age": request.age}
 
     # MCP sends model fields directly (flat arguments), not wrapped under "request"
-    result = asyncio.get_event_loop().run_until_complete(
-        _call_handler(endpoint_handler, name="Alice", age=30)
-    )
+    result = asyncio.get_event_loop().run_until_complete(_call_handler(endpoint_handler, name="Alice", age=30))
     assert any("Alice" in c.text for c in result)
 
     # Also verify it works when arguments ARE keyed by the parameter name


### PR DESCRIPTION
## Summary

Fixes #560

- `_call_handler` assumed MCP arguments would be keyed by the endpoint handler's parameter name (e.g. `request`), but MCP clients send the model's fields directly as flat keyword arguments. When no key matches the parameter name, `bind_partial` produces empty bindings and the call raises `endpoint_handler() missing 1 required positional argument: 'request'`.
- Fix: detect single-parameter handlers whose parameter is a `BaseModel` subclass and construct the model instance from the flat MCP arguments. Also handles the case where arguments are already wrapped under the parameter name.
- Added test `test_call_handler_with_flat_mcp_arguments` covering both flat and wrapped argument styles.

## Test plan

- [x] All 15 existing + new MCP unit tests pass (`tests/unit/test_mcp.py`)
- [x] New test verifies both flat args (`name="Alice", age=30`) and wrapped args (`request={"name": "Bob", "age": 25}`) resolve correctly