### PR TITLE
fix(specs): accept standard OpenAI tool choices

### DIFF
--- a/src/litserve/specs/openai.py
+++ b/src/litserve/specs/openai.py
@@ -100,12 +100,22 @@ class Function(BaseModel):
 class ToolChoice(str, Enum):
     auto: str = "auto"
     none: str = "none"
+    required: str = "required"
     any: str = "any"
 
 
 class Tool(BaseModel):
     type: Literal["function"]
     function: Function
+
+
+class NamedToolChoiceFunction(BaseModel):
+    name: str
+
+
+class NamedToolChoice(BaseModel):
+    type: Literal["function"]
+    function: NamedToolChoiceFunction
 
 
 class FunctionCall(BaseModel):
@@ -178,7 +188,7 @@ class ChatCompletionRequest(BaseModel):
     frequency_penalty: Optional[float] = 0.0
     user: Optional[str] = None
     tools: Optional[list[Tool]] = None
-    tool_choice: Optional[ToolChoice] = ToolChoice.auto
+    tool_choice: Optional[Union[ToolChoice, NamedToolChoice]] = ToolChoice.auto
     response_format: Optional[ResponseFormat] = None
     reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
     metadata: Optional[dict[str, str]] = None

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -86,6 +86,31 @@ async def test_openai_spec(openai_request_data, api):
             assert final_output == "This is a generated output ", f"final_output: {final_output}"
 
 
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "any",
+        "required",
+        {"type": "function", "function": {"name": "lookup_weather"}},
+    ],
+)
+@pytest.mark.asyncio
+async def test_openai_spec_tool_choice(openai_request_data, tool_choice):
+    openai_request_data["tool_choice"] = tool_choice
+    request = ChatCompletionRequest(**openai_request_data)
+    assert request.model_dump(mode="json")["tool_choice"] == tool_choice
+
+    server = ls.LitServer(TestAPI(spec=OpenAISpec()))
+    with wrap_litserve_start(server) as server:
+        async with (
+            LifespanManager(server.app) as manager,
+            AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://test") as ac,
+        ):
+            response = await ac.post("/v1/chat/completions", json=openai_request_data, timeout=10)
+
+    assert response.status_code == 200
+
+
 # OpenAIWithUsage
 @pytest.mark.asyncio
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Fixes #745.

`OpenAISpec` currently returns HTTP 422 for two standard Chat Completions `tool_choice` forms: `"required"` and a named function object. This extends the request schema to accept both while preserving the existing `"auto"`, `"none"`, and `"any"` values.

For users, OpenAI-compatible clients can now require at least one tool call or select a particular function without LitServe rejecting the request before `LitAPI` receives it. This change only validates and passes through the selection; it does not execute tools or choose one inside LitServe.

The accepted forms follow the current [OpenAI Chat Completions API reference](https://developers.openai.com/api/reference/cli/resources/chat):

```json
{"tool_choice": "required"}
```

```json
{
  "tool_choice": {
    "type": "function",
    "function": {"name": "lookup_weather"}
  }
}
```

### Validation

- Before the production change, the two new standard-value regressions both failed with Pydantic validation errors.
- `python -m pytest -q tests/unit/test_specs.py` — 31 passed.
- `python -m pytest -q -m unit tests/unit` — 308 passed, 10 skipped.
- `uvx ruff check src/litserve/specs/openai.py tests/unit/test_specs.py` — passed.
- `uvx ruff format --check src/litserve/specs/openai.py tests/unit/test_specs.py` — passed.
- `uvx pre-commit run --files src/litserve/specs/openai.py tests/unit/test_specs.py` — all applicable hooks passed.

All validation was CPU-only on macOS with Python 3.13. No GPU, hosted model, or paid service was used.

### Before submitting

- [ ] Maintainer scope agreement on #745 (issue filed; feedback pending).
- [x] Read the current LitServe contribution guide and linked Pull Request guidance.
- [x] Added request-model and live endpoint regression coverage.
- [x] No documentation update is needed; this corrects the existing OpenAI-compatible request contract.

I used Codex assistance to investigate, implement, test, and prepare this PR. Human review is pending. No competing PR code was copied.
