### PR TITLE
ci: migrate PyPI release to trusted publishing

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
       - name: Pull reusable 🤖 actions️
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
           path: .cicd
@@ -33,25 +33,41 @@ jobs:
         run: pip install -r ./.cicd/requirements/gha-package.txt
       - name: Create 📦 package
         uses: ./.cicd/.github/actions/pkg-create
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
 
-  publish-package:
+  upload-release-assets:
     needs: build-package
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-packages-${{ github.sha }}
+          path: dist
+      - run: ls -lh dist/
+      - name: Upload to release
+        uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962 # v4.0.0
+        with:
+          files: "dist/*"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-pypi:
+    needs: build-package
+    if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
       - run: ls -lh dist/
 
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## What does this PR do?

Migrates the PyPI release workflow from token-based authentication to [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/), aligning with the release pattern used in related Lightning repositories.

- Publishes to PyPI using OIDC (`permissions: id-token: write`) instead of the `pypi_password` secret
- Uploads built distributions to the GitHub Release page
- Pins release workflow actions to commit SHAs for supply-chain security

**Pre-requisite before merging:** configure a trusted publisher on the LitServe PyPI project 

ref pr: https://github.com/Lightning-AI/litData/pull/827

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we did not discuss your PR in GitHub issues there is a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃