### PR TITLE
Expose HTTP request headers to LitAPI via context["headers"]

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -246,7 +246,14 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
         pass
 
     def decode_request(self, request, **kwargs):
-        """Convert the request payload to your model input."""
+        """Convert the request payload to your model input.
+
+        Add a context argument, decode_request(self, request, context), to also get the request context. The HTTP
+        request headers are available as context["headers"] (a dict), so hooks such as decode_request, predict, and
+        encode_response can access things like auth tokens, trace/correlation IDs, or user agent without needing them
+        repacked into the request body.
+
+        """
         if self._spec:
             return self._spec.decode_request(request, **kwargs)
         return request

--- a/src/litserve/loops/base.py
+++ b/src/litserve/loops/base.py
@@ -38,7 +38,7 @@ MultiPartParser.max_file_size = sys.maxsize
 MultiPartParser.spool_max_size = sys.maxsize
 
 _DEFAULT_STOP_LOOP_MESSAGE = "Received sentinel value, stopping loop"
-_SENTINEL_VALUE = (None, None, None, None)
+_SENTINEL_VALUE = (None, None, None, None, None)
 
 
 def _inject_context(context: Union[list[dict], dict], func, *args, **kwargs):
@@ -115,7 +115,7 @@ def collate_requests(
                 if request_data == _SENTINEL_VALUE:
                     raise _StopLoopError()
 
-                response_queue_id, uid, timestamp, x_enc = request_data
+                response_queue_id, uid, timestamp, x_enc, headers = request_data
 
                 loop.put_response(
                     transport=transport,
@@ -129,7 +129,7 @@ def collate_requests(
                 if apply_timeout and time.monotonic() - timestamp > lit_api.request_timeout:
                     timed_out_uids.append((response_queue_id, uid))
                 else:
-                    payloads.append((response_queue_id, uid, x_enc))
+                    payloads.append((response_queue_id, uid, x_enc, headers))
             except Empty:
                 break
         return payloads, timed_out_uids
@@ -144,7 +144,7 @@ def collate_requests(
             if request_data == _SENTINEL_VALUE:
                 raise _StopLoopError()
 
-            response_queue_id, uid, timestamp, x_enc = request_data
+            response_queue_id, uid, timestamp, x_enc, headers = request_data
 
             loop.put_response(
                 transport=transport,
@@ -158,7 +158,7 @@ def collate_requests(
             if apply_timeout and time.monotonic() - timestamp > lit_api.request_timeout:
                 timed_out_uids.append((response_queue_id, uid))
             else:
-                payloads.append((response_queue_id, uid, x_enc))
+                payloads.append((response_queue_id, uid, x_enc, headers))
 
         except Empty:
             continue
@@ -203,7 +203,7 @@ class _BaseLoop(ABC):
             if item is None:
                 return
 
-            response_queue_id, uid, timestamp, x_enc = item
+            response_queue_id, uid, timestamp, x_enc, headers = item
             # Expects LitAPI to implement the load_cache method
             lit_api.load_cache(x_enc)
             x = lit_api.decode_request(x_enc)

--- a/src/litserve/loops/simple_loops.py
+++ b/src/litserve/loops/simple_loops.py
@@ -46,7 +46,7 @@ class SingleLoop(DefaultLoop):
                     logger.debug("Received sentinel value, stopping loop")
                     return
 
-                response_queue_id, uid, timestamp, x_enc = request_data
+                response_queue_id, uid, timestamp, x_enc, headers = request_data
 
                 self.put_response(
                     transport=transport,
@@ -83,7 +83,7 @@ class SingleLoop(DefaultLoop):
                 )
                 continue
             try:
-                context = {}
+                context = {"headers": headers}
                 if hasattr(lit_spec, "populate_context"):
                     lit_spec.populate_context(context, x_enc)
 
@@ -152,9 +152,9 @@ class SingleLoop(DefaultLoop):
         lit_spec: Optional[LitSpec] = None,
     ):
         lit_spec = lit_spec or lit_api.spec
-        response_queue_id, uid, timestamp, x_enc = request
+        response_queue_id, uid, timestamp, x_enc, headers = request
         try:
-            context = {}
+            context = {"headers": headers}
             if hasattr(lit_spec, "populate_context"):
                 lit_spec.populate_context(context, x_enc)
 
@@ -232,7 +232,7 @@ class SingleLoop(DefaultLoop):
                         logger.debug("Received sentinel value, stopping loop")
                         return
 
-                    response_queue_id, uid, timestamp, x_enc = request_data
+                    response_queue_id, uid, timestamp, x_enc, headers = request_data
 
                     self.put_response(
                         transport=transport,
@@ -269,7 +269,7 @@ class SingleLoop(DefaultLoop):
                 # of multiple requests
                 task = asyncio.create_task(
                     self._process_single_request(
-                        (response_queue_id, uid, timestamp, x_enc),
+                        (response_queue_id, uid, timestamp, x_enc, headers),
                         lit_api,
                         transport,
                         callback_runner,
@@ -347,10 +347,10 @@ class BatchedLoop(DefaultLoop):
             if not batches:
                 continue
             logger.debug(f"{len(batches)} batched requests received")
-            response_queue_ids, uids, inputs = zip(*batches)
+            response_queue_ids, uids, inputs, headers_list = zip(*batches)
             num_inputs = len(inputs)
             try:
-                contexts = [{} for _ in range(num_inputs)]
+                contexts = [{"headers": headers} for headers in headers_list]
                 if hasattr(lit_spec, "populate_context"):
                     for input, context in zip(inputs, contexts):
                         lit_spec.populate_context(context, input)

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -45,7 +45,7 @@ class StreamingLoop(DefaultLoop):
                 if request_data == _SENTINEL_VALUE:
                     logger.debug("Received sentinel value, stopping loop")
                     return
-                response_queue_id, uid, timestamp, x_enc = request_data
+                response_queue_id, uid, timestamp, x_enc, headers = request_data
 
                 self.put_response(
                     transport=transport,
@@ -79,7 +79,7 @@ class StreamingLoop(DefaultLoop):
                 continue
 
             try:
-                context = {}
+                context = {"headers": headers}
                 if hasattr(lit_spec, "populate_context"):
                     lit_spec.populate_context(context, x_enc)
                 x = _inject_context(
@@ -143,9 +143,9 @@ class StreamingLoop(DefaultLoop):
         lit_spec: Optional[LitSpec] = None,
     ):
         lit_spec = lit_api.spec
-        response_queue_id, uid, timestamp, x_enc = request
+        response_queue_id, uid, timestamp, x_enc, headers = request
         try:
-            context = {}
+            context = {"headers": headers}
             if hasattr(lit_spec, "populate_context"):
                 lit_spec.populate_context(context, x_enc)
 
@@ -226,7 +226,7 @@ class StreamingLoop(DefaultLoop):
                         logger.debug("Received sentinel value, stopping loop")
                         return
 
-                    response_queue_id, uid, timestamp, x_enc = request_data
+                    response_queue_id, uid, timestamp, x_enc, headers = request_data
 
                     self.put_response(
                         transport=transport,
@@ -261,7 +261,7 @@ class StreamingLoop(DefaultLoop):
 
                 task = asyncio.create_task(
                     self._process_streaming_request(
-                        (response_queue_id, uid, timestamp, x_enc),
+                        (response_queue_id, uid, timestamp, x_enc, headers),
                         lit_api,
                         transport,
                         callback_runner,
@@ -328,10 +328,10 @@ class BatchedStreamingLoop(DefaultLoop):
 
             if not batches:
                 continue
-            response_queue_ids, uids, inputs = zip(*batches)
+            response_queue_ids, uids, inputs, headers_list = zip(*batches)
             num_inputs = len(inputs)
             try:
-                contexts = [{} for _ in range(num_inputs)]
+                contexts = [{"headers": headers} for headers in headers_list]
                 if hasattr(lit_spec, "populate_context"):
                     for input, context in zip(inputs, contexts):
                         lit_spec.populate_context(context, input)

--- a/src/litserve/loops/streaming_loops.py
+++ b/src/litserve/loops/streaming_loops.py
@@ -329,7 +329,6 @@ class BatchedStreamingLoop(DefaultLoop):
             if not batches:
                 continue
             response_queue_ids, uids, inputs, headers_list = zip(*batches)
-            num_inputs = len(inputs)
             try:
                 contexts = [{"headers": headers} for headers in headers_list]
                 if hasattr(lit_spec, "populate_context"):

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -294,16 +294,21 @@ class BaseRequestHandler(ABC):
         self.lit_api = lit_api
         self.server = server
 
-    async def _prepare_request(self, request, request_type) -> dict:
-        """Common request preparation logic."""
+    async def _prepare_request(self, request, request_type) -> tuple[dict, dict]:
+        """Common request preparation logic.
+
+        Returns the decoded payload and the request headers.
+
+        """
         if request_type == Request:
             content_type = request.headers.get("Content-Type", "")
+            headers = dict(request.headers)
             if content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):
-                return await request.form()
-            return await request.json()
-        return request
+                return await request.form(), headers
+            return await request.json(), headers
+        return request, {}
 
-    async def _submit_request(self, payload: dict) -> tuple[str, asyncio.Event]:
+    async def _submit_request(self, payload: dict, headers: Optional[dict] = None) -> tuple[str, asyncio.Event]:
         """Submit request to worker queue."""
         request_queue = self.server._get_request_queue(self.lit_api.api_path)
         response_queue_id = self.server.app.response_queue_id
@@ -316,7 +321,7 @@ class BaseRequestHandler(ABC):
             litserver=self.server,
         )
 
-        request_queue.put((response_queue_id, uid, time.monotonic(), payload))
+        request_queue.put((response_queue_id, uid, time.monotonic(), payload, headers or {}))
         logger.debug(f"Submitted request uid={uid}")
         return uid, response_queue_id
 
@@ -330,10 +335,10 @@ class RegularRequestHandler(BaseRequestHandler):
         try:
             logger.debug(f"Handling request: {request}")
             # Prepare request
-            payload = await self._prepare_request(request, request_type)
+            payload, headers = await self._prepare_request(request, request_type)
 
             # Submit to worker
-            uid, _ = await self._submit_request(payload)
+            uid, _ = await self._submit_request(payload, headers)
 
             # Wait for response
             event = asyncio.Event()
@@ -383,10 +388,10 @@ class StreamingRequestHandler(BaseRequestHandler):
     async def handle_request(self, request, request_type) -> StreamingResponse:
         try:
             # Prepare request
-            payload = await self._prepare_request(request, request_type)
+            payload, headers = await self._prepare_request(request, request_type)
 
             # Submit to worker
-            uid, _ = await self._submit_request(payload)
+            uid, _ = await self._submit_request(payload, headers)
 
             # Set up streaming response
             event = asyncio.Event()

--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -497,9 +497,12 @@ class OpenAISpec(LitSpec):
     async def options_chat_completions(self, request: Request):
         return Response(status_code=200)
 
-    async def chat_completion(self, request: ChatCompletionRequest, background_tasks: BackgroundTasks):
+    async def chat_completion(
+        self, request: ChatCompletionRequest, raw_request: Request, background_tasks: BackgroundTasks
+    ):
         response_queue_id = self.response_queue_id
         logger.debug("Received chat completion request %s", request)
+        headers = dict(raw_request.headers)
         uids = [uuid.uuid4() for _ in range(request.n)]
         self.queues = []
         self.events = []
@@ -517,7 +520,7 @@ class OpenAISpec(LitSpec):
             q = deque()
             event = asyncio.Event()
             self.response_buffer[uid] = ResponseBufferItem(response_queue=q, event=event)
-            self.request_queue.put((response_queue_id, uid, time.monotonic(), request_el))
+            self.request_queue.put((response_queue_id, uid, time.monotonic(), request_el, headers))
             self.queues.append(q)
             self.events.append(event)
 

--- a/src/litserve/specs/openai_embedding.py
+++ b/src/litserve/specs/openai_embedding.py
@@ -245,8 +245,9 @@ class OpenAIEmbeddingSpec(LitSpec):
 
         return result
 
-    async def embeddings_endpoint(self, request: EmbeddingRequest) -> EmbeddingResponse:
+    async def embeddings_endpoint(self, request: EmbeddingRequest, raw_request: Request) -> EmbeddingResponse:
         response_queue_id = self.response_queue_id
+        headers = dict(raw_request.headers)
         num_items = request.get_num_items()
         if num_items > 1 and self._max_batch_size > 1:
             raise HTTPException(
@@ -269,7 +270,7 @@ class OpenAIEmbeddingSpec(LitSpec):
             litserver=self._server,
         )
 
-        self.request_queue.put_nowait((response_queue_id, uid, time.monotonic(), request.model_copy()))
+        self.request_queue.put_nowait((response_queue_id, uid, time.monotonic(), request.model_copy(), headers))
         await event.wait()
 
         response_buffer_item = self.response_buffer.pop(uid)

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -208,8 +208,8 @@ class FakeTransport(MessageTransport):
 def test_batched_loop():
     requests_queue = Queue()
     response_queue_id = 0
-    requests_queue.put((response_queue_id, "uuid-1234", time.monotonic(), {"input": 4.0}))
-    requests_queue.put((response_queue_id, "uuid-1235", time.monotonic(), {"input": 5.0}))
+    requests_queue.put((response_queue_id, "uuid-1234", time.monotonic(), {"input": 4.0}, {}))
+    requests_queue.put((response_queue_id, "uuid-1235", time.monotonic(), {"input": 5.0}, {}))
     requests_queue.put(_SENTINEL_VALUE)
 
     lit_api_mock = MagicMock()
@@ -256,7 +256,9 @@ def test_collate_requests(batch_timeout, batch_size):
     api.request_timeout = 5
     request_queue = Queue()
     for i in range(batch_size):
-        request_queue.put((i, f"uuid-abc-{i}", time.monotonic(), i))  # response_queue_id, uid, timestamp, x_enc
+        request_queue.put(
+            (i, f"uuid-abc-{i}", time.monotonic(), i, {})
+        )  # response_queue_id, uid, timestamp, x_enc, headers
     payloads, timed_out_uids = collate_requests(MagicMock(), api, request_queue, MagicMock())
     assert len(payloads) == batch_size, f"Should have {batch_size} payloads, got {len(payloads)}"
     assert len(timed_out_uids) == 0, "No timed out uids"

--- a/tests/unit/test_loops.py
+++ b/tests/unit/test_loops.py
@@ -71,8 +71,8 @@ def mock_transport():
 @pytest.fixture
 def loop_args():
     requests_queue = Queue()
-    requests_queue.put((0, "uuid-123", time.monotonic(), 1))  # response_queue_id, uid, timestamp, x_enc
-    requests_queue.put((1, "uuid-234", time.monotonic(), 2))
+    requests_queue.put((0, "uuid-123", time.monotonic(), 1, {}))  # response_queue_id, uid, timestamp, x_enc, headers
+    requests_queue.put((1, "uuid-234", time.monotonic(), 2, {}))
 
     lit_api_mock = MagicMock()
     lit_api_mock.request_timeout = 1
@@ -113,8 +113,8 @@ class AsyncTestLitAPI(LitAPI):
 @pytest.fixture
 def async_loop_args():
     requests_queue = TestQueue()
-    requests_queue.put((0, "uuid-123", time.monotonic(), {"input": 1}))
-    requests_queue.put((1, "uuid-234", time.monotonic(), {"input": 2}))
+    requests_queue.put((0, "uuid-123", time.monotonic(), {"input": 1}, {}))
+    requests_queue.put((1, "uuid-234", time.monotonic(), {"input": 2}, {}))
     requests_queue.put(_SENTINEL_VALUE)
 
     lit_api = AsyncTestLitAPI()
@@ -223,7 +223,7 @@ def test_streaming_loop():
     fake_stream_api.format_encoded_response = MagicMock(side_effect=lambda x: x)
 
     requests_queue = Queue()
-    requests_queue.put((0, "UUID-1234", time.monotonic(), {"prompt": "Hello"}))
+    requests_queue.put((0, "UUID-1234", time.monotonic(), {"prompt": "Hello"}, {}))
     transport = FakeStreamSender(num_streamed_outputs)
 
     lit_loop = StreamingLoop()
@@ -257,7 +257,7 @@ class AsyncTestStreamLitAPI(LitAPI):
 
 @pytest.mark.asyncio
 async def test_streaming_loop_process_streaming_request(mock_transport):
-    request = (0, "UUID-1234", time.monotonic(), {"input": 5})
+    request = (0, "UUID-1234", time.monotonic(), {"input": 5}, {})
 
     lit_api = AsyncTestStreamLitAPI()
     loop = StreamingLoop()
@@ -278,7 +278,7 @@ async def test_streaming_loop_process_streaming_request(mock_transport):
 
 def test_run_streaming_loop_with_async(mock_transport, monkeypatch):
     requests_queue = TestQueue()
-    requests_queue.put((0, "uuid-123", time.monotonic(), {"input": 5}))
+    requests_queue.put((0, "uuid-123", time.monotonic(), {"input": 5}, {}))
     requests_queue.put(_SENTINEL_VALUE)  # Sentinel to stop the loop
 
     lit_api = AsyncTestStreamLitAPI()
@@ -359,8 +359,8 @@ def test_batched_streaming_loop(mock_transport):
     fake_stream_api.batch_timeout = 2
 
     requests_queue = Queue()
-    requests_queue.put((0, "UUID-001", time.monotonic(), {"prompt": "Hello"}))
-    requests_queue.put((0, "UUID-002", time.monotonic(), {"prompt": "World"}))
+    requests_queue.put((0, "UUID-001", time.monotonic(), {"prompt": "Hello"}, {}))
+    requests_queue.put((0, "UUID-002", time.monotonic(), {"prompt": "World"}, {}))
 
     lit_loop = BatchedStreamingLoop()
     transport = FakeBatchStreamTransport(num_streamed_outputs)
@@ -426,7 +426,7 @@ async def test_run_single_loop(mock_transport):
     lit_api.request_timeout = 1
 
     request_queue = Queue()
-    request_queue.put((0, "UUID-001", time.monotonic(), {"input": 4.0}))
+    request_queue.put((0, "UUID-001", time.monotonic(), {"input": 4.0}, {}))
     transport = mock_transport
 
     # Run the loop in a separate thread to allow it to be stopped
@@ -460,7 +460,7 @@ async def test_run_single_loop_timeout():
 
     request_queue = Queue()
     transport = MockMPQueueTransport()
-    old_request = (0, "UUID-001", time.monotonic(), {"input": 4.0})
+    old_request = (0, "UUID-001", time.monotonic(), {"input": 4.0}, {})
     time.sleep(0.1)  # Age the request
     request_queue.put(old_request)
 
@@ -493,7 +493,10 @@ async def test_run_batched_loop():
     request_queue = Queue()
     transport = MockMPQueueTransport(1)
 
-    requests = [(0, "UUID-001", time.monotonic(), {"input": 4.0}), (0, "UUID-002", time.monotonic(), {"input": 5.0})]
+    requests = [
+        (0, "UUID-001", time.monotonic(), {"input": 4.0}, {}),
+        (0, "UUID-002", time.monotonic(), {"input": 5.0}, {}),
+    ]
     for req in requests:
         request_queue.put(req)
 
@@ -538,8 +541,8 @@ async def test_run_batched_loop_timeout(mock_transport):
 
     # First request will time out, second will succeed
     requests = [
-        (0, "UUID-001", time.monotonic() - 0.2, {"input": 4.0}),  # Old request
-        (0, "UUID-002", time.monotonic(), {"input": 5.0}),  # Fresh request
+        (0, "UUID-001", time.monotonic() - 0.2, {"input": 4.0}, {}),  # Old request
+        (0, "UUID-002", time.monotonic(), {"input": 5.0}, {}),  # Fresh request
     ]
     for req in requests:
         request_queue.put(req)
@@ -575,7 +578,7 @@ async def test_run_streaming_loop(mock_transport):
     lit_api.request_timeout = 1
 
     request_queue = Queue()
-    request_queue.put((0, "UUID-001", time.monotonic(), {"input": "Hello"}))
+    request_queue.put((0, "UUID-001", time.monotonic(), {"input": "Hello"}, {}))
 
     # Run the loop in a separate thread to allow it to be stopped
     lit_loop = StreamingLoop()
@@ -609,7 +612,7 @@ async def test_run_streaming_loop_timeout(mock_transport):
     lit_api.request_timeout = 0.1
 
     request_queue = Queue()
-    request_queue.put((0, "UUID-001", time.monotonic() - 5, {"input": "Hello"}))
+    request_queue.put((0, "UUID-001", time.monotonic() - 5, {"input": "Hello"}, {}))
 
     # Run the loop in a separate thread to allow it to be stopped
     lit_loop = StreamingLoop()
@@ -643,9 +646,9 @@ def off_test_run_batched_streaming_loop(openai_request_data):
     lit_api.pre_setup(spec=spec, timeout=30)
 
     request_queue = Queue()
-    # response_queue_id, uid, timestamp, x_enc
-    r1 = (0, "UUID-001", time.monotonic(), openai_request_data)
-    r2 = (0, "UUID-002", time.monotonic(), openai_request_data)
+    # response_queue_id, uid, timestamp, x_enc, headers
+    r1 = (0, "UUID-001", time.monotonic(), openai_request_data, {})
+    r2 = (0, "UUID-002", time.monotonic(), openai_request_data, {})
     request_queue.put(r1)
     request_queue.put(r2)
     response_queues = [Queue()]
@@ -708,7 +711,7 @@ class TestLoop(LitLoop):
         if item is None:
             return
 
-        response_queue_id, uid, timestamp, x_enc = item
+        response_queue_id, uid, timestamp, x_enc, headers = item
         cache = lit_api.load_cache(x_enc)
         x = lit_api.decode_request(x_enc) * cache
         response = lit_api.predict(x)
@@ -726,7 +729,7 @@ async def test_custom_loop(mock_transport):
     lit_api.load_cache = MagicMock(return_value=1.0)
     lit_api.encode_response = MagicMock(return_value={"output": 16.0})
     request_queue = Queue()
-    request_queue.put((0, "UUID-001", time.monotonic(), {"input": 4.0}))
+    request_queue.put((0, "UUID-001", time.monotonic(), {"input": 4.0}, {}))
 
     loop(lit_api, "cpu", 0, request_queue, mock_transport, {}, NOOP_CB_RUNNER)
     response = await mock_transport.areceive(0)
@@ -824,19 +827,19 @@ def test_lit_loop_get_batch_requests(lit_loop_setup):
     lit_loop, lit_api, request_queue = lit_loop_setup
     lit_api.max_batch_size = 2
     lit_api.batch_timeout = 0.2
-    request_queue.put((0, "UUID-001", time.monotonic(), {"input": 4.0}))
-    request_queue.put((0, "UUID-002", time.monotonic(), {"input": 5.0}))
+    request_queue.put((0, "UUID-001", time.monotonic(), {"input": 4.0}, {}))
+    request_queue.put((0, "UUID-002", time.monotonic(), {"input": 5.0}, {}))
     batches, timed_out_uids = lit_loop.get_batch_requests(lit_api, request_queue, MagicMock())
     assert len(batches) == 2
-    assert batches == [(0, "UUID-001", {"input": 4.0}), (0, "UUID-002", {"input": 5.0})]
+    assert batches == [(0, "UUID-001", {"input": 4.0}, {}), (0, "UUID-002", {"input": 5.0}, {})]
     assert timed_out_uids == []
 
 
 def test_lit_loop_get_request(lit_loop_setup):
     lit_loop, _, request_queue = lit_loop_setup
     t = time.monotonic()
-    request_queue.put((0, "UUID-001", t, {"input": 4.0}))
-    response_queue_id, uid, timestamp, x_enc = lit_loop.get_request(request_queue, timeout=1)
+    request_queue.put((0, "UUID-001", t, {"input": 4.0}, {}))
+    response_queue_id, uid, timestamp, x_enc, headers = lit_loop.get_request(request_queue, timeout=1)
     assert uid == "UUID-001"
     assert response_queue_id == 0
     assert timestamp == t

--- a/tests/unit/test_request_handlers.py
+++ b/tests/unit/test_request_handlers.py
@@ -67,8 +67,8 @@ class TestRequestHandler(BaseRequestHandler):
         self.litapi_request_queues = {"/predict": Queue()}
 
     async def handle_request(self, request, request_type):
-        payload = await self._prepare_request(request, request_type)
-        uid, response_queue_id = await self._submit_request(payload)
+        payload, headers = await self._prepare_request(request, request_type)
+        uid, response_queue_id = await self._submit_request(payload, headers)
         return response_queue_id
 
 


### PR DESCRIPTION
## Summary
- Fixes #718 (and addresses the underlying question in #566): request headers were dropped as soon as the body was parsed, so `decode_request`/`predict`/`encode_response` had no way to read things like auth tokens, trace/correlation IDs, or user agent without callers repacking them into the request body.
- Headers are now captured when a request is received and threaded through the existing per-request `context` dict (the same mechanism already used for `batch`/`unbatch` context), so any hook that opts in via a `context` argument can read `context["headers"]`.
- Wired through the single, batched, streaming, and batched-streaming loops, plus the OpenAI-compatible chat completion and embedding endpoints (via an added `raw_request: Request` parameter to access headers before the pydantic body model takes over).
- `continuous_batching_loop.py` doesn't support the `context` mechanism at all today (no other hook does either), so it's left untouched — out of scope for this change.

## Usage
```python
class MyAPI(ls.LitAPI):
    def decode_request(self, request, context):
        context["headers"]  # dict of request headers
        return request
```

## Test plan
- [x] `pytest tests/unit/test_loops.py tests/unit/test_batch.py tests/unit/test_request_handlers.py` — 50 passed
- [x] `pytest tests/unit` — 298 passed, 10 skipped; the 5 pre-existing failures are unrelated to this change (missing `fastmcp`/`openai` optional deps in the sandbox, not caused by this PR)

## AI Usage Disclaimer
- [x] AI assistance (Claude Code) was used for this change.