### PR TITLE
chore: pin docformatter Python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     rev: v1.7.7
     hooks:
       - id: docformatter
+        language_version: python3.13
         additional_dependencies: [tomli]
         args: ["--in-place"]
 


### PR DESCRIPTION
## What does this PR do?

Pins the `docformatter` pre-commit hook to Python 3.13 to avoid pre-commit runtime issues with newer Python versions.

## Changes

- Sets `language_version: python3.13` for the `docformatter` hook in `.pre-commit-config.yaml`.