### PR TITLE
fix: preserve raw request bodies for custom content types

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -32,7 +32,7 @@ from collections import deque
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from queue import Queue
-from typing import TYPE_CHECKING, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import uvicorn
 import uvicorn.server
@@ -294,10 +294,10 @@ class BaseRequestHandler(ABC):
         self.lit_api = lit_api
         self.server = server
 
-    async def _prepare_request(self, request, request_type) -> dict:
+    async def _prepare_request(self, request, request_type) -> Any:
         """Common request preparation logic."""
         if request_type == Request:
-            content_type = request.headers.get("Content-Type", "")
+            content_type = request.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
             if content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):
                 return await request.form()
             if content_type == "application/json" or content_type.endswith("+json"):

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -300,7 +300,9 @@ class BaseRequestHandler(ABC):
             content_type = request.headers.get("Content-Type", "")
             if content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):
                 return await request.form()
-            return await request.json()
+            if content_type == "application/json" or content_type.endswith("+json"):
+                return await request.json()
+            return await request.body()
         return request
 
     async def _submit_request(self, payload: dict) -> tuple[str, asyncio.Event]:

--- a/tests/unit/test_request_handlers.py
+++ b/tests/unit/test_request_handlers.py
@@ -52,16 +52,22 @@ class MockRequest:
         self._form_data = form_data or {}
         self._body = body
         self.headers = {"Content-Type": content_type}
+        self.json_called = False
+        self.form_called = False
+        self.body_called = False
 
     async def json(self):
+        self.json_called = True
         if self._json_data is None:
             raise json.JSONDecodeError("Invalid JSON", "", 0)
         return self._json_data
 
     async def form(self):
+        self.form_called = True
         return self._form_data
 
     async def body(self):
+        self.body_called = True
         return self._body
 
 
@@ -95,6 +101,30 @@ async def test_request_handler_preserves_raw_body(mock_lit_api):
     await handler.handle_request(mock_request, Request)
 
     assert mock_server.request_queue.get()[3] == body
+    assert mock_request.body_called
+    assert not mock_request.json_called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_type", ["application/json", "application/vnd.api+json", "application/json; charset=utf-8"])
+async def test_request_handler_preserves_json_decoding(mock_lit_api, content_type):
+    handler = TestRequestHandler(mock_lit_api, MockServer(mock_lit_api))
+    request = MockRequest(json_data={"input": 1}, content_type=content_type)
+
+    assert await handler._prepare_request(request, Request) == {"input": 1}
+    assert request.json_called
+    assert not request.body_called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_type", ["application/x-www-form-urlencoded", "multipart/form-data; boundary=test"])
+async def test_request_handler_preserves_form_decoding(mock_lit_api, content_type):
+    handler = TestRequestHandler(mock_lit_api, MockServer(mock_lit_api))
+    request = MockRequest(form_data={"input": "1"}, content_type=content_type)
+
+    assert await handler._prepare_request(request, Request) == {"input": "1"}
+    assert request.form_called
+    assert not request.body_called
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_request_handlers.py
+++ b/tests/unit/test_request_handlers.py
@@ -106,7 +106,9 @@ async def test_request_handler_preserves_raw_body(mock_lit_api):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("content_type", ["application/json", "application/vnd.api+json", "application/json; charset=utf-8"])
+@pytest.mark.parametrize(
+    "content_type", ["application/json", "application/vnd.api+json", "application/json; charset=utf-8"]
+)
 async def test_request_handler_preserves_json_decoding(mock_lit_api, content_type):
     handler = TestRequestHandler(mock_lit_api, MockServer(mock_lit_api))
     request = MockRequest(json_data={"input": 1}, content_type=content_type)

--- a/tests/unit/test_request_handlers.py
+++ b/tests/unit/test_request_handlers.py
@@ -47,9 +47,10 @@ class MockServer:
 class MockRequest:
     """Mock FastAPI Request object for testing."""
 
-    def __init__(self, json_data=None, form_data=None, content_type="application/json"):
+    def __init__(self, json_data=None, form_data=None, body=b"", content_type="application/json"):
         self._json_data = json_data or {}
         self._form_data = form_data or {}
+        self._body = body
         self.headers = {"Content-Type": content_type}
 
     async def json(self):
@@ -59,6 +60,9 @@ class MockRequest:
 
     async def form(self):
         return self._form_data
+
+    async def body(self):
+        return self._body
 
 
 class TestRequestHandler(BaseRequestHandler):
@@ -79,6 +83,18 @@ async def test_request_handler(mock_lit_api):
     mock_request = MockRequest()
     response_queue_id = await handler.handle_request(mock_request, Request)
     assert response_queue_id == 0
+
+
+@pytest.mark.asyncio
+async def test_request_handler_preserves_raw_body(mock_lit_api):
+    mock_server = MockServer(mock_lit_api)
+    handler = TestRequestHandler(mock_lit_api, mock_server)
+    body = b"\x00protobuf-payload\xff"
+    mock_request = MockRequest(body=body, content_type="application/x-recordio-protobuf")
+
+    await handler.handle_request(mock_request, Request)
+
+    assert mock_server.request_queue.get()[3] == body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Closes #732
- Preserve raw request bodies for non-JSON, non-form content types.
- Add a regression test covering binary payloads.

## Implementation
```text
Requests with `application/json` (including `+json`) continue through JSON decoding, and form/multipart requests keep their existing behavior. Other request content types now use FastAPI's `Request.body()`, allowing `decode_request` to receive the original bytes unchanged.
```

## Compatibility
Existing JSON and form/multipart request handling is unchanged. Custom content types that previously failed JSON parsing now receive raw bytes.

## Tests
- `python -m compileall -q src/litserve/server.py tests/unit/test_request_handlers.py` — passed
- `git diff --check` — passed
- `pytest tests/unit/test_request_handlers.py -q` — not completed: the uv-managed environment remained silent/hung during dependency setup/import in this Windows environment; the process was stopped.
- Docker checks were not run; this change does not require external services and the repository provides no Docker test configuration.
