### PR TITLE
fix: reset active request count after errors

### DIFF
--- a/src/litserve/middlewares.py
+++ b/src/litserve/middlewares.py
@@ -66,5 +66,7 @@ class RequestCountMiddleware(BaseHTTPMiddleware):
             return
 
         self.active_counter.value += 1
-        await self.app(scope, receive, send)
-        self.active_counter.value -= 1
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            self.active_counter.value -= 1

--- a/tests/unit/test_middlewares.py
+++ b/tests/unit/test_middlewares.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import multiprocessing as mp
 
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
@@ -116,17 +114,22 @@ def test_track_requests_middleware_isolation():
         )
 
 
-def test_request_count_is_reset_after_error():
-    active_counter = mp.Value("i", 0, lock=True)
-    app = FastAPI()
-    app.add_middleware(RequestCountMiddleware, active_counter=active_counter)
+def test_active_requests_reset_after_error():
+    """A request that fails should not stay counted in `LitServer.active_requests`."""
+    in_flight = []
 
-    @app.get("/fail")
-    def fail():
-        assert active_counter.value == 1
-        raise RuntimeError("request failed")
+    class FailingMiddleware(BaseHTTPMiddleware):
+        """Fails a request downstream of RequestCountMiddleware, which wraps all user middlewares."""
 
-    with TestClient(app) as client, pytest.raises(RuntimeError, match="request failed"):
-        client.get("/fail")
+        async def dispatch(self, request, call_next):
+            await call_next(request)
+            in_flight.append(server.active_requests)
+            raise RuntimeError("request failed")
 
-    assert active_counter.value == 0
+    server = ls.LitServer(ls.test_examples.SimpleLitAPI(), track_requests=True, middlewares=[FailingMiddleware])
+    with wrap_litserve_start(server) as server, TestClient(server.app) as client:
+        with pytest.raises(RuntimeError, match="request failed"):
+            client.post("/predict", json={"input": 4.0})
+
+        assert in_flight == [1], "request should be counted while it is in flight"
+        assert server.active_requests == 0, "failed request should not stay in the active request count"

--- a/tests/unit/test_middlewares.py
+++ b/tests/unit/test_middlewares.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import multiprocessing as mp
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
@@ -112,3 +114,19 @@ def test_track_requests_middleware_isolation():
         assert any(mw.cls is RequestCountMiddleware for mw in app_copy.user_middleware), (
             "RequestCountMiddleware not found in middleware list"
         )
+
+
+def test_request_count_is_reset_after_error():
+    active_counter = mp.Value("i", 0, lock=True)
+    app = FastAPI()
+    app.add_middleware(RequestCountMiddleware, active_counter=active_counter)
+
+    @app.get("/fail")
+    def fail():
+        assert active_counter.value == 1
+        raise RuntimeError("request failed")
+
+    with TestClient(app) as client, pytest.raises(RuntimeError, match="request failed"):
+        client.get("/fail")
+
+    assert active_counter.value == 0


### PR DESCRIPTION
## What does this PR do?

Fixes #747.

With `track_requests=True`, `RequestCountMiddleware` decremented the active-request counter only after a successful downstream return, so a request that raised left the counter permanently incremented. Repeated failures inflate `LitServer.active_requests` with requests that are no longer running.

- Wrap the downstream dispatch in `try`/`finally` so the counter is restored whether the request succeeds or fails, with no change to exception handling
- Add a regression test that drives a real request through `LitServer` and asserts `active_requests` returns to zero

<details>
<summary>Why the test injects the failure from a middleware</summary>

A `LitAPI` that raises can't reproduce the leak. The request handlers convert every exception into an `HTTPException`, and Starlette's `ExceptionMiddleware` sits inside `RequestCountMiddleware`, so it becomes a response before it ever crosses the counter.

The test therefore uses the public `middlewares=` parameter and raises after `call_next`, so a full `/predict` round-trip completes before the error propagates through the counter. It fails on `main` (`active_requests == 1`) and passes with the fix.

</details>

## Before submitting

- [x] Bug reported in #747 before implementation
- [x] Read the contributor guidelines
- [x] Added a regression test
- [x] No documentation update needed; public behavior is unchanged apart from correcting stale counts

AI assistance was used to investigate, implement, and test this change. No human review is claimed.
