### PR TITLE
fix(specs): fix EmbeddingRequest item count for token lists and register OPTIONS method

### DIFF
--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -21,7 +21,6 @@ import warnings
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from fastapi import HTTPException, Request, Response, status
-from fastapi import status as status_code
 from pydantic import BaseModel
 
 from litserve.callbacks.base import EventTypes
@@ -46,10 +45,14 @@ class EmbeddingRequest(BaseModel):
     user: Optional[str] = None
 
     def get_num_items(self) -> int:
-        """Return the number of sentences or tokens in the input."""
+        """Return the number of sentences or items in the input."""
+        if isinstance(self.input, str):
+            return 1
         if isinstance(self.input, list):
-            if isinstance(self.input[0], list):
-                return len(self.input[0])
+            if not self.input:
+                return 0
+            if isinstance(self.input[0], int):
+                return 1
             return len(self.input)
         return 1
 
@@ -144,7 +147,7 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         # register the endpoint
         self.add_endpoint(self.api_path, self.embeddings_endpoint, ["POST"])
-        self.add_endpoint(self.api_path, self.options_embeddings, ["GET"])
+        self.add_endpoint(self.api_path, self.options_embeddings, ["OPTIONS"])
 
         # validate LitAPI methods
         if inspect.isgeneratorfunction(lit_api.predict):
@@ -226,7 +229,7 @@ class OpenAIEmbeddingSpec(LitSpec):
             embeddings = embeddings.tolist()
 
         # expand dims for list of floats
-        if isinstance(embeddings, (list, tuple)) and isinstance(embeddings[0], (int, float)):
+        if isinstance(embeddings, (list, tuple)) and len(embeddings) > 0 and isinstance(embeddings[0], (int, float)):
             embeddings = [embeddings]
 
         # check if we have total num_items number of embeddings vectors
@@ -273,15 +276,15 @@ class OpenAIEmbeddingSpec(LitSpec):
         await event.wait()
 
         response_buffer_item = self.response_buffer.pop(uid)
-        response, status = response_buffer_item.response
+        response, lit_status = response_buffer_item.response
 
-        if status == LitAPIStatus.ERROR and isinstance(response, HTTPException):
+        if lit_status == LitAPIStatus.ERROR and isinstance(response, HTTPException):
             logger.error("Error in embedding request: %s", response)
             raise response
 
-        if status == LitAPIStatus.ERROR:
+        if lit_status == LitAPIStatus.ERROR:
             logger.error("Error in embedding request: %s", response)
-            raise HTTPException(status_code=status_code.HTTP_500_INTERNAL_SERVER_ERROR)
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         logger.debug(response)
 

--- a/tests/unit/test_openai_embedding.py
+++ b/tests/unit/test_openai_embedding.py
@@ -209,3 +209,28 @@ async def test_batching_with_client_side_batching(openai_embedding_request_data_
                 == "The OpenAIEmbedding spec does not support dynamic batching when client-side batching is used. "
                 "To resolve this, either set `max_batch_size=1` or send a single input from the client."
             )
+
+
+def test_embedding_request_get_num_items():
+    from litserve.specs.openai_embedding import EmbeddingRequest
+
+    assert EmbeddingRequest(input="", model="text-embedding-3-small").get_num_items() == 1
+    assert EmbeddingRequest(input="hello world", model="text-embedding-3-small").get_num_items() == 1
+    assert EmbeddingRequest(input=["hello", "world"], model="text-embedding-3-small").get_num_items() == 2
+    assert EmbeddingRequest(input=[101, 2054, 2003, 102], model="text-embedding-3-small").get_num_items() == 1
+    assert EmbeddingRequest(input=[[101, 2054], [101, 2003, 102]], model="text-embedding-3-small").get_num_items() == 2
+    assert EmbeddingRequest(input=[], model="text-embedding-3-small").get_num_items() == 0
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_spec_options():
+    spec = OpenAIEmbeddingSpec()
+    server = ls.LitServer(TestEmbedAPI(spec=spec))
+
+    with wrap_litserve_start(server) as server:
+        async with (
+            LifespanManager(server.app) as manager,
+            AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://test") as ac,
+        ):
+            resp = await ac.options("/v1/embeddings", timeout=10)
+            assert resp.status_code == 200, f"Expected 200 OK for OPTIONS request, got {resp.status_code}"


### PR DESCRIPTION
### Summary

Fixes `EmbeddingRequest.get_num_items()` when `input` is token-based (`list[int]` or `list[list[int]]`) or empty, and registers the `options_embeddings` endpoint handler with `OPTIONS` HTTP method rather than `GET`.

### Problem

1. **Token Input Item Count**: According to OpenAI Embeddings API, `input` can be a single token array `list[int]` (1 sequence) or a batch of token arrays `list[list[int]]` (N sequences).
   - When passing `input=[101, 2054, 2003, 102]` (`list[int]`), `get_num_items()` returned `4` (the number of tokens) instead of `1` (the single sequence). When the embedding model returned 1 vector for the input, `num_response_items != num_items` raised `ValueError: Mismatch between requested and returned embeddings: expected 4, but got 1`.
   - When passing `input=[[101, 2054], [101, 2003, 102]]` (`list[list[int]]`), `get_num_items()` returned `len(self.input[0])` (the length of the first token sequence) instead of `len(self.input)` (the batch size).
   - When passing `input=[]`, `self.input[0]` raised `IndexError: list index out of range`.

2. **CORS OPTIONS Preflight**: In `OpenAIEmbeddingSpec.pre_setup`, `options_embeddings` was registered with `["GET"]` instead of `["OPTIONS"]`. Browser clients and SDK preflight requests received `405 Method Not Allowed`.

3. **Empty Response Indexing**: `_handle_embedding_response` indexed `embeddings[0]` directly without verifying `len(embeddings) > 0`.

### Solution

- Updated `EmbeddingRequest.get_num_items()` to differentiate between a single tokenized sequence (`list[int]` $\rightarrow 1$) and a list of sequences (`list[str]` / `list[list[int]]` $\rightarrow \text{len}(\text{input})$), while returning `1` for strings and `0` for empty lists.
- Fixed `OpenAIEmbeddingSpec.pre_setup` to register `options_embeddings` with `["OPTIONS"]`.
- Added safety check `len(embeddings) > 0` before checking `isinstance(embeddings[0], (int, float))` in `_handle_embedding_response`.

### Tests

- Added `test_embedding_request_get_num_items` in `tests/unit/test_openai_embedding.py` covering strings, string lists, token lists, batch token lists, and empty lists.
- Added `test_openai_embedding_spec_options` to verify `OPTIONS /v1/embeddings` returns `200 OK`.
- Verified existing unit tests in `tests/unit/test_openai_embedding.py` (all 13 tests passing).
- Verified formatting and linting with `ruff`.
