### PR TITLE
Support context argument in batch and unbatch methods

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -253,7 +253,12 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
         return request
 
     def batch(self, inputs):
-        """Convert a list of inputs to a batched input."""
+        """Convert a list of inputs to a batched input.
+
+        Accepts an optional ``context`` argument that receives the list of context
+        dicts, one per request in the batch.
+
+        """
         # consider assigning an implementation when starting server
         # to avoid the runtime cost of checking (should be negligible)
         if hasattr(inputs[0], "__torch_function__"):
@@ -325,6 +330,9 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
 
         If you need to return dictionaries, return a list of dicts:
             [{"key1": val1, "key2": val3}, {"key1": val2, "key2": val4}]  # Correct
+
+        Accepts an optional ``context`` argument that receives the list of context
+        dicts, one per request in the batch.
 
         """
         if self._default_unbatch is None:

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -255,8 +255,8 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
     def batch(self, inputs):
         """Convert a list of inputs to a batched input.
 
-        Accepts an optional ``context`` argument that receives the list of context
-        dicts, one per request in the batch.
+        Add a context argument, batch(self, inputs, context), to also get the request context: one dict per input, in
+        the same order. The argument must be named context.
 
         """
         # consider assigning an implementation when starting server
@@ -331,8 +331,13 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
         If you need to return dictionaries, return a list of dicts:
             [{"key1": val1, "key2": val3}, {"key1": val2, "key2": val4}]  # Correct
 
-        Accepts an optional ``context`` argument that receives the list of context
-        dicts, one per request in the batch.
+        Add a context argument to also get the request context, one dict per request in the same
+        order as the outputs:
+
+            def unbatch(self, output, context):
+                return [ctx["input"] for ctx in context]
+
+        The argument must be named context.
 
         """
         if self._default_unbatch is None:

--- a/src/litserve/loops/simple_loops.py
+++ b/src/litserve/loops/simple_loops.py
@@ -366,13 +366,13 @@ class BatchedLoop(DefaultLoop):
                 ]
                 callback_runner.trigger_event(EventTypes.AFTER_DECODE_REQUEST.value, lit_api=lit_api)
 
-                x = lit_api.batch(x)
+                x = _inject_context(contexts, lit_api.batch, x)
 
                 callback_runner.trigger_event(EventTypes.BEFORE_PREDICT.value, lit_api=lit_api)
                 y = _inject_context(contexts, lit_api.predict, x)
                 callback_runner.trigger_event(EventTypes.AFTER_PREDICT.value, lit_api=lit_api)
 
-                outputs = lit_api.unbatch(y)
+                outputs = _inject_context(contexts, lit_api.unbatch, y)
 
                 if len(outputs) != num_inputs:
                     actual = len(outputs)

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -347,13 +347,13 @@ class BatchedStreamingLoop(DefaultLoop):
                 ]
                 callback_runner.trigger_event(EventTypes.AFTER_DECODE_REQUEST.value, lit_api=lit_api)
 
-                x = lit_api.batch(x)
+                x = _inject_context(contexts, lit_api.batch, x)
 
                 callback_runner.trigger_event(EventTypes.BEFORE_PREDICT.value, lit_api=lit_api)
                 y_iter = _inject_context(contexts, lit_api.predict, x)
                 callback_runner.trigger_event(EventTypes.AFTER_PREDICT.value, lit_api=lit_api)
 
-                unbatched_iter = lit_api.unbatch(y_iter)
+                unbatched_iter = _inject_context(contexts, lit_api.unbatch, y_iter)
 
                 callback_runner.trigger_event(EventTypes.BEFORE_ENCODE_RESPONSE.value, lit_api=lit_api)
                 y_enc_iter = _inject_context(contexts, lit_api.encode_response, unbatched_iter)

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -393,6 +393,37 @@ class IdentityBatchedStreamingAPI(ls.test_examples.SimpleBatchedAPI):
             yield [{"output": ctx["input"]} for ctx in context]
 
 
+class BatchUnbatchContextAPI(ls.test_examples.SimpleBatchedAPI):
+    def batch(self, inputs, context):
+        for c, x in zip(context, inputs):
+            c["input"] = float(x)
+        return super().batch(inputs)
+
+    def unbatch(self, output, context):
+        return [c["input"] for c in context]
+
+    def encode_response(self, output):
+        return {"output": output}
+
+
+class BatchUnbatchContextStreamingAPI(ls.test_examples.SimpleBatchedAPI):
+    def batch(self, inputs, context):
+        for c, x in zip(context, inputs):
+            c["input"] = float(x)
+        return super().batch(inputs)
+
+    def predict(self, x_batch):
+        yield self.model(x_batch)
+
+    def unbatch(self, output_stream, context):
+        for _ in output_stream:
+            yield [c["input"] for c in context]
+
+    def encode_response(self, output_stream):
+        for outputs in output_stream:
+            yield [{"output": output} for output in outputs]
+
+
 class PredictErrorAPI(ls.test_examples.SimpleLitAPI):
     def predict(self, x, y, context):
         context["input"] = x
@@ -440,6 +471,29 @@ async def test_inject_context():
     with wrap_litserve_start(server) as server, TestClient(server.app) as client:
         resp = client.post("/predict", json={"input": 5.0}, timeout=10)
         assert resp.status_code == 500, "predict() missed 1 required positional argument: 'y'"
+
+
+@pytest.mark.asyncio
+async def test_inject_context_in_batch_and_unbatch():
+    # Test context injection into batch/unbatch with batched loop
+    server = LitServer(BatchUnbatchContextAPI(max_batch_size=2, batch_timeout=0.01))
+    with wrap_litserve_start(server) as server:
+        async with (
+            LifespanManager(server.app) as manager,
+            AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://test") as ac,
+        ):
+            resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
+    assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
+
+    # Test context injection into batch/unbatch with batched streaming loop
+    server = LitServer(BatchUnbatchContextStreamingAPI(max_batch_size=2, batch_timeout=0.01, stream=True))
+    with wrap_litserve_start(server) as server:
+        async with (
+            LifespanManager(server.app) as manager,
+            AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://test") as ac,
+        ):
+            resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
+    assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
 
 
 def test_custom_api_path():

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -399,19 +399,21 @@ class BatchUnbatchContextAPI(ls.test_examples.SimpleBatchedAPI):
     def batch(self, inputs, context):
         for c, x in zip(context, inputs):
             c["input"] = float(x)
+            c["batch_size"] = len(inputs)
         return super().batch(inputs)
 
     def unbatch(self, output, context):
-        return [c["input"] for c in context]
+        return [{"input": c["input"], "batch_size": c["batch_size"]} for c in context]
 
     def encode_response(self, output):
-        return {"output": output}
+        return {"output": output["input"], "batch_size": output["batch_size"]}
 
 
 class BatchUnbatchContextStreamingAPI(ls.test_examples.SimpleBatchedAPI):
     def batch(self, inputs, context):
         for c, x in zip(context, inputs):
             c["input"] = float(x)
+            c["batch_size"] = len(inputs)
         return super().batch(inputs)
 
     def predict(self, x_batch):
@@ -419,11 +421,11 @@ class BatchUnbatchContextStreamingAPI(ls.test_examples.SimpleBatchedAPI):
 
     def unbatch(self, output_stream, context):
         for _ in output_stream:
-            yield [c["input"] for c in context]
+            yield [{"input": c["input"], "batch_size": c["batch_size"]} for c in context]
 
     def encode_response(self, output_stream):
         for outputs in output_stream:
-            yield [{"output": output} for output in outputs]
+            yield [{"output": output["input"], "batch_size": output["batch_size"]} for output in outputs]
 
 
 class PredictErrorAPI(ls.test_examples.SimpleLitAPI):
@@ -477,25 +479,32 @@ async def test_inject_context():
 
 @pytest.mark.asyncio
 async def test_inject_context_in_batch_and_unbatch():
-    # Test context injection into batch/unbatch with batched loop
-    server = LitServer(BatchUnbatchContextAPI(max_batch_size=2, batch_timeout=0.01))
+    # Two requests at once, so each one must get its own context back. batched loop:
+    server = LitServer(BatchUnbatchContextAPI(max_batch_size=2, batch_timeout=4), timeout=10)
     with wrap_litserve_start(server) as server:
         async with (
             LifespanManager(server.app) as manager,
             AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://test") as ac,
         ):
-            resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
-    assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
+            resp1 = ac.post("/predict", json={"input": 5.0})
+            resp2 = ac.post("/predict", json={"input": 7.0})
+            resp1, resp2 = await asyncio.gather(resp1, resp2)
+    # batch_size == 2 proves they really shared a batch
+    assert resp1.json() == {"output": 5.0, "batch_size": 2}
+    assert resp2.json() == {"output": 7.0, "batch_size": 2}
 
-    # Test context injection into batch/unbatch with batched streaming loop
-    server = LitServer(BatchUnbatchContextStreamingAPI(max_batch_size=2, batch_timeout=0.01, stream=True))
+    # ...and the same for the batched streaming loop:
+    server = LitServer(BatchUnbatchContextStreamingAPI(max_batch_size=2, batch_timeout=4, stream=True), timeout=10)
     with wrap_litserve_start(server) as server:
         async with (
             LifespanManager(server.app) as manager,
             AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://test") as ac,
         ):
-            resp = await ac.post("/predict", json={"input": 5.0}, timeout=10)
-    assert resp.json()["output"] == 5.0, "output from Identity server must be same as input"
+            resp1 = ac.post("/predict", json={"input": 5.0})
+            resp2 = ac.post("/predict", json={"input": 7.0})
+            resp1, resp2 = await asyncio.gather(resp1, resp2)
+    assert resp1.json() == {"output": 5.0, "batch_size": 2}
+    assert resp2.json() == {"output": 7.0, "batch_size": 2}
 
 
 def test_custom_api_path():


### PR DESCRIPTION
## What does this PR do?

Fixes #617.

`LitAPI.batch` and `LitAPI.unbatch` are the only hooks that never receive the per-request `context`. It is worse than a missing option: declaring `batch(self, inputs, context)` with `max_batch_size > 1` currently fails every batched request with `TypeError: batch() missing 1 required positional argument: 'context'`, surfaced as HTTP 500.

Root cause: the batched loops (regular and streaming) call `lit_api.batch`/`lit_api.unbatch` directly instead of through the `_inject_context` helper that `decode_request`/`predict`/`encode_response` already go through — even though the `contexts` list is in scope at all four call sites. This PR wraps those call sites with `_inject_context(contexts, ...)` and documents the optional `context` argument in the `batch`/`unbatch` docstrings. `_inject_context` only passes `context` when the method signature declares it, so existing implementations are unaffected.

Added `test_inject_context_in_batch_and_unbatch` covering both loops: `batch` stores each request's input in its per-request context and `unbatch` reads it back, so the test fails with the `TypeError` above without the fix. `tests/unit/test_lit_server.py`, `tests/unit/test_batch.py` and `tests/unit/test_loops.py` pass locally.


<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
