### PR TITLE
Bump version from 0.2.18 to 0.2.19

### DIFF
--- a/src/litserve/__about__.py
+++ b/src/litserve/__about__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.2.18"
+__version__ = "0.2.19"
 __author__ = "Lightning-AI et al."
 __author_email__ = "community@lightning.ai"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Bumps the package version for the next release.

- `src/litserve/__about__.py`: `0.2.18` → `0.2.19`