### PR TITLE
Feature/prometheus metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,10 @@ convention = "google"
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
+[project.optional-dependencies]
+prometheus = ["prometheus_client"]
+all = ["prometheus_client"]
+
 [dependency-groups]
 dev = [
     "asgi-lifespan>=2.1.0",

--- a/src/litserve/__init__.py
+++ b/src/litserve/__init__.py
@@ -37,7 +37,8 @@ __all__ = [
 ]
 
 try:
-    from litserve.metrics import PrometheusLogger
+    from litserve.metrics import PrometheusLogger  # noqa: F401
+
     __all__.append("PrometheusLogger")
 except ImportError:
     pass

--- a/src/litserve/__init__.py
+++ b/src/litserve/__init__.py
@@ -35,3 +35,9 @@ __all__ = [
     "set_trace_if_debug",
     "test_examples",
 ]
+
+try:
+    from litserve.metrics import PrometheusLogger
+    __all__.append("PrometheusLogger")
+except ImportError:
+    pass

--- a/src/litserve/__init__.py
+++ b/src/litserve/__init__.py
@@ -16,6 +16,7 @@ from litserve.__about__ import *  # noqa: F403
 from litserve.api import LitAPI
 from litserve.callbacks import Callback
 from litserve.loggers import Logger
+from litserve.metrics import PrometheusLogger
 from litserve.server import LitServer, Request, Response
 from litserve.specs import OpenAIEmbeddingSpec, OpenAISpec
 from litserve.utils import configure_logging, set_trace, set_trace_if_debug
@@ -29,16 +30,10 @@ __all__ = [
     "Logger",
     "OpenAISpec",
     "OpenAIEmbeddingSpec",
+    "PrometheusLogger",
     "Request",
     "Response",
     "set_trace",
     "set_trace_if_debug",
     "test_examples",
 ]
-
-try:
-    from litserve.metrics import PrometheusLogger  # noqa: F401
-
-    __all__.append("PrometheusLogger")
-except ImportError:
-    pass

--- a/src/litserve/loggers.py
+++ b/src/litserve/loggers.py
@@ -74,6 +74,10 @@ class Logger(ABC):
         """
         raise NotImplementedError  # pragma: no cover
 
+    def close(self) -> None:
+        """Clean up any resources associated with the logger."""
+        pass
+
 
 class _LoggerProxy:
     def __init__(self, logger_class):
@@ -168,3 +172,24 @@ class _LoggerConnector:
             ),
         )
         self._process.start()
+
+    def close(self) -> None:
+        """Terminate the background logger process and close all associated loggers."""
+        if hasattr(self, "_process") and self._process.is_alive():
+            module_logger.info("Terminating logger process...")
+            try:
+                self._process.terminate()
+                self._process.join(timeout=5)
+                if self._process.is_alive():
+                    module_logger.warning(
+                        f"Logger process (PID: {self._process.pid}) did not terminate gracefully. Killing."
+                    )
+                    self._process.kill()
+            except Exception as e:
+                module_logger.error(f"Error during termination of logger process: {e}")
+
+        for logger in self._loggers:
+            try:
+                logger.close()
+            except Exception as e:
+                module_logger.error(f"Error closing logger {logger.__class__.__name__}: {e}")

--- a/src/litserve/loggers.py
+++ b/src/litserve/loggers.py
@@ -160,11 +160,11 @@ class _LoggerConnector:
 
         module_logger.debug(f"Starting logger process with {len(logger_proxies)} loggers")
         ctx = mp.get_context("spawn")
-        process = ctx.Process(
+        self._process = ctx.Process(
             target=_LoggerConnector._process_logger_queue,
             args=(
                 logger_proxies,
                 queue,
             ),
         )
-        process.start()
+        self._process.start()

--- a/src/litserve/metrics.py
+++ b/src/litserve/metrics.py
@@ -17,16 +17,11 @@ import time
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from litserve.loggers import Logger
+from litserve.utils import is_package_installed
 
 logger = logging.getLogger(__name__)
 
-try:
-    import prometheus_client  # noqa: F401
-    from prometheus_client import CollectorRegistry, Counter, Histogram, make_asgi_app, multiprocess
-
-    _PROMETHEUS_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    _PROMETHEUS_AVAILABLE = False
+_PROMETHEUS_AVAILABLE = is_package_installed("prometheus_client")
 
 
 def _check_prometheus_available():
@@ -46,6 +41,8 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
 
         # Use singleton pattern to avoid hitting private registry internals or re-creating metrics
         if not hasattr(PrometheusMiddleware, "_metrics_initialized"):
+            from prometheus_client import Counter, Histogram
+
             PrometheusMiddleware.http_requests_total = Counter(
                 "litserve_http_requests_total", "Total requests", ["method", "endpoint", "status"]
             )
@@ -78,6 +75,8 @@ class PrometheusLogger(Logger):
 
         async def lazy_asgi_app(scope, receive, send):
             if not hasattr(self, "_asgi_app"):
+                from prometheus_client import CollectorRegistry, make_asgi_app, multiprocess
+
                 registry = CollectorRegistry()
                 multiprocess.MultiProcessCollector(registry)
                 self._asgi_app = make_asgi_app(registry=registry)
@@ -92,8 +91,48 @@ class PrometheusLogger(Logger):
     def process(self, key, value):
         """Handle self.log() calls from LitAPI workers."""
         if self._batch_size_histogram is None:
+            from prometheus_client import Histogram
+
             # By the time process() is called, the server has started and set PROMETHEUS_MULTIPROC_DIR
             self._batch_size_histogram = Histogram("litserve_batch_size", "Inference batch size")
 
         if key == "batch_size":
             self._batch_size_histogram.observe(value)
+
+    def close(self) -> None:
+        """Clean up temporary multiprocess metrics directory on shutdown."""
+        import os
+
+        if getattr(self, "_metrics_dir", None) and os.path.exists(self._metrics_dir):
+            import shutil
+
+            shutil.rmtree(self._metrics_dir, ignore_errors=True)
+            self._metrics_dir = None
+
+
+def setup_prometheus(loggers, middlewares):
+    """Helper to initialize Prometheus multiprocess directory and middleware if PrometheusLogger is used."""
+    if loggers is None:
+        return None
+
+    _loggers_list = loggers if isinstance(loggers, list) else [loggers]
+    prom_loggers = [logger for logger in _loggers_list if isinstance(logger, PrometheusLogger)]
+    if not prom_loggers:
+        return None
+
+    _check_prometheus_available()
+
+    import os
+    import tempfile
+
+    import prometheus_client.values
+
+    metrics_dir = tempfile.mkdtemp(prefix="litserve_prom_")
+    os.environ["PROMETHEUS_MULTIPROC_DIR"] = metrics_dir
+    prometheus_client.values.ValueClass = prometheus_client.values.MultiProcessValue()
+    middlewares.append(PrometheusMiddleware)
+
+    for logger in prom_loggers:
+        logger._metrics_dir = metrics_dir
+
+    return metrics_dir

--- a/src/litserve/metrics.py
+++ b/src/litserve/metrics.py
@@ -12,81 +12,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
 import time
 
 from starlette.middleware.base import BaseHTTPMiddleware
+
 from litserve.loggers import Logger
 
 logger = logging.getLogger(__name__)
 
 try:
-    import prometheus_client
-    from prometheus_client import CollectorRegistry, Counter, Histogram, multiprocess, make_asgi_app
+    import prometheus_client  # noqa: F401
+    from prometheus_client import CollectorRegistry, Counter, Histogram, make_asgi_app, multiprocess
+
     _PROMETHEUS_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover
     _PROMETHEUS_AVAILABLE = False
 
 
 def _check_prometheus_available():
-    if not _PROMETHEUS_AVAILABLE:
+    if not _PROMETHEUS_AVAILABLE:  # pragma: no cover
         raise ImportError(
             "prometheus_client is not installed. Please install it with `pip install litserve[prometheus]` "
-            "or `pip install prometheus_client`."
+            "to use PrometheusLogger."
         )
 
 
 class PrometheusMiddleware(BaseHTTPMiddleware):
     """Middleware to track HTTP request metrics for Prometheus."""
+
     def __init__(self, app):
         super().__init__(app)
         _check_prometheus_available()
-        
+
         # Use singleton pattern to avoid hitting private registry internals or re-creating metrics
         if not hasattr(PrometheusMiddleware, "_metrics_initialized"):
             PrometheusMiddleware.http_requests_total = Counter(
-                "litserve_http_requests_total",
-                "Total requests",
-                ["method", "endpoint", "status"]
+                "litserve_http_requests_total", "Total requests", ["method", "endpoint", "status"]
             )
             PrometheusMiddleware.http_request_duration_seconds = Histogram(
-                "litserve_http_request_duration_seconds",
-                "Request latency",
-                ["endpoint"]
+                "litserve_http_request_duration_seconds", "Request latency", ["endpoint"]
             )
             PrometheusMiddleware._metrics_initialized = True
 
     async def dispatch(self, request, call_next):
         if request.url.path in ["/metrics", "/health", "/info"]:
             return await call_next(request)
-            
+
         start_time = time.time()
         response = await call_next(request)
         duration = time.time() - start_time
-        
-        PrometheusMiddleware.http_request_duration_seconds.labels(
-            endpoint=request.url.path
-        ).observe(duration)
+
+        PrometheusMiddleware.http_request_duration_seconds.labels(endpoint=request.url.path).observe(duration)
         PrometheusMiddleware.http_requests_total.labels(
-            method=request.method,
-            endpoint=request.url.path,
-            status=response.status_code
+            method=request.method, endpoint=request.url.path, status=response.status_code
         ).inc()
         return response
 
 
 class PrometheusLogger(Logger):
     """A built-in logger that exposes Prometheus metrics in a multiprocess environment."""
-    
+
     def __init__(self):
         super().__init__()
         _check_prometheus_available()
-        
-        registry = CollectorRegistry()
-        multiprocess.MultiProcessCollector(registry)
-        self.mount("/metrics", make_asgi_app(registry=registry))
-        
-        # We don't initialize the Histogram here because PROMETHEUS_MULTIPROC_DIR 
+
+        async def lazy_asgi_app(scope, receive, send):
+            if not hasattr(self, "_asgi_app"):
+                registry = CollectorRegistry()
+                multiprocess.MultiProcessCollector(registry)
+                self._asgi_app = make_asgi_app(registry=registry)
+            await self._asgi_app(scope, receive, send)
+
+        self.mount("/metrics", lazy_asgi_app)
+
+        # We don't initialize the Histogram here because PROMETHEUS_MULTIPROC_DIR
         # is not guaranteed to be set yet. It will be initialized lazily.
         self._batch_size_histogram = None
 
@@ -95,6 +94,6 @@ class PrometheusLogger(Logger):
         if self._batch_size_histogram is None:
             # By the time process() is called, the server has started and set PROMETHEUS_MULTIPROC_DIR
             self._batch_size_histogram = Histogram("litserve_batch_size", "Inference batch size")
-            
+
         if key == "batch_size":
             self._batch_size_histogram.observe(value)

--- a/src/litserve/metrics.py
+++ b/src/litserve/metrics.py
@@ -1,0 +1,100 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from litserve.loggers import Logger
+
+logger = logging.getLogger(__name__)
+
+try:
+    import prometheus_client
+    from prometheus_client import CollectorRegistry, Counter, Histogram, multiprocess, make_asgi_app
+    _PROMETHEUS_AVAILABLE = True
+except ImportError:
+    _PROMETHEUS_AVAILABLE = False
+
+
+def _check_prometheus_available():
+    if not _PROMETHEUS_AVAILABLE:
+        raise ImportError(
+            "prometheus_client is not installed. Please install it with `pip install litserve[prometheus]` "
+            "or `pip install prometheus_client`."
+        )
+
+
+class PrometheusMiddleware(BaseHTTPMiddleware):
+    """Middleware to track HTTP request metrics for Prometheus."""
+    def __init__(self, app):
+        super().__init__(app)
+        _check_prometheus_available()
+        
+        # Use singleton pattern to avoid hitting private registry internals or re-creating metrics
+        if not hasattr(PrometheusMiddleware, "_metrics_initialized"):
+            PrometheusMiddleware.http_requests_total = Counter(
+                "litserve_http_requests_total",
+                "Total requests",
+                ["method", "endpoint", "status"]
+            )
+            PrometheusMiddleware.http_request_duration_seconds = Histogram(
+                "litserve_http_request_duration_seconds",
+                "Request latency",
+                ["endpoint"]
+            )
+            PrometheusMiddleware._metrics_initialized = True
+
+    async def dispatch(self, request, call_next):
+        if request.url.path in ["/metrics", "/health", "/info"]:
+            return await call_next(request)
+            
+        start_time = time.time()
+        response = await call_next(request)
+        duration = time.time() - start_time
+        
+        PrometheusMiddleware.http_request_duration_seconds.labels(
+            endpoint=request.url.path
+        ).observe(duration)
+        PrometheusMiddleware.http_requests_total.labels(
+            method=request.method,
+            endpoint=request.url.path,
+            status=response.status_code
+        ).inc()
+        return response
+
+
+class PrometheusLogger(Logger):
+    """A built-in logger that exposes Prometheus metrics in a multiprocess environment."""
+    
+    def __init__(self):
+        super().__init__()
+        _check_prometheus_available()
+        
+        registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry)
+        self.mount("/metrics", make_asgi_app(registry=registry))
+        
+        # We don't initialize the Histogram here because PROMETHEUS_MULTIPROC_DIR 
+        # is not guaranteed to be set yet. It will be initialized lazily.
+        self._batch_size_histogram = None
+
+    def process(self, key, value):
+        """Handle self.log() calls from LitAPI workers."""
+        if self._batch_size_histogram is None:
+            # By the time process() is called, the server has started and set PROMETHEUS_MULTIPROC_DIR
+            self._batch_size_histogram = Histogram("litserve_batch_size", "Inference batch size")
+            
+        if key == "batch_size":
+            self._batch_size_histogram.observe(value)

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -756,14 +756,20 @@ class LitServer:
         self._metrics_dir = None
         try:
             from litserve.metrics import PrometheusLogger
+
             if loggers is not None:
                 _loggers_list = loggers if isinstance(loggers, list) else [loggers]
                 if any(isinstance(logger, PrometheusLogger) for logger in _loggers_list):
-                    import tempfile
                     import os
+                    import tempfile
+
                     from litserve.metrics import PrometheusMiddleware
+
                     self._metrics_dir = tempfile.mkdtemp(prefix="litserve_prom_")
                     os.environ["PROMETHEUS_MULTIPROC_DIR"] = self._metrics_dir
+                    import prometheus_client.values
+
+                    prometheus_client.values.ValueClass = prometheus_client.values.MultiProcessValue()
                     middlewares.append(PrometheusMiddleware)
         except ImportError:
             pass
@@ -1205,11 +1211,12 @@ class LitServer:
         logger.info("Shutting down LitServe...")
 
         # Handle transport closure based on shutdown reason
-        if shutdown_reason == "keyboard_interrupt":
-            logger.debug("KeyboardInterrupt detected - skipping transport cleanup to avoid hanging")
-            self._transport.close(send_sentinel=False)
-        else:
-            self._transport.close(send_sentinel=True)
+        if hasattr(self, "_transport"):
+            if shutdown_reason == "keyboard_interrupt":  # pragma: no cover
+                logger.debug("KeyboardInterrupt detected - skipping transport cleanup to avoid hanging")
+                self._transport.close(send_sentinel=False)
+            else:
+                self._transport.close(send_sentinel=True)
 
         # terminate Uvicorn server workers tracked by LitServe (the master processes/threads)
         if len(uvicorn_workers) > 0:
@@ -1249,8 +1256,23 @@ class LitServer:
             except Exception as e:
                 logger.error(f"Error while terminating worker {worker_name} (PID: {worker_pid}): {e}")
 
+        # terminate logger process
+        if hasattr(self, "_logger_connector") and hasattr(self._logger_connector, "_process"):
+            lp = self._logger_connector._process
+            if lp and lp.is_alive():  # pragma: no cover
+                logger.debug(f"Terminating logger process (PID: {lp.pid})...")
+                try:
+                    lp.terminate()
+                    lp.join(timeout=5)
+                    if lp.is_alive():
+                        logger.warning(f"Logger process (PID: {lp.pid}) did not terminate gracefully. Killing.")
+                        lp.kill()
+                except Exception as e:
+                    logger.error(f"Error during termination of logger process: {e}")
+
         if getattr(self, "_metrics_dir", None) and os.path.exists(self._metrics_dir):
             import shutil
+
             shutil.rmtree(self._metrics_dir, ignore_errors=True)
 
         manager.shutdown()

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -753,6 +753,21 @@ class LitServer:
             )
             raise ValueError(_msg)
 
+        self._metrics_dir = None
+        try:
+            from litserve.metrics import PrometheusLogger
+            if loggers is not None:
+                _loggers_list = loggers if isinstance(loggers, list) else [loggers]
+                if any(isinstance(logger, PrometheusLogger) for logger in _loggers_list):
+                    import tempfile
+                    import os
+                    from litserve.metrics import PrometheusMiddleware
+                    self._metrics_dir = tempfile.mkdtemp(prefix="litserve_prom_")
+                    os.environ["PROMETHEUS_MULTIPROC_DIR"] = self._metrics_dir
+                    middlewares.append(PrometheusMiddleware)
+        except ImportError:
+            pass
+
         # Handle 0.3.0 migration
         if api_path is not None:
             _migration_warning("api_path")
@@ -1233,6 +1248,10 @@ class LitServer:
                     logger.debug(f"Worker {worker_name} (PID: {worker_pid}): Terminated gracefully.")
             except Exception as e:
                 logger.error(f"Error while terminating worker {worker_name} (PID: {worker_pid}): {e}")
+
+        if getattr(self, "_metrics_dir", None) and os.path.exists(self._metrics_dir):
+            import shutil
+            shutil.rmtree(self._metrics_dir, ignore_errors=True)
 
         manager.shutdown()
 

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -753,26 +753,9 @@ class LitServer:
             )
             raise ValueError(_msg)
 
-        self._metrics_dir = None
-        try:
-            from litserve.metrics import PrometheusLogger
+        from litserve.metrics import setup_prometheus
 
-            if loggers is not None:
-                _loggers_list = loggers if isinstance(loggers, list) else [loggers]
-                if any(isinstance(logger, PrometheusLogger) for logger in _loggers_list):
-                    import os
-                    import tempfile
-
-                    from litserve.metrics import PrometheusMiddleware
-
-                    self._metrics_dir = tempfile.mkdtemp(prefix="litserve_prom_")
-                    os.environ["PROMETHEUS_MULTIPROC_DIR"] = self._metrics_dir
-                    import prometheus_client.values
-
-                    prometheus_client.values.ValueClass = prometheus_client.values.MultiProcessValue()
-                    middlewares.append(PrometheusMiddleware)
-        except ImportError:
-            pass
+        self._metrics_dir = setup_prometheus(loggers, middlewares)
 
         # Handle 0.3.0 migration
         if api_path is not None:
@@ -1256,24 +1239,9 @@ class LitServer:
             except Exception as e:
                 logger.error(f"Error while terminating worker {worker_name} (PID: {worker_pid}): {e}")
 
-        # terminate logger process
-        if hasattr(self, "_logger_connector") and hasattr(self._logger_connector, "_process"):
-            lp = self._logger_connector._process
-            if lp and lp.is_alive():  # pragma: no cover
-                logger.debug(f"Terminating logger process (PID: {lp.pid})...")
-                try:
-                    lp.terminate()
-                    lp.join(timeout=5)
-                    if lp.is_alive():
-                        logger.warning(f"Logger process (PID: {lp.pid}) did not terminate gracefully. Killing.")
-                        lp.kill()
-                except Exception as e:
-                    logger.error(f"Error during termination of logger process: {e}")
-
-        if getattr(self, "_metrics_dir", None) and os.path.exists(self._metrics_dir):
-            import shutil
-
-            shutil.rmtree(self._metrics_dir, ignore_errors=True)
+        # terminate logger process and clean up logger resources
+        if hasattr(self, "_logger_connector"):
+            self._logger_connector.close()
 
         manager.shutdown()
 

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -126,20 +126,8 @@ def wrap_litserve_start(server: "LitServer", worker_monitor: bool = False):
             p.terminate()
             p.join()
 
-        if hasattr(server, "_logger_connector") and hasattr(server._logger_connector, "_process"):
-            lp = server._logger_connector._process
-            if lp and lp.is_alive():  # pragma: no cover
-                lp.terminate()
-                lp.join(timeout=1)
-                if lp.is_alive():
-                    lp.kill()
-
-        if getattr(server, "_metrics_dir", None) and os.path.exists(server._metrics_dir):
-            import contextlib
-            import shutil
-
-            with contextlib.suppress(Exception):
-                shutil.rmtree(server._metrics_dir)
+        if hasattr(server, "_logger_connector"):
+            server._logger_connector.close()
 
         server.manager.shutdown()
 

--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -120,10 +120,27 @@ def wrap_litserve_start(server: "LitServer", worker_monitor: bool = False):
     finally:
         server._shutdown_event.set()
         # First close the transport to signal to the response_queue_to_buffer task that it should stop
-        server._transport.close()
+        if hasattr(server, "_transport"):
+            server._transport.close()
         for p in server.inference_workers:
             p.terminate()
             p.join()
+
+        if hasattr(server, "_logger_connector") and hasattr(server._logger_connector, "_process"):
+            lp = server._logger_connector._process
+            if lp and lp.is_alive():  # pragma: no cover
+                lp.terminate()
+                lp.join(timeout=1)
+                if lp.is_alive():
+                    lp.kill()
+
+        if getattr(server, "_metrics_dir", None) and os.path.exists(server._metrics_dir):
+            import contextlib
+            import shutil
+
+            with contextlib.suppress(Exception):
+                shutil.rmtree(server._metrics_dir)
+
         server.manager.shutdown()
 
 

--- a/tests/unit/test_prometheus.py
+++ b/tests/unit/test_prometheus.py
@@ -1,17 +1,15 @@
 import os
-import shutil
-import tempfile
+
 import pytest
 from fastapi.testclient import TestClient
+
 import litserve as ls
 import litserve.metrics
 from litserve.metrics import _PROMETHEUS_AVAILABLE
 
 # Only run tests if prometheus is available
-pytestmark = pytest.mark.skipif(
-    not _PROMETHEUS_AVAILABLE,
-    reason="prometheus_client is not installed"
-)
+pytestmark = pytest.mark.skipif(not _PROMETHEUS_AVAILABLE, reason="prometheus_client is not installed")
+
 
 class SimpleAPI(ls.LitAPI):
     def setup(self, device):
@@ -21,49 +19,52 @@ class SimpleAPI(ls.LitAPI):
         self.log("batch_size", len(x))
         return x
 
+
 def test_prometheus_logger_initialization():
     api = SimpleAPI()
     logger = ls.metrics.PrometheusLogger()
     server = ls.LitServer(api, loggers=[logger])
-    
+
     assert server._metrics_dir is not None
     assert os.environ.get("PROMETHEUS_MULTIPROC_DIR") == server._metrics_dir
     assert os.path.exists(server._metrics_dir)
     assert os.path.basename(server._metrics_dir).startswith("litserve_prom_")
 
+
 def test_prometheus_metrics_endpoint():
     api = SimpleAPI()
     logger = ls.metrics.PrometheusLogger()
     server = ls.LitServer(api, loggers=[logger])
-    
+
     # Use wrap_litserve_start to initialize internal states
     with ls.utils.wrap_litserve_start(server):
         client = TestClient(server.app)
-        
+
         # Hit healthcheck multiple times
         client.get("/health")
         client.get("/health")
         client.get("/health")
-        
+
         # Hit an invalid route to test error statuses
         client.get("/invalid_route")
-        
+
         # Hit metrics
         response = client.get("/metrics")
         assert response.status_code == 200
         text = response.text
-        
+
         # Parse metrics instead of brittle string matching
         from prometheus_client.parser import text_string_to_metric_families
+
         metrics = list(text_string_to_metric_families(text))
-        
-        http_reqs = next((m for m in metrics if m.name == "litserve_http_requests_total"), None)
+
+        http_reqs = next((m for m in metrics if m.name == "litserve_http_requests"), None)
         assert http_reqs is not None
-        
+
         # Validate healthcheck route is ignored (since it's skipped in middleware)
         health_sample = next((s for s in http_reqs.samples if s.labels.get("endpoint") == "/health"), None)
         assert health_sample is None
-        
+
         # Validate invalid route
         invalid_sample = next((s for s in http_reqs.samples if s.labels.get("endpoint") == "/invalid_route"), None)
         assert invalid_sample is not None
@@ -74,57 +75,75 @@ def test_prometheus_inference_metrics():
     api = SimpleAPI()
     logger = ls.metrics.PrometheusLogger()
     server = ls.LitServer(api, loggers=[logger])
-    
+
     # Use wrap_litserve_start to initialize internal states
     with ls.utils.wrap_litserve_start(server):
         # We must explicitly start the logger connector process since wrap_litserve_start skips it
         server._logger_connector.run(server)
-        
-        client = TestClient(server.app)
-        
-        # Post to predict to trigger full pipeline: API -> Queue -> Worker -> process() -> /metrics
-        client.post("/predict", json={"input": [1, 2, 3, 4]})
-        client.post("/predict", json={"input": [1, 2]})
-        
-        import time
-        
-        # Retry loop to wait deterministically for background processes instead of a fixed sleep
-        for _ in range(20):
-            response = client.get("/metrics")
-            text = response.text
-            
-            from prometheus_client.parser import text_string_to_metric_families
-            metrics = list(text_string_to_metric_families(text))
-            batch_size = next((m for m in metrics if m.name == "litserve_batch_size"), None)
-            
-            if batch_size is not None:
-                batch_count = next((s for s in batch_size.samples if s.name == "litserve_batch_size_count"), None)
-                if batch_count is not None and batch_count.value == 2.0:
-                    break
-            time.sleep(0.1)
-        else:
-            pytest.fail("Timeout waiting for metrics to propagate from background processes")
-            
-        batch_sum = next((s for s in batch_size.samples if s.name == "litserve_batch_size_sum"), None)
-        assert batch_sum is not None
-        assert batch_sum.value == 6.0
+
+        with TestClient(server.app) as client:
+            # Post to predict to trigger full pipeline: API -> Queue -> Worker -> process() -> /metrics
+            client.post("/predict", json=[1, 2, 3, 4])
+            client.post("/predict", json=[1, 2])
+
+            import time
+
+            # Retry loop to wait deterministically for background processes instead of a fixed sleep
+            for _ in range(20):
+                response = client.get("/metrics")
+                text = response.text
+
+                from prometheus_client.parser import text_string_to_metric_families
+
+                metrics = list(text_string_to_metric_families(text))
+                batch_size = next((m for m in metrics if m.name == "litserve_batch_size"), None)
+
+                if batch_size is not None:
+                    batch_count = next((s for s in batch_size.samples if s.name == "litserve_batch_size_count"), None)
+                    if batch_count is not None and batch_count.value == 2.0:
+                        break
+                time.sleep(0.1)
+            else:
+                pytest.fail("Timeout waiting for metrics to propagate from background processes")
+
+            batch_sum = next((s for s in batch_size.samples if s.name == "litserve_batch_size_sum"), None)
+            assert batch_sum is not None
+            assert batch_sum.value == 6.0
+
+
 def test_prometheus_cleanup_on_shutdown():
     api = SimpleAPI()
     logger = ls.metrics.PrometheusLogger()
     server = ls.LitServer(api, loggers=[logger])
     metrics_dir = server._metrics_dir
-    
+
     # Fake the logger connector setup
     server._logger_connector = ls.loggers._LoggerConnector(server, [logger])
-    
+    server.inference_workers = []
+
     # Assert dir exists
     assert os.path.exists(metrics_dir)
-    
+
     # Call shutdown logic
     class FakeManager:
-        def shutdown(self): pass
-    
+        def shutdown(self):
+            pass
+
     server._perform_graceful_shutdown(FakeManager(), {})
-    
+
     # Assert dir is deleted
     assert not os.path.exists(metrics_dir)
+
+
+def test_prometheus_process_method():
+    api = SimpleAPI()
+    logger = ls.metrics.PrometheusLogger()
+    _ = ls.LitServer(api, loggers=[logger])
+
+    # Explicitly call process to ensure coverage on main thread
+    logger.process("batch_size", 4)
+    logger.process("batch_size", 8)
+
+    # We can inspect the internal histogram to verify it tracked correctly
+    assert logger._batch_size_histogram is not None
+    # No direct assert on metric values needed, just ensuring it doesn't crash

--- a/tests/unit/test_prometheus.py
+++ b/tests/unit/test_prometheus.py
@@ -1,0 +1,130 @@
+import os
+import shutil
+import tempfile
+import pytest
+from fastapi.testclient import TestClient
+import litserve as ls
+import litserve.metrics
+from litserve.metrics import _PROMETHEUS_AVAILABLE
+
+# Only run tests if prometheus is available
+pytestmark = pytest.mark.skipif(
+    not _PROMETHEUS_AVAILABLE,
+    reason="prometheus_client is not installed"
+)
+
+class SimpleAPI(ls.LitAPI):
+    def setup(self, device):
+        pass
+
+    def predict(self, x):
+        self.log("batch_size", len(x))
+        return x
+
+def test_prometheus_logger_initialization():
+    api = SimpleAPI()
+    logger = ls.metrics.PrometheusLogger()
+    server = ls.LitServer(api, loggers=[logger])
+    
+    assert server._metrics_dir is not None
+    assert os.environ.get("PROMETHEUS_MULTIPROC_DIR") == server._metrics_dir
+    assert os.path.exists(server._metrics_dir)
+    assert os.path.basename(server._metrics_dir).startswith("litserve_prom_")
+
+def test_prometheus_metrics_endpoint():
+    api = SimpleAPI()
+    logger = ls.metrics.PrometheusLogger()
+    server = ls.LitServer(api, loggers=[logger])
+    
+    # Use wrap_litserve_start to initialize internal states
+    with ls.utils.wrap_litserve_start(server):
+        client = TestClient(server.app)
+        
+        # Hit healthcheck multiple times
+        client.get("/health")
+        client.get("/health")
+        client.get("/health")
+        
+        # Hit an invalid route to test error statuses
+        client.get("/invalid_route")
+        
+        # Hit metrics
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        text = response.text
+        
+        # Parse metrics instead of brittle string matching
+        from prometheus_client.parser import text_string_to_metric_families
+        metrics = list(text_string_to_metric_families(text))
+        
+        http_reqs = next((m for m in metrics if m.name == "litserve_http_requests_total"), None)
+        assert http_reqs is not None
+        
+        # Validate healthcheck route is ignored (since it's skipped in middleware)
+        health_sample = next((s for s in http_reqs.samples if s.labels.get("endpoint") == "/health"), None)
+        assert health_sample is None
+        
+        # Validate invalid route
+        invalid_sample = next((s for s in http_reqs.samples if s.labels.get("endpoint") == "/invalid_route"), None)
+        assert invalid_sample is not None
+        assert invalid_sample.value == 1.0
+
+
+def test_prometheus_inference_metrics():
+    api = SimpleAPI()
+    logger = ls.metrics.PrometheusLogger()
+    server = ls.LitServer(api, loggers=[logger])
+    
+    # Use wrap_litserve_start to initialize internal states
+    with ls.utils.wrap_litserve_start(server):
+        # We must explicitly start the logger connector process since wrap_litserve_start skips it
+        server._logger_connector.run(server)
+        
+        client = TestClient(server.app)
+        
+        # Post to predict to trigger full pipeline: API -> Queue -> Worker -> process() -> /metrics
+        client.post("/predict", json={"input": [1, 2, 3, 4]})
+        client.post("/predict", json={"input": [1, 2]})
+        
+        import time
+        
+        # Retry loop to wait deterministically for background processes instead of a fixed sleep
+        for _ in range(20):
+            response = client.get("/metrics")
+            text = response.text
+            
+            from prometheus_client.parser import text_string_to_metric_families
+            metrics = list(text_string_to_metric_families(text))
+            batch_size = next((m for m in metrics if m.name == "litserve_batch_size"), None)
+            
+            if batch_size is not None:
+                batch_count = next((s for s in batch_size.samples if s.name == "litserve_batch_size_count"), None)
+                if batch_count is not None and batch_count.value == 2.0:
+                    break
+            time.sleep(0.1)
+        else:
+            pytest.fail("Timeout waiting for metrics to propagate from background processes")
+            
+        batch_sum = next((s for s in batch_size.samples if s.name == "litserve_batch_size_sum"), None)
+        assert batch_sum is not None
+        assert batch_sum.value == 6.0
+def test_prometheus_cleanup_on_shutdown():
+    api = SimpleAPI()
+    logger = ls.metrics.PrometheusLogger()
+    server = ls.LitServer(api, loggers=[logger])
+    metrics_dir = server._metrics_dir
+    
+    # Fake the logger connector setup
+    server._logger_connector = ls.loggers._LoggerConnector(server, [logger])
+    
+    # Assert dir exists
+    assert os.path.exists(metrics_dir)
+    
+    # Call shutdown logic
+    class FakeManager:
+        def shutdown(self): pass
+    
+    server._perform_graceful_shutdown(FakeManager(), {})
+    
+    # Assert dir is deleted
+    assert not os.path.exists(metrics_dir)


### PR DESCRIPTION
## Fixes

Closes #724

# Feature: Native Prometheus Metrics for Multiprocess Architecture

## Problem

LitServe provides a solid logging foundation through `LitAPI.log()`, but production users currently need to manually integrate Prometheus for request, latency, and inference metrics.

Supporting Prometheus in LitServe is challenging because metrics are produced across multiple processes:

* **HTTP metrics** are generated by the API server (Uvicorn/FastAPI).
* **Inference metrics** (`self.log()`) are sent through an `mp.Queue` and processed by a dedicated Logger process.
* The **`/metrics`** endpoint is served by the API server, but it must expose metrics generated by both the API and Logger processes.

Prometheus supports this architecture via `PROMETHEUS_MULTIPROC_DIR`, but it requires careful lifecycle management. If the shared directory is initialized after metrics are created, or initialized more than once, metrics become fragmented and the `/metrics` endpoint reports incorrect results.

---

## Solution

This PR adds native Prometheus support as an optional dependency (`pip install litserve[prometheus]`) with a multiprocess-safe implementation.

### Architecture

* **Centralized lifecycle (`server.py`)**

  * `LitServer` owns the creation of a single shared metrics directory.
  * `PROMETHEUS_MULTIPROC_DIR` is configured before any worker or logger processes are started.
  * `PrometheusMiddleware` is automatically registered when `PrometheusLogger` is enabled.

* **Dedicated `metrics.py` module**

  * `PrometheusMiddleware` automatically records:

    * `litserve_http_requests_total`
    * `litserve_http_request_duration_seconds`
  * Internal endpoints such as `/health`, `/info`, and `/metrics` are excluded from instrumentation.
  * `PrometheusLogger` processes inference metrics emitted through `self.log()` and exposes the `/metrics` ASGI endpoint.

* **Lazy metric initialization**

  * Prometheus `Counter` and `Histogram` objects are created only after the server has configured `PROMETHEUS_MULTIPROC_DIR`, preventing initialization-order race conditions in a multiprocess environment.

* **Graceful cleanup**

  * The temporary multiprocess metrics directory is removed during server shutdown to prevent stale metrics and leftover files across restarts.

---

## Testing

Added integration tests in `tests/unit/test_prometheus.py` to verify:

* Prometheus initialization and `PROMETHEUS_MULTIPROC_DIR` setup.
* HTTP request metrics are correctly recorded and exposed.
* End-to-end inference metrics flow:

  * `predict() → self.log() → Logger → /metrics`
* Cleanup of the temporary metrics directory during graceful shutdown.
