### PR TITLE
fix: stop uvicorn threads during shutdown

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -421,6 +421,24 @@ class _Server(uvicorn.server.Server):
         return super().run(sockets)
 
 
+class _UvicornThread(threading.Thread):
+    def __init__(
+        self,
+        server: _Server,
+        worker_id: int,
+        sockets: Union[list[socket.socket], None],
+        name: str,
+    ) -> None:
+        super().__init__(target=server.run, args=(worker_id, sockets), name=name)
+        self.server = server
+
+    def terminate(self) -> None:
+        self.server.should_exit = True
+
+    def kill(self) -> None:
+        self.server.force_exit = True
+
+
 class LitServer:
     """Initialize a LitServer for high-performance AI model serving.
 
@@ -1575,8 +1593,11 @@ class LitServer:
                     target=server.run, args=(response_queue_id, sockets), name=f"LitServer-{response_queue_id}"
                 )
             elif uvicorn_worker_type == "thread":
-                w = threading.Thread(
-                    target=server.run, args=(response_queue_id, sockets), name=f"LitServer-{response_queue_id}"
+                w = _UvicornThread(
+                    server=server,
+                    worker_id=response_queue_id,
+                    sockets=sockets,
+                    name=f"LitServer-{response_queue_id}",
                 )
             else:
                 raise ValueError("Invalid value for api_server_worker_type. Must be 'process' or 'thread'")

--- a/tests/unit/test_lit_server.py
+++ b/tests/unit/test_lit_server.py
@@ -31,7 +31,7 @@ from httpx import ASGITransport, AsyncClient
 import litserve as ls
 from litserve import LitAPI
 from litserve.connector import _Connector
-from litserve.server import LitServer
+from litserve.server import LitServer, _UvicornThread
 from litserve.utils import WorkerSetupStatus, wrap_litserve_start
 
 
@@ -245,6 +245,17 @@ def test_start_server(mock_server):
     server._start_server(8000, 1, "info", sockets, "process")
     mock_server.assert_called()
     assert server.lit_api.spec.response_queue_id is not None, "response_queue_id must be generated"
+
+
+def test_uvicorn_thread_shutdown_signals():
+    uvicorn_server = MagicMock()
+    worker = _UvicornThread(uvicorn_server, worker_id=0, sockets=None, name="LitServer-0")
+
+    worker.terminate()
+    assert uvicorn_server.should_exit is True
+
+    worker.kill()
+    assert uvicorn_server.force_exit is True
 
 
 @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

Fixes #684

On Windows, LitServe runs each Uvicorn server in a thread. The shutdown path treated those threads like multiprocessing workers and called methods that `threading.Thread` does not provide, leaving the server hanging or logging an attribute error

This change gives Uvicorn worker threads the same small lifecycle surface used by the existing shutdown loop. `terminate()` requests Uvicorn's graceful exit, while the existing timeout fallback sets `force_exit`. Process workers keep their current behavior

Validation:

- `pytest tests/unit/test_lit_server.py::test_uvicorn_thread_shutdown_signals -q` (1 passed)
- `ruff check src/litserve/server.py tests/unit/test_lit_server.py`
- `ruff format --check src/litserve/server.py tests/unit/test_lit_server.py`

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the contributor guideline, Pull Request section?
- [ ] Did you make sure to update the docs? Not needed for this internal lifecycle fix
- [x] Did you write any new necessary tests?

</details>

## PR review

Anyone in the community is free to review the PR once the tests have passed

## Did you have fun?

Yes
