### PR TITLE
ci: add 2-day package install cooldown

### DIFF
--- a/.github/workflows/ci-minimal-dependency-check.yml
+++ b/.github/workflows/ci-minimal-dependency-check.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     timeout-minutes: 30
+    env:
+      UV_EXCLUDE_NEWER: "2 days"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-parity.yml
+++ b/.github/workflows/ci-parity.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     timeout-minutes: 30
+    env:
+      UV_EXCLUDE_NEWER: "2 days"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 35
     env:
       TORCH_URL: "https://download.pytorch.org/whl/cpu/torch_stable.html"
+      UV_EXCLUDE_NEWER: "2 days"
       UV_TORCH_BACKEND: "cpu"
 
     steps:


### PR DESCRIPTION
## What does this PR do?

Adds a CI-only supply-chain guard: the resolver refuses any PyPI release published within the last **2 days**, so typosquats and malicious uploads that get yanked within ~24 h do not land in the CI environment.

### How it is wired

The uv-based workflows set:

| Env var | Value | Scope |
|---|---|---|
| `UV_EXCLUDE_NEWER` | `"2 days"` | uv-based CI jobs |

Reference: [pytorch-lightning#21722](https://github.com/Lightning-AI/pytorch-lightning/pull/21722).