### PR TITLE
fix(build): pin hatchling<1.32 to avoid invalid Metadata-Version 2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,9 @@ lightning = "litserve.cli:main"
 
 
 [build-system]
-requires = ["hatchling"]
+# hatchling 1.32.0 emits Metadata-Version 2.5, which twine/pkginfo don't yet recognize as valid,
+# causing `twine check --strict` to fail. Pin below it until upstream fixes this.
+requires = ["hatchling<1.32"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]


### PR DESCRIPTION
## What does this PR do?

CI's `check-package` job (`twine check --strict`) is failing on every PR right now, including #727:

Ref: https://github.com/Lightning-AI/LitServe/actions/runs/31575598966/job/94047549795?pr=727

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling 1.32.0 emits `Metadata-Version: 2.5` in the wheel, but the current core metadata spec only goes up to 2.4, so `twine`/`pkginfo` reject it. This pins `hatchling<1.32` until upstream ships a fix.

Verified locally that building with the pin produces a valid `Metadata-Version: 2.4`.