### PR TITLE
fix(ci): pin fastmcp below 4 to keep mcp on the 1.x line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,8 @@ max-complexity = 10
 dev = [
     "asgi-lifespan>=2.1.0",
     "coverage[toml]>=7.5.3",
-    "fastmcp>=2.9.2 ; python_full_version >= '3.10'",
+    # fastmcp 4 requires mcp>=2, which removed `mcp.server.fastmcp` (see litserve/mcp.py)
+    "fastmcp>=2.9.2,<4 ; python_full_version >= '3.10'",
     "httpx>=0.27.0",
     "lightning>2.0.0",
     "mypy==2.3.0",


### PR DESCRIPTION
## What does this PR do?

Restores CI, which has been red since 2026-09-03.

<img width="1204" height="457" alt="image" src="https://github.com/user-attachments/assets/1c462147-434a-484f-911b-531c04242f59" />

Ref: https://github.com/Lightning-AI/LitServe/actions/runs/34295503977/job/102291134136


`fastmcp` was declared as `fastmcp>=2.9.2` with no upper bound. fastmcp 4 requires `mcp>=2`, and mcp 2.0 removed `mcp.server.fastmcp` — the module `litserve/mcp.py` imports. `tests/unit/test_mcp.py` then fails to import, which takes the whole matrix down.

- Caps the dev dependency at `fastmcp>=2.9.2,<4`, resolving to fastmcp 3.4.7 → mcp 1.30.0
- No source changes; `litserve/mcp.py` is untouched

<details>
  <summary><b>How it broke</b></summary>

`mcp` is not a declared dependency at all — it arrives transitively:

```
fastmcp 4.0.3 → fastmcp-slim[client,server] 4.0.3 → mcp 2.2.0
```

fastmcp pins the mcp major (`slim` 3.4.7 → `mcp<2.0`, 4.0.0 → `mcp>=2.0`), but our unbounded floor let the fastmcp major float and drag the mcp major with it.

| date | fastmcp | mcp | result |
| --- | --- | --- | --- |
| 08-31 | 3.4.7 | 1.29.1 | [green](https://github.com/Lightning-AI/LitServe/actions/runs/33345090538) |
| 09-03 | 4.0.0 | 2.1.1 | [`test_mcp.py` ImportError](https://github.com/Lightning-AI/LitServe/actions/runs/33700058230) |
| 09-09 | 4.0.3 | 2.1.1 | [same](https://github.com/Lightning-AI/LitServe/actions/runs/34295503977) |

</details>

<details>
  <summary><b>Why not migrate to mcp 2.x here</b></summary>

Gating the import on the mcp version is not enough — 2.x also reworked the APIs `litserve/mcp.py` uses:

- `Tool(inputSchema=...)` is now `input_schema`
- `@server.list_tools()` and `@server.call_tool()` no longer exist on `mcp.server.lowlevel.Server`

Verified against mcp 2.2.0: fixing only the import leaves `tests/unit/test_mcp.py` at 3 failed, 11 passed. That migration deserves its own PR — see the SDK's [v2 migration guide](https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver).

</details>
