### PR TITLE
chore: pin GitHub Actions to verified commit SHAs

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -17,14 +17,14 @@ jobs:
   #      actions-ref: main
 
   check-schema:
-    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       azure-dir: ""
 
   check-package:
-    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
-      actions-ref: main
+      actions-ref: 86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
       import-name: "litserve"
       artifact-name: dist-packages-${{ github.sha }}
       testing-matrix: |

--- a/.github/workflows/ci-minimal-dependency-check.yml
+++ b/.github/workflows/ci-minimal-dependency-check.yml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv and setup python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: "3.12"

--- a/.github/workflows/ci-parity.yml
+++ b/.github/workflows/ci-parity.yml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv and setup python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: "3.12"

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -34,9 +34,9 @@ jobs:
       UV_TORCH_BACKEND: "cpu"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv and setup python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version }}
@@ -69,7 +69,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
       - name: Pull reusable 🤖 actions️
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
+          ref: 86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
           path: .cicd
           repository: Lightning-AI/utilities
 
@@ -33,7 +33,7 @@ jobs:
         run: pip install -r ./.cicd/requirements/gha-package.txt
       - name: Create 📦 package
         uses: ./.cicd/.github/actions/pkg-create
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
@@ -51,7 +51,7 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Pull reusable 🤖 actions️
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
-          ref: 86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
+          ref: main
           path: .cicd
           repository: Lightning-AI/utilities
 
@@ -33,7 +33,7 @@ jobs:
         run: pip install -r ./.cicd/requirements/gha-package.txt
       - name: Create 📦 package
         uses: ./.cicd/.github/actions/pkg-create
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - uses: actions/upload-artifact@v7
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@v8
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
@@ -51,7 +51,7 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
## What does this PR do?

Pins GitHub Actions to verified commit SHAs for supply chain security.

Follows the same pattern as [pytorch-lightning#21735](https://github.com/Lightning-AI/pytorch-lightning/pull/21735).

Note: `.github/workflows/release-pypi.yml` was dropped from this PR to avoid merge conflicts. The release workflow changes are being handled separately in #709.

## Pinned references

| Action | Release | Commit SHA |
|--------|---------|------------|
| `actions/checkout` | [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2) | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `astral-sh/setup-uv` | [v7.6.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.6.0) | `37802adc94f370d6bfd71619e3f0bf239e1f3b78` |
| `codecov/codecov-action` | [v6.0.1](https://github.com/codecov/codecov-action/releases/tag/v6.0.1) | `e79a6962e0d4c0c17b229090214935d2e33f8354` |
| `Lightning-AI/utilities` | [v0.15.3](https://github.com/Lightning-AI/utilities/releases/tag/v0.15.3) | `86fe1b20b4609835ba9e8c8739cd39707ba76868` |