### PR TITLE
fix: gracefully stop uvicorn threads during shutdown

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -1208,6 +1208,12 @@ class LitServer:
                     logger.warning(f"{log_prefix}: Already not alive.")
                     continue
                 try:
+                    if isinstance(uw, threading.Thread):
+                        getattr(uw, "_litserve_server").should_exit = True
+                        uw.join(timeout=self.uvicorn_graceful_timeout)
+                        if uw.is_alive():
+                            logger.warning(f"{log_prefix}: Did not terminate gracefully.")
+                        continue
                     uw.terminate()
                     uw.join(timeout=self.uvicorn_graceful_timeout)
                     if uw.is_alive():
@@ -1577,6 +1583,7 @@ class LitServer:
                 w = threading.Thread(
                     target=server.run, args=(response_queue_id, sockets), name=f"LitServer-{response_queue_id}"
                 )
+                setattr(w, "_litserve_server", server)
             else:
                 raise ValueError("Invalid value for api_server_worker_type. Must be 'process' or 'thread'")
             w.start()

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -16,6 +16,7 @@ import contextlib
 import json
 import os
 import sys
+import threading
 import time
 from time import sleep
 from unittest.mock import MagicMock, patch
@@ -338,6 +339,28 @@ def test_server_terminate():
         mock_launch.assert_called()
         mock_start.assert_called()
         server._transport.close.assert_called()
+
+
+def test_graceful_shutdown_stops_uvicorn_thread(simple_litapi):
+    server = LitServer(simple_litapi)
+    server._transport = MagicMock()
+    server.inference_workers = []
+    uvicorn_server = MagicMock(should_exit=False)
+
+    def wait_for_shutdown():
+        while not uvicorn_server.should_exit:
+            sleep(0.01)
+
+    worker = threading.Thread(target=wait_for_shutdown, name="LitServer-0")
+    setattr(worker, "_litserve_server", uvicorn_server)
+    worker.start()
+
+    manager = MagicMock()
+    server._perform_graceful_shutdown(manager, {0: worker})
+
+    assert uvicorn_server.should_exit is True
+    assert not worker.is_alive()
+    manager.shutdown.assert_called_once()
 
 
 @pytest.mark.parametrize(("disable_openapi_url", "should_print"), [(False, True), (True, False)])


### PR DESCRIPTION
## Summary
- retain the Uvicorn server instance for thread-backed API workers
- request thread shutdown through `server.should_exit` instead of calling process-only `terminate()` and `kill()` methods
- add regression coverage for graceful thread shutdown

## Tests
- `.venv/bin/python -m ruff check src/litserve/server.py tests/unit/test_lit_server.py`
- `.venv/bin/python -m compileall -q src/litserve/server.py tests/unit/test_lit_server.py`
- focused shutdown regression check using a thread-backed Uvicorn server double

Closes #684