### PR TITLE
Add per-LitAPI health check endpoints

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -510,6 +510,8 @@ class LitServer:
 
             - Returns 200 when all workers are ready
             - Critical for Kubernetes/Docker deployments
+            - Each LitAPI also gets its own health check endpoint at ``{api_path}{healthcheck_path}``
+              (e.g. "/predict/health") to monitor a single API independently
 
         info_path:
             Server information endpoint. Defaults to "/info".
@@ -1021,6 +1023,22 @@ class LitServer:
             return sum(counter.value for counter in self.active_counters)
         return None
 
+    async def _check_lit_api_health(self, lit_api: LitAPI) -> bool:
+        """Check worker readiness and the user-defined ``LitAPI.health`` hook for a single LitAPI."""
+        endpoint = lit_api.api_path.split("/")[-1]
+        worker_statuses = [v for k, v in self.workers_setup_status.items() if k.rsplit("_", 1)[0] == endpoint]
+        workers_ready = bool(worker_statuses) and all(v == WorkerSetupStatus.READY for v in worker_statuses)
+
+        try:
+            health_status = lit_api.health()
+            if inspect.isawaitable(health_status):
+                health_status = await health_status
+        except Exception:
+            logger.exception(f"Health check failed for {lit_api.__class__.__name__}")
+            health_status = False
+
+        return workers_ready and bool(health_status)
+
     def _register_internal_endpoints(self):
         @self.app.get("/", dependencies=[Depends(self.setup_auth())])
         async def index(request: Request) -> Response:
@@ -1028,27 +1046,10 @@ class LitServer:
 
         @self.app.get(self.healthcheck_path, dependencies=[Depends(self.setup_auth())])
         async def health(request: Request) -> Response:
-            workers_ready = bool(self.workers_setup_status) and all(
-                v == WorkerSetupStatus.READY for v in self.workers_setup_status.values()
-            )
-
-            lit_api_health_status = True
             for lit_api in self.litapi_connector:
-                try:
-                    result = lit_api.health()
-                    if inspect.isawaitable(result):
-                        result = await result
-                    if not result:
-                        lit_api_health_status = False
-                        break
-                except Exception:
-                    logger.exception(f"Health check failed for {lit_api.__class__.__name__}")
-                    lit_api_health_status = False
-                    break
-            if workers_ready and lit_api_health_status:
-                return Response(content="ok", status_code=200)
-
-            return Response(content="not ready", status_code=503)
+                if not await self._check_lit_api_health(lit_api):
+                    return Response(content="not ready", status_code=503)
+            return Response(content="ok", status_code=200)
 
         @self.app.get(self.info_path, dependencies=[Depends(self.setup_auth())])
         async def info(request: Request) -> Response:
@@ -1116,6 +1117,19 @@ class LitServer:
                 methods=["POST"],
                 dependencies=[Depends(self.setup_auth(lit_api))],
             )
+
+        # Register a per-LitAPI health check endpoint, e.g. /predict/health
+        async def health_endpoint(request: Request) -> Response:
+            if await self._check_lit_api_health(lit_api):
+                return Response(content="ok", status_code=200)
+            return Response(content="not ready", status_code=503)
+
+        self.app.add_api_route(
+            f"{lit_api.api_path}{self.healthcheck_path}",
+            health_endpoint,
+            methods=["GET"],
+            dependencies=[Depends(self.setup_auth(lit_api))],
+        )
 
         # Handle specs
         self._register_spec_endpoints(lit_api)

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -950,7 +950,7 @@ def test_health_check_returns_503_when_workers_setup_status_is_empty(lifespan_mo
 def test_health_check_returns_503_on_health_exception(lifespan_mock, simple_litapi):
     """Health check should return 503 (not 500) when a custom health() method raises an exception."""
     server = LitServer(simple_litapi, accelerator="cpu", devices=1, timeout=10)
-    server.workers_setup_status = {"worker-0": WorkerSetupStatus.READY}
+    server.workers_setup_status = {"predict_0": WorkerSetupStatus.READY}
 
     @contextlib.asynccontextmanager
     async def mock_lifespan(app):
@@ -982,11 +982,11 @@ def test_health_check_detects_worker_status_change(lifespan_mock, simple_litapi)
         lit_api.health = MagicMock(return_value=True)
 
     with TestClient(server.app) as client:
-        server.workers_setup_status = {"worker-0": WorkerSetupStatus.READY}
+        server.workers_setup_status = {"predict_0": WorkerSetupStatus.READY}
         response = client.get("/health")
         assert response.status_code == 200
 
-        server.workers_setup_status = {"worker-0": WorkerSetupStatus.ERROR}
+        server.workers_setup_status = {"predict_0": WorkerSetupStatus.ERROR}
         response = client.get("/health")
         assert response.status_code == 503, "Health check should return 503 after worker enters error state"
         assert response.text == "not ready"
@@ -1007,17 +1007,17 @@ def test_health_check_no_stale_cache(lifespan_mock, simple_litapi):
         lit_api.health = MagicMock(return_value=True)
 
     with TestClient(server.app) as client:
-        server.workers_setup_status = {"worker-0": WorkerSetupStatus.READY}
+        server.workers_setup_status = {"predict_0": WorkerSetupStatus.READY}
         response = client.get("/health")
         assert response.status_code == 200
 
         response = client.get("/health")
         assert response.status_code == 200
 
-        server.workers_setup_status = {"worker-0": WorkerSetupStatus.ERROR}
+        server.workers_setup_status = {"predict_0": WorkerSetupStatus.ERROR}
         response = client.get("/health")
         assert response.status_code == 503, "Should not serve stale cached status"
 
-        server.workers_setup_status = {"worker-0": WorkerSetupStatus.READY}
+        server.workers_setup_status = {"predict_0": WorkerSetupStatus.READY}
         response = client.get("/health")
         assert response.status_code == 200, "Should recover when workers become ready again"

--- a/tests/unit/test_simple.py
+++ b/tests/unit/test_simple.py
@@ -177,6 +177,68 @@ def test_workers_health_with_async_health_method(use_zmq):
         assert response.text == "ok"
 
 
+class UnhealthyLitAPI(SimpleLitAPI):
+    def health(self) -> bool:
+        return False
+
+
+@pytest.mark.parametrize("use_zmq", [True, False])
+def test_per_api_health(use_zmq):
+    server = LitServer(
+        [SimpleLitAPI(api_path="/healthy"), UnhealthyLitAPI(api_path="/unhealthy")],
+        accelerator="cpu",
+        devices=1,
+        timeout=5,
+        fast_queue=use_zmq,
+    )
+
+    with wrap_litserve_start(server) as server, TestClient(server.app) as client:
+        # wait for workers to be ready
+        for _ in range(10):
+            response = client.get("/healthy/health")
+            if response.status_code == 200:
+                break
+            time.sleep(0.5)
+        assert response.status_code == 200
+        assert response.text == "ok"
+
+        response = client.get("/unhealthy/health")
+        assert response.status_code == 503
+        assert response.text == "not ready"
+
+        # global health check aggregates all APIs
+        response = client.get("/health")
+        assert response.status_code == 503
+        assert response.text == "not ready"
+
+
+@pytest.mark.parametrize("use_zmq", [True, False])
+def test_per_api_health_custom_path(use_zmq):
+    server = LitServer(
+        SlowSetupLitAPI(api_path="/api1"),
+        accelerator="cpu",
+        healthcheck_path="/my_server/health",
+        devices=1,
+        timeout=5,
+        workers_per_device=2,
+        fast_queue=use_zmq,
+    )
+
+    with wrap_litserve_start(server) as server, TestClient(server.app) as client:
+        response = client.get("/api1/my_server/health")
+        assert response.status_code == 503
+        assert response.text == "not ready"
+
+        # wait for workers to be ready
+        for _ in range(10):
+            response = client.get("/api1/my_server/health")
+            if response.status_code == 200:
+                break
+            time.sleep(0.5)
+        assert response.status_code == 200
+        assert response.text == "ok"
+
+
 def make_load_request(server, outputs):
     with TestClient(server.app) as client:
         for i in range(100):


### PR DESCRIPTION
## What does this PR do?

Fixes #605.

Each LitAPI now exposes its own health check at `{api_path}{healthcheck_path}` — e.g. `/api1/health`, `/api2/health` (and `/api1/my_server/health` with a custom `healthcheck_path`). The per-API check reports worker readiness for that API's workers only, plus its user-defined `health()` hook, returning the same `200 "ok"` / `503 "not ready"` contract as the global endpoint. Auth matches the API's predict route (`setup_auth(lit_api)`).

The per-API logic lives in a single helper, `LitServer._check_lit_api_health`, and the global healthcheck endpoint now aggregates it across all APIs, so the two can't drift. Worker keys are matched by exact `{endpoint}_{worker_id}` parsing rather than a prefix check so an API named `predict` doesn't pick up `predict_v2`'s workers. Global endpoint behavior is unchanged, including 503 on empty `workers_setup_status` and calling the `health()` hook even before workers are ready.

Two existing tests stubbed `workers_setup_status` with a synthetic `"worker-0"` key, a format `launch_inference_worker` never produces; they now use the real `"predict_0"` format. New tests cover a two-API server (healthy API 200, unhealthy API 503, global 503) and the custom `healthcheck_path` + custom `api_path` combination, parametrized over zmq like the neighboring health tests.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
-->

As a user running multiple LitAPIs behind one server, I can now ask "is *this specific* API healthy?" by hitting `/api1/health` instead of only the aggregate `/health`, which masks which API is degraded. This makes per-API liveness/readiness probes (Kubernetes, load balancers) and targeted alerting possible without custom workaround endpoints.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Yes 🙃

---

🤖 Implemented with the help of [Claude Code](https://claude.com/claude-code).
