### PR TITLE
fix: improve request type handling for unannotated endpoints in Swagger

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -32,7 +32,7 @@ from collections import deque
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from queue import Queue
-from typing import TYPE_CHECKING, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import uvicorn
 import uvicorn.server
@@ -296,6 +296,9 @@ class BaseRequestHandler(ABC):
 
     async def _prepare_request(self, request, request_type) -> dict:
         """Common request preparation logic."""
+        # FastAPI parses JSON body to dict when endpoint uses dict type annotation
+        if isinstance(request, dict):
+            return request
         if request_type == Request:
             content_type = request.headers.get("Content-Type", "")
             if content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):
@@ -1084,18 +1087,21 @@ class LitServer:
             encode_response_signature = inspect.signature(lit_api.encode_response)
 
             request_type = decode_request_signature.parameters["request"].annotation
-            if request_type == decode_request_signature.empty:
+            # Distinguish missing annotation from explicit `Request` annotation.
+            # Missing: use dict[str, Any] for Swagger. Explicit: keep Request for form/file uploads.
+            request_type_is_default = request_type == decode_request_signature.empty
+            if request_type_is_default:
                 request_type = Request
 
             response_type = encode_response_signature.return_annotation
             if response_type == encode_response_signature.empty:
                 response_type = Response
-            self._register_api_endpoints(lit_api, request_type, response_type)
+            self._register_api_endpoints(lit_api, request_type, response_type, request_type_is_default)
 
     def _get_request_queue(self, api_path: str):
         return self.litapi_request_queues[api_path]
 
-    def _register_api_endpoints(self, lit_api: LitAPI, request_type, response_type):
+    def _register_api_endpoints(self, lit_api: LitAPI, request_type, response_type, request_type_is_default=False):
         """Register endpoint routes for the FastAPI app."""
 
         self._callback_runner.trigger_event(EventTypes.ON_SERVER_START.value, litserver=self)
@@ -1103,8 +1109,11 @@ class LitServer:
         # Create handlers
         handler = StreamingRequestHandler(lit_api, self) if lit_api.stream else RegularRequestHandler(lit_api, self)
 
+        # When no type annotation is provided, use dict[str, Any] so Swagger renders a request body form.
+        endpoint_request_type = dict[str, Any] if request_type_is_default else request_type
+
         # Create endpoint function
-        async def endpoint_handler(request: request_type) -> response_type:
+        async def endpoint_handler(request: endpoint_request_type) -> response_type:  # type: ignore[reportInvalidTypeForm]
             return await handler.handle_request(request, request_type)
 
         # Register endpoint

--- a/tests/unit/test_pydantic.py
+++ b/tests/unit/test_pydantic.py
@@ -45,3 +45,19 @@ def test_pydantic():
     with wrap_litserve_start(server) as server, TestClient(server.app) as client:
         response = client.post("/predict", json={"input": 4.0})
         assert response.json() == {"output": 16.0}
+
+
+class NoAnnotationLitAPI(LitAPI):
+    def setup(self, device):
+        pass
+
+    def predict(self, request):
+        return {"output": request["input"] ** 2}
+
+
+def test_swagger_request_body_without_annotation():
+    server = LitServer(NoAnnotationLitAPI(), accelerator="cpu", devices=1, timeout=5)
+    schema = server.app.openapi()
+    predict_post = schema["paths"]["/predict"]["post"]
+    assert "requestBody" in predict_post, "Swagger must expose a requestBody for /predict"
+    assert "application/json" in predict_post["requestBody"]["content"]


### PR DESCRIPTION
Fixes #667

## What does this PR do?

As a user, I want to use the Swagger UI (`/docs`) to test my LitServe endpoints interactively. Before this fix, the `/predict` endpoint showed no input form in Swagger when `decode_request` had no type annotation, so clicking "Execute" sent an empty body and crashed the server with a JSONDecodeError. Now Swagger correctly renders a JSON request body form for these endpoints.

  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->



## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
