### PR TITLE
Keep the restart_workers monitor alive on transient errors (and drop debug prints)

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -1605,8 +1605,8 @@ class LitServer:
         uvicorn_workers: dict[str, Union[mp.Process, threading.Thread]],
     ):
         def monitor():
-            try:
-                while not self._shutdown_event.is_set():
+            while not self._shutdown_event.is_set():
+                try:
                     broken_workers = {}
 
                     for i, proc in enumerate(self.inference_workers):
@@ -1655,17 +1655,15 @@ class LitServer:
                                 resp.response_queue.append((None, LitAPIStatus.ERROR))
 
                             resp.event.set()
-                            print(f"[monoriting] Marked {uid} set")
 
-                        print(f"[monoriting] Worker {worker_id} is dead. Restarting it")
+                        logger.info(f"Worker {worker_id} is dead. Restarting it")
                         lit_api = self.litapi_connector.lit_apis[lit_api_id]
                         self.inference_workers[idx] = self.launch_single_inference_worker(lit_api, worker_id)
-                        print(f"[monoriting] Worker {worker_id} has been started.")
+                        logger.info(f"Worker {worker_id} has been restarted")
+                except Exception:
+                    logger.exception("Error in worker monitoring loop")
 
-                    time.sleep(self.monitor_internal)
-
-            except Exception as e:
-                print(e)
+                time.sleep(self.monitor_internal)
 
         t = threading.Thread(target=monitor, daemon=True, name="litserve-monitoring")
         t.start()


### PR DESCRIPTION
### Problem

The `restart_workers` watchdog in `_start_worker_monitoring.monitor()` wraps its **entire** `while not self._shutdown_event.is_set()` loop in a single `try/except`:

```python
def monitor():
    try:
        while not self._shutdown_event.is_set():
            ...           # map dead workers, relaunch them
    except Exception as e:
        print(e)
```

So if any single iteration raises — a transient worker→API mapping error, a failed `launch_single_inference_worker`, etc. — the exception breaks out of the `while` loop, the monitor thread exits, and **`restart_workers` self-healing is permanently disabled** for the rest of the server's lifetime. The loop also shipped three leftover debug prints (misspelled `[monoriting]`).

### Fix

Move the `try/except` **inside** the loop so a single bad iteration is logged (`logger.exception`) and the watchdog keeps monitoring. Replace the `[monoriting]` debug prints with `logger` calls. The intentional `return` on `restart_workers=False` (graceful shutdown) is preserved.

### Verification

Modeled both control-flow shapes with a body that raises once then succeeds:

```
OLD: ran 0 iterations then the monitor thread DIED (self-healing disabled)
NEW: ran 3 iterations — survived the transient error and kept monitoring
```
