### PR TITLE
Fix Swagger UI URL for wildcard host binds

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -217,6 +217,10 @@ def _migration_warning(feature_name):
     )
 
 
+def _swagger_ui_display_host(host: str) -> str:
+    return "localhost" if host in ("0.0.0.0", "::") else host
+
+
 class _LitAPIConnector:
     """A helper class to manage one or more `LitAPI` instances.
 
@@ -1510,7 +1514,7 @@ class LitServer:
             )
 
             if not self._disable_openapi_url:
-                print(f"Swagger UI is available at http://0.0.0.0:{port}/docs")
+                print(f"Swagger UI is available at http://{_swagger_ui_display_host(host)}:{port}/docs")
 
             if self._monitor_workers:
                 self._start_worker_monitoring(manager, uvicorn_workers)

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -341,9 +341,19 @@ def test_server_terminate():
 
 
 @pytest.mark.parametrize(("disable_openapi_url", "should_print"), [(False, True), (True, False)])
+@pytest.mark.parametrize(
+    ("host", "display_host"),
+    [
+        ("0.0.0.0", "localhost"),
+        ("127.0.0.1", "127.0.0.1"),
+        ("::", "localhost"),
+    ],
+)
 @patch("builtins.print")
 @patch("litserve.server.uvicorn")
-def test_disable_openapi_url_print_message(mock_uvicorn, mock_print, mock_manager, disable_openapi_url, should_print):
+def test_disable_openapi_url_print_message(
+    mock_uvicorn, mock_print, mock_manager, disable_openapi_url, should_print, host, display_host
+):
     """Test that the Swagger UI message is only printed when disable_openapi_url=False."""
     server = LitServer(SimpleLitAPI(), disable_openapi_url=disable_openapi_url, restart_workers=False)
     server.verify_worker_status = MagicMock()
@@ -353,10 +363,10 @@ def test_disable_openapi_url_print_message(mock_uvicorn, mock_print, mock_manage
         contextlib.suppress(Exception),
     ):
         server._monitor_workers = False
-        server.run(port=8000)
+        server.run(host=host, port=8000, generate_client_file=False)
 
     if should_print:
-        mock_print.assert_called_with("Swagger UI is available at http://0.0.0.0:8000/docs")
+        mock_print.assert_called_with(f"Swagger UI is available at http://{display_host}:8000/docs")
     else:
         mock_print.assert_not_called()
 

--- a/tests/unit/test_swagger_ui_display_url.py
+++ b/tests/unit/test_swagger_ui_display_url.py
@@ -1,0 +1,73 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litserve import LitAPI, LitServer
+
+
+class MinimalLitAPI(LitAPI):
+    def setup(self, device):
+        pass
+
+    def decode_request(self, request):
+        return request
+
+    def predict(self, x):
+        return x
+
+    def encode_response(self, output):
+        return output
+
+
+@pytest.mark.parametrize(
+    ("host", "display_host"),
+    [
+        ("0.0.0.0", "localhost"),
+        ("127.0.0.1", "127.0.0.1"),
+        ("::", "localhost"),
+    ],
+)
+@patch("builtins.print")
+@patch("litserve.server.uvicorn")
+def test_swagger_ui_message_uses_browser_reachable_host(mock_uvicorn, mock_print, mock_manager, host, display_host):
+    server = LitServer(MinimalLitAPI(), restart_workers=False)
+    server.verify_worker_status = MagicMock()
+
+    with (
+        patch("litserve.server.mp.Manager", return_value=mock_manager),
+        contextlib.suppress(Exception),
+    ):
+        server._monitor_workers = False
+        server.run(host=host, port=8000, generate_client_file=False)
+
+    mock_print.assert_called_with(f"Swagger UI is available at http://{display_host}:8000/docs")
+
+
+@patch("builtins.print")
+@patch("litserve.server.uvicorn")
+def test_swagger_ui_message_is_hidden_when_openapi_url_is_disabled(mock_uvicorn, mock_print, mock_manager):
+    server = LitServer(MinimalLitAPI(), disable_openapi_url=True, restart_workers=False)
+    server.verify_worker_status = MagicMock()
+
+    with (
+        patch("litserve.server.mp.Manager", return_value=mock_manager),
+        contextlib.suppress(Exception),
+    ):
+        server._monitor_workers = False
+        server.run(port=8000, generate_client_file=False)
+
+    mock_print.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Fixes #697.

When `LitServer.run()` binds to a wildcard host like `0.0.0.0` or `::`, the server should keep that bind address but print a browser-reachable Swagger UI URL. This changes the displayed docs URL to use `localhost` for wildcard binds while preserving explicit `127.0.0.1` output.

## Tests

- `.venv/bin/python -m pytest tests/unit/test_swagger_ui_display_url.py -q`
- `.venv/bin/python -m py_compile src/litserve/server.py tests/unit/test_lit_server.py tests/unit/test_swagger_ui_display_url.py`
- `git diff --check`
