### PR TITLE
fix(server): print localhost Swagger URL instead of 0.0.0.0

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -1510,7 +1510,7 @@ class LitServer:
             )
 
             if not self._disable_openapi_url:
-                print(f"Swagger UI is available at http://0.0.0.0:{port}/docs")
+                print(f"Swagger UI is available at http://localhost:{port}/docs")
 
             if self._monitor_workers:
                 self._start_worker_monitoring(manager, uvicorn_workers)

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -356,7 +356,7 @@ def test_disable_openapi_url_print_message(mock_uvicorn, mock_print, mock_manage
         server.run(port=8000)
 
     if should_print:
-        mock_print.assert_called_with("Swagger UI is available at http://0.0.0.0:8000/docs")
+        mock_print.assert_called_with("Swagger UI is available at http://localhost:8000/docs")
     else:
         mock_print.assert_not_called()
 


### PR DESCRIPTION
## Summary
- Changes the printed Swagger UI URL from `http://0.0.0.0:{port}/docs` to `http://localhost:{port}/docs`.
- `0.0.0.0` is not a valid address to open in a browser on Windows, so users copying the URL could not access the docs.
- `localhost` works on Windows, macOS, and Linux.

## Test Plan
- [x] Updated `test_disable_openapi_url_print_message` assertion to expect `localhost`.

## Notes
- Fixes #697
- Scope intentionally small.
