### PR TITLE
feat: Decouple the predict interface from batching config with LitAPI(`batched=True`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     rev: v1.7.7
     hooks:
       - id: docformatter
+        language_version: python3.13
         additional_dependencies: [tomli]
         args: ["--in-place"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,6 @@ repos:
     rev: v1.7.7
     hooks:
       - id: docformatter
-        language_version: python3.13
         additional_dependencies: [tomli]
         args: ["--in-place"]
 

--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -70,6 +70,8 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
     Configuration:
         max_batch_size: Batch multiple requests for better GPU utilization. Defaults to 1.
         batch_timeout: Wait time for batch to fill (seconds). Defaults to 0.0.
+        batched: Always use the batched interface, so `predict` receives a batch (of size 1 or more)
+            regardless of `max_batch_size`. Defaults to False.
         stream: Enable streaming responses for real-time output. Defaults to False.
         api_path: URL endpoint path. Defaults to "/predict".
         enable_async: Enable async/await for non-blocking operations. Defaults to False.
@@ -87,6 +89,10 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
                 return self.model(batch)
 
         api = BatchedAPI(max_batch_size=8, batch_timeout=0.1)
+
+        # `predict` keeps receiving a batch even when batching is turned off,
+        # so the implementation does not have to change with the server config.
+        api = BatchedAPI(batched=True)
         ```
 
         Streaming LLM:
@@ -130,6 +136,7 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
     """
 
     _stream: bool = False
+    _batched: bool = False
     _default_unbatch: Optional[Callable] = None
     _spec: Optional[LitSpec] = None
     _device: Optional[str] = None
@@ -146,6 +153,7 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
         spec: Optional[LitSpec] = None,
         mcp: Optional["MCP"] = None,
         enable_async: bool = False,
+        batched: bool = False,
     ):
         """Initialize LitAPI with configuration options."""
         if max_batch_size <= 0:
@@ -173,7 +181,7 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
         batch_overridden = self.batch.__code__ is not LitAPI.batch.__code__
         unbatch_overridden = self.unbatch.__code__ is not LitAPI.unbatch.__code__
 
-        if batch_overridden and unbatch_overridden and max_batch_size == 1:
+        if batch_overridden and unbatch_overridden and max_batch_size == 1 and not batched:
             warnings.warn(
                 "The LitServer has both batch and unbatch methods implemented, "
                 "but the max_batch_size parameter was not set."
@@ -185,6 +193,7 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
         self._spec = spec
         self.max_batch_size = max_batch_size
         self.batch_timeout = batch_timeout
+        self._batched = batched
         self.enable_async = enable_async
         self._validate_async_methods()
         self.mcp = mcp
@@ -274,9 +283,11 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
     def predict(self, x, **kwargs):
         """Run the model on the input and return or yield the output.
 
-        When batching is enabled (max_batch_size > 1), this method receives
-        a batched input and must return a list-like structure where each element
-        corresponds to one input in the batch.
+        When batching is enabled (``max_batch_size > 1`` or ``batched=True``), this method
+        receives a batched input and must return a list-like structure where each element
+        corresponds to one input in the batch. Use ``batched=True`` to keep this contract
+        stable even when ``max_batch_size`` is 1, so the implementation does not have to
+        change with the server configuration.
 
         Returns:
             For non-batched mode: Single prediction output
@@ -372,6 +383,20 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
         self._stream = value
 
     @property
+    def batched(self) -> bool:
+        """Whether ``predict`` receives a batch of inputs.
+
+        True when ``max_batch_size > 1``, or when ``batched=True`` was passed to keep the batched
+        interface regardless of the batch size.
+
+        """
+        return self._batched or self.max_batch_size > 1
+
+    @batched.setter
+    def batched(self, value: bool):
+        self._batched = value
+
+    @property
     def device(self):
         return self._device
 
@@ -432,7 +457,7 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
         if self._loop == "auto":
             from litserve.loops.loops import get_default_loop
 
-            self._loop = get_default_loop(self.stream, self.max_batch_size, self.enable_async)
+            self._loop = get_default_loop(self.stream, self.max_batch_size, self.enable_async, self.batched)
         return self._loop
 
     @loop.setter

--- a/src/litserve/loops/base.py
+++ b/src/litserve/loops/base.py
@@ -424,7 +424,7 @@ class DefaultLoop(LitLoop):
             )
         if (
             lit_api.stream
-            and lit_api.max_batch_size > 1
+            and lit_api.batched
             and not all(
                 [
                     inspect.isgeneratorfunction(lit_api.predict) or inspect.isasyncgenfunction(lit_api.predict),
@@ -439,7 +439,7 @@ class DefaultLoop(LitLoop):
             )
         ):
             raise ValueError(
-                """When `stream=True` with max_batch_size > 1, `lit_api.predict`, `lit_api.encode_response` and
+                """When `stream=True` with batching enabled, `lit_api.predict`, `lit_api.encode_response` and
                 `lit_api.unbatch` must generate values using `yield` (can be regular or async generators).
 
              Example:

--- a/src/litserve/loops/loops.py
+++ b/src/litserve/loops/loops.py
@@ -26,13 +26,14 @@ from litserve.utils import WorkerSetupStatus
 logger = logging.getLogger(__name__)
 
 
-def get_default_loop(stream: bool, max_batch_size: int, enable_async: bool = False) -> _BaseLoop:
+def get_default_loop(stream: bool, max_batch_size: int, enable_async: bool = False, batched: bool = False) -> _BaseLoop:
     """Get the default loop based on the stream flag, batch size, and async support.
 
     Args:
         stream: Whether streaming is enabled
         max_batch_size: Maximum batch size
         enable_async: Whether async support is enabled (supports both coroutines and async generators)
+        batched: Whether the batched interface is requested even when max_batch_size is 1
 
     Returns:
         The appropriate loop implementation
@@ -41,19 +42,21 @@ def get_default_loop(stream: bool, max_batch_size: int, enable_async: bool = Fal
         ValueError: If async and batching are enabled together (not supported)
 
     """
+    batched = batched or max_batch_size > 1
+
     if enable_async:
-        if max_batch_size > 1:
+        if batched:
             raise ValueError("Async batching is not supported. Please use enable_async=False with batching.")
         if stream:
             return StreamingLoop()  # StreamingLoop now supports async
         return SingleLoop()  # Only SingleLoop supports async currently
 
     if stream:
-        if max_batch_size > 1:
+        if batched:
             return BatchedStreamingLoop()
         return StreamingLoop()
 
-    if max_batch_size > 1:
+    if batched:
         return BatchedLoop()
     return SingleLoop()
 
@@ -93,7 +96,7 @@ def inference_worker(
         logging.info(f"LitServe will use {lit_spec.__class__.__name__} spec")
 
     if loop == "auto":
-        loop = get_default_loop(stream, lit_api.max_batch_size, lit_api.enable_async)
+        loop = get_default_loop(stream, lit_api.max_batch_size, lit_api.enable_async, lit_api.batched)
 
     loop._restart_workers = restart_workers
 

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -28,6 +28,7 @@ from litserve import LitAPI, LitServer
 from litserve.callbacks import CallbackRunner
 from litserve.loops.base import _SENTINEL_VALUE, _StopLoopError, collate_requests
 from litserve.loops.simple_loops import BatchedLoop
+from litserve.loops.streaming_loops import BatchedStreamingLoop
 from litserve.test_examples import SimpleBatchedAPI
 from litserve.transport.base import MessageTransport
 from litserve.utils import LoopResponseType, wrap_litserve_start
@@ -348,3 +349,68 @@ def test_batch_predict_set_warning():
     # When list() is called on a set, the order is arbitrary
     # This could lead to incorrect results
     assert len(outputs) == 2
+
+
+class ConsistentBatchAPI(LitAPI):
+    """A single implementation that works with and without dynamic batching."""
+
+    def setup(self, device):
+        self.model = lambda x: x * 2
+
+    def decode_request(self, request):
+        return request["input"]
+
+    def predict(self, batch):
+        assert isinstance(batch, list), "predict must always receive a list when batched=True"
+        return [self.model(x) for x in batch]
+
+    def encode_response(self, output):
+        return {"output": output, "batch_size": 1}
+
+
+def test_batched_flag_defaults():
+    assert not SimpleBatchedAPI(max_batch_size=1).batched, "batching is off by default"
+    assert SimpleBatchedAPI(max_batch_size=2).batched, "max_batch_size > 1 implies batching"
+    assert SimpleBatchedAPI(max_batch_size=1, batched=True).batched, "batched=True opts into the batched interface"
+
+
+def test_batched_flag_selects_batched_loop():
+    api = ConsistentBatchAPI(batched=True)
+    assert isinstance(api.loop, BatchedLoop), "batched=True must use the batched loop with max_batch_size=1"
+
+    api = ConsistentBatchAPI(batched=True, stream=True)
+    api.predict = MagicMock()
+    assert isinstance(api.loop, BatchedStreamingLoop), "batched=True must use the batched streaming loop"
+
+
+def test_batched_flag_rejects_async():
+    class AsyncAPI(LitAPI):
+        async def predict(self, x):
+            return x
+
+    api = AsyncAPI(enable_async=True, batched=True)
+    with pytest.raises(ValueError, match="Async batching is not supported"):
+        _ = api.loop
+
+
+def test_batched_flag_skips_unset_batch_size_warning(recwarn):
+    SimpleBatchedAPI(max_batch_size=1, batched=True)
+    assert not [w for w in recwarn if "max_batch_size parameter was not set" in str(w.message)]
+
+
+@pytest.mark.parametrize(
+    ("max_batch_size", "batch_timeout"),
+    [(1, 0.0), (4, 0.05)],
+)
+@pytest.mark.asyncio
+async def test_batched_flag_keeps_predict_interface_stable(max_batch_size, batch_timeout):
+    """The same LitAPI must work regardless of the batching configuration."""
+    api = ConsistentBatchAPI(max_batch_size=max_batch_size, batch_timeout=batch_timeout, batched=True)
+    server = LitServer(api, accelerator="cpu", devices=1, timeout=10)
+    with wrap_litserve_start(server) as server:
+        async with (
+            LifespanManager(server.app) as manager,
+            AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://test") as ac,
+        ):
+            response = await ac.post("/predict", json={"input": 4.0})
+    assert response.json() == {"output": 8.0, "batch_size": 1}

--- a/tests/unit/test_loops.py
+++ b/tests/unit/test_loops.py
@@ -385,6 +385,7 @@ def test_inference_worker(mock_single_loop, mock_batched_loop):
     lit_api_mock.stream = False
     lit_api_mock.api_path = "/predict"
     lit_api_mock.loop = "auto"
+    lit_api_mock.batched = True
 
     inference_worker(
         lit_api_mock,
@@ -405,6 +406,7 @@ def test_inference_worker(mock_single_loop, mock_batched_loop):
     lit_api_mock.stream = False
     lit_api_mock.api_path = "/predict"
     lit_api_mock.loop = "auto"
+    lit_api_mock.batched = False
 
     inference_worker(
         lit_api_mock,
@@ -417,6 +419,29 @@ def test_inference_worker(mock_single_loop, mock_batched_loop):
         restart_workers=True,
     )
     mock_single_loop.assert_called_once()
+
+    # batched=True keeps the batched loop even when max_batch_size is 1
+    mock_batched_loop.reset_mock()
+    lit_api_mock = MagicMock()
+    lit_api_mock.max_batch_size = 1
+    lit_api_mock.batch_timeout = 0
+    lit_api_mock.enable_async = False
+    lit_api_mock.stream = False
+    lit_api_mock.api_path = "/predict"
+    lit_api_mock.loop = "auto"
+    lit_api_mock.batched = True
+
+    inference_worker(
+        lit_api_mock,
+        "cpu",
+        0,
+        MagicMock(),
+        MagicMock(),
+        workers_setup_status={},
+        callback_runner=NOOP_CB_RUNNER,
+        restart_workers=True,
+    )
+    mock_batched_loop.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -800,6 +825,16 @@ def test_get_default_loop():
     )
 
 
+def test_get_default_loop_batched():
+    loop = ls.loops.get_default_loop(stream=False, max_batch_size=1, batched=True)
+    assert isinstance(loop, ls.loops.BatchedLoop), "BatchedLoop must be returned when batched=True"
+
+    loop = ls.loops.get_default_loop(stream=True, max_batch_size=1, batched=True)
+    assert isinstance(loop, ls.loops.BatchedStreamingLoop), (
+        "BatchedStreamingLoop must be returned when stream=True and batched=True"
+    )
+
+
 def test_get_default_loop_enable_async():
     lit_api = MagicMock()
     lit_api.max_batch_size = 2
@@ -808,6 +843,11 @@ def test_get_default_loop_enable_async():
         ValueError, match="Async batching is not supported. Please use enable_async=False with batching."
     ):
         ls.loops.get_default_loop(lit_api.stream, lit_api.max_batch_size, lit_api.enable_async)
+
+    with pytest.raises(
+        ValueError, match="Async batching is not supported. Please use enable_async=False with batching."
+    ):
+        ls.loops.get_default_loop(stream=False, max_batch_size=1, enable_async=True, batched=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

Fixes #412.


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

<!--
⚠️ How does this PR impact the user? ⚠️
Describe (in plain English, not technical Jargon) how this improves the user experience. If you can't tie it back to a real tangible, user goal or describe it in plain english, it's a hint that this is likely not needed and is probably an "engineering nit". 

✅ GOOD:
"As a user, I need to serve models faster. This PR focuses on enabling speed gains by using GPUs"

⛔️ BAD:
"This PR enables GPUs". 
This is bad because the *user problem* is not clear... instead it just jumps to the solution without any context. 

PRs without this will not be merged.
-->

Adds an opt-in `batched` flag to `LitAPI` so `predict` always receives a batch,
regardless of `max_batch_size`:

```python
api = MyAPI(batched=True)  # predict gets a list (of size >= 1), even with max_batch_size=1
```

In the current implementation, the contract flips with server configuration:
- `max_batch_size=1` hands predict a bare input
- `max_batch_size>1` hands it a list.
So the same API implementation has to change when batching is turned on or off.





## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
