### PR TITLE
docs: add Code of Conduct, Contributing, and Governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,19 @@
 # Each line is a file pattern followed by one or more owners.
+# See GOVERNANCE.md for the maintainer model.
 
 # These owners will be the default owners for everything in the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for review when someone opens a pull request.
-* @lantiga @aniketmaurya @ethanwharris @justusschock @tchaton @andyland @k223kim @KaelanDt @dmitsf @Abdul-0x4A
+* @andyland @dmitsf @Abdul-0x4A @tchaton @justusschock @k223kim @KaelanDt @ethanwharris
 
 # CI/CD and configs
-/.github/       @andyland @dmitsf @Abdul-0x4A
-*.yaml          @andyland @dmitsf @Abdul-0x4A
-*.yml           @andyland @dmitsf @Abdul-0x4A
+/.github/       @andyland @dmitsf @Abdul-0x4A @tchaton
+*.yaml          @andyland @dmitsf @Abdul-0x4A @tchaton
+*.yml           @andyland @dmitsf @Abdul-0x4A @tchaton
 
-/README.md                           @williamfalcon @lantiga
-/requirements.txt                    @williamfalcon
+# Docs
+/README.md                           @williamfalcon @andyland
+
+# Retired committers
+#   @aniketmaurya      (Aniket Maurya)
+#   @borda             (Jirka Borovec)
+#   @lantiga           (Luca Antiga)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socioeconomic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at community@lightning.ai. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to LitServe
+
+We welcome all contributions, regardless of your level of experience or hardware. Whether it's a bug fix, a new feature, a new example, or an improvement to the docs — we appreciate your help!
+
+By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## What we're looking for
+
+- **Bug fixes** — especially around worker lifecycle, shutdown, streaming, and platform-specific behavior.
+- **New features** — batching, streaming, specs (OpenAI/MCP), transports, loggers, and callbacks.
+- **Integrations and examples** — serving a new model type or inference engine with LitServe.
+- **Documentation** — clarifications, missing docstrings, and better examples.
+- **Performance** — LitServe targets a minimum 2x speedup over plain FastAPI; benchmarks that expose regressions are valuable.
+
+## How to contribute
+
+1. **Open an issue** — describe the bug or feature before writing code. This helps us align on scope early.
+2. **Fork the repo** and create a branch from `main`.
+3. **Make your changes** and add or update relevant tests.
+4. **Open a pull request** against `main`. Include a clear description of what changed and why.
+
+New to open source? Start with an issue labeled [good first issue](https://github.com/Lightning-AI/litserve/labels/good%20first%20issue).
+
+## Development setup
+
+```bash
+git clone https://github.com/<your-username>/litserve
+cd litserve
+```
+
+```bash
+# using uv (recommended — matches CI)
+uv sync --all-extras --dev
+
+# using pip (installing the dev group needs a recent pip)
+pip install -e .
+pip install --group dev
+```
+
+Install pre-commit hooks to catch style issues before pushing:
+
+```bash
+# using uvx
+uvx pre-commit install          # install hooks
+uvx pre-commit run --all-files   # run manually
+
+# using pip
+pip install pre-commit
+pre-commit install              # install hooks
+pre-commit run --all-files       # run manually
+```
+
+## Running tests
+
+```bash
+# full suite, as CI runs it
+pytest --cov=litserve tests/ -v -s --durations=100
+
+# a single file or test
+pytest tests/unit/test_batch.py -v
+pytest tests/unit/test_batch.py::test_max_batch_size -v
+```
+
+Tests live in `tests/unit/`, `tests/integration/`, and `tests/e2e/`. The matching `unit` / `integration` / `e2e` marker is applied automatically based on that directory (see [tests/conftest.py](tests/conftest.py)), so put a new test in the right folder and you're done — no manual marker needed. To run one tier:
+
+```bash
+pytest -m unit tests/          # fast, no server startup
+pytest -m integration tests/   # spins up real servers
+pytest -m e2e tests/           # end-to-end, slowest
+```
+
+## Guidelines
+
+- Keep pull requests focused — one logical change per PR.
+- Write tests for new functionality, and add a regression test alongside any bug fix.
+- Follow the existing code style (enforced via [ruff](https://docs.astral.sh/ruff/) and pre-commit).
+- Don't leave `print` calls in library code — use the module logger.
+- All code should be your own original work; third-party snippets must be attributed.
+
+## Reviews and merging
+
+Pull requests need approval from at least one code owner (see [.github/CODEOWNERS](.github/CODEOWNERS)) and green CI before merging. See [GOVERNANCE.md](GOVERNANCE.md) for how decisions are made and how maintainers are added.
+
+## Community
+
+- [Request a feature or report a bug](https://github.com/Lightning-AI/litserve/issues)
+- [Documentation](https://lightning.ai/docs/litserve/home)
+- [Community guide](https://lightning.ai/docs/litserve/community)
+- [Join our Discord](https://discord.com/invite/MWAEvnC5fU)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,38 @@
+# Governance
+
+LitServe is an open source project backed by [Lightning AI](https://lightning.ai/), released under the [Apache-2.0](LICENSE) license.
+
+## Roles and responsibilities
+
+**Maintainers** review and merge contributions, triage issues, guide technical direction, and cut releases. The current maintainers are listed in [.github/CODEOWNERS](.github/CODEOWNERS), where ownership is scoped by path.
+
+**Contributors** are anyone contributing code, tests, docs, triage, or review. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+
+**Retired committers** are past maintainers, recorded in [.github/CODEOWNERS](.github/CODEOWNERS) and not requested for review.
+
+Maintainers are invited on the strength of sustained contribution, with the agreement of the current maintainers. A maintainer may step down, or be moved to retired status after a long period of inactivity, by a pull request updating [.github/CODEOWNERS](.github/CODEOWNERS).
+
+## Decision making
+
+Changes land through pull requests against `main`; direct pushes are not used. A pull request needs passing CI and approval from a maintainer who owns the affected paths. Larger changes — new public APIs, breaking changes, new dependencies — should start as an issue. Maintainers work by consensus and resolve disagreements in the open.
+
+## Communication
+
+GitHub issues and pull requests are the source of truth for decisions. Discussion also happens on [Discord](https://discord.com/invite/MWAEvnC5fU), but anything affecting the project is recorded on GitHub.
+
+## Releases
+
+LitServe follows `MAJOR.MINOR.PATCH` versioning, with the version in [src/litserve/\_\_about\_\_.py](src/litserve/__about__.py).
+
+- **Cadence:** cut as needed rather than on a fixed calendar, once a meaningful set of fixes or features has landed on `main`. Regressions and security fixes ship as soon as they are ready.
+- **Criteria:** `main` green across the CI matrix in [.github/workflows](.github/workflows), plus the multi-GPU pipeline.
+- **Process:** a maintainer bumps the version and publishes a GitHub Release; [`release-pypi.yml`](.github/workflows/release-pypi.yml) publishes to PyPI via trusted publishing.
+- **Supported versions:** Python and PyTorch versions are declared in [pyproject.toml](pyproject.toml) and the CI matrix. LitServe is validated against the latest two PyTorch releases; torch is not a runtime dependency.
+
+## Code of Conduct
+
+All participants follow the [Code of Conduct](CODE_OF_CONDUCT.md). Reports go to community@lightning.ai.
+
+## Changing this document
+
+By pull request, with approval from at least two maintainers.


### PR DESCRIPTION
## What does this PR do?

Addresses repo-layout items raised during the [PyTorch Ecosystem 6-month review](https://github.com/pytorch-fdn/ecosystem/issues/27#issuecomment-4791249572):
Ref: [PyTorch Ecosystem Project Review Checklist](https://docs.google.com/document/d/1wHBiqrNMzeIq-0ohSKoiA65Pw0CcNPJ4anTotwdLrz4)

1. **`CODE_OF_CONDUCT.md`** — Contributor Covenant v1.4, mirroring the [PL](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CODE_OF_CONDUCT.md) and [LitGPT](https://github.com/Lightning-AI/litgpt/blob/main/CODE_OF_CONDUCT.md) Code of Conduct, keeping the same `community@lightning.ai` enforcement contact.

2. **`CONTRIBUTING.md`** — dev setup (uv and pip), how to run the test suite, and PR guidelines.

3. **`GOVERNANCE.md`** — roles and responsibilities, decision making, communication, and the release methodology, cadence, and criteria. The review flagged that no governance doc existed in the repo.

4. **`.github/CODEOWNERS`** — adds a `Retired committers` section, drops the stale `/requirements.txt` rule (no such file exists), and points to `GOVERNANCE.md`.